### PR TITLE
feat: Implement ADRP+ADD to NOP+ADR relaxation for AArch64

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -6068,6 +6068,10 @@ fn classify_symbol_relocation<
         section_flags,
         true,
         None,
+        1,    // sym_addr: assume non-zero
+        0,    // section_address
+        0,    // rel_addend
+        None, // previous_relocation
     )
     .filter(|relaxation| args.should_relax() || relaxation.is_mandatory())
     {

--- a/libwild/src/elf_aarch64.rs
+++ b/libwild/src/elf_aarch64.rs
@@ -10,14 +10,18 @@ use crate::layout::Layout;
 use crate::malfunction_point_ret;
 use crate::platform::ObjectFile as _;
 use crate::platform::Platform;
+use crate::platform::PreviousRelocationInfo;
 use linker_utils::aarch64::RelaxationKind;
 use linker_utils::aarch64::relocation_type_from_raw;
+use linker_utils::bit_misc::BitExtraction;
 use linker_utils::elf::AArch64Instruction;
+use linker_utils::elf::AllowedRange;
 use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::PAGE_MASK_4KB;
 use linker_utils::elf::RelocationKind;
 use linker_utils::elf::RelocationKindInfo;
 use linker_utils::elf::SIZE_4KB;
+use linker_utils::elf::Sign;
 use linker_utils::elf::aarch64_rel_type_to_string;
 use linker_utils::elf::shf;
 use linker_utils::relaxation::RelocationModifier;
@@ -163,6 +167,12 @@ impl crate::platform::Arch for ElfAArch64 {
         section_flags: linker_utils::elf::SectionFlags,
         _non_zero_address: bool,
         _relax_deltas: Option<&linker_utils::relaxation::SectionRelaxDeltas>,
+        sym_addr: u64,
+        section_address: u64,
+        rel_addend: i64,
+        previous_relocation: Option<
+            PreviousRelocationInfo<<Self::Platform as Platform>::RelocationInfo>,
+        >,
     ) -> Option<Self::Relaxation>
     where
         Self: std::marker::Sized,
@@ -307,7 +317,50 @@ impl crate::platform::Arch for ElfAArch64 {
                     mandatory: false,
                 });
             }
-
+            // Relax ADRP+ADD to NOP+ADR. Applied at ADD position when previous relocation
+            // was ADRP for the same symbol at the consecutive offset.
+            object::elf::R_AARCH64_ADD_ABS_LO12_NC
+                if !interposable && flags.is_address() && sym_addr != 0 =>
+            {
+                if let Some(prev) = previous_relocation
+                    && prev.kind == object::elf::R_AARCH64_ADR_PREL_PG_HI21
+                    && prev.offset + 4 == offset_in_section
+                    && prev.addend == 0
+                {
+                    let offset = offset_in_section as usize;
+                    if let Some(adrp_bytes) = offset
+                        .checked_sub(4)
+                        .and_then(|s| section_bytes.get(s..offset))
+                        && let Some(add_bytes) = section_bytes.get(offset..offset + 4)
+                    {
+                        let adrp_instr =
+                            u64::from(u32::from_le_bytes(adrp_bytes.try_into().unwrap()));
+                        let add_instr =
+                            u64::from(u32::from_le_bytes(add_bytes.try_into().unwrap()));
+                        if (adrp_instr as u32 & 0x9f000000) == 0x90000000
+                            && (add_instr as u32 & 0xffc00000) == 0x91000000
+                            && adrp_instr.extract_bit_range(0..5)
+                                == add_instr.extract_bit_range(0..5)
+                            && adrp_instr.extract_bit_range(0..5)
+                                == add_instr.extract_bit_range(5..10)
+                        {
+                            let add_place = section_address + offset_in_section;
+                            let diff = (sym_addr as i64)
+                                .wrapping_add(rel_addend)
+                                .wrapping_sub(add_place as i64);
+                            if AllowedRange::from_bit_size(21, Sign::Signed).contains(diff) {
+                                return Some(Relaxation {
+                                    kind: RelaxationKind::AdrpAddToNopAdr,
+                                    rel_info: rel_info_from_type!(
+                                        object::elf::R_AARCH64_ADR_PREL_LO21
+                                    ),
+                                    mandatory: false,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
             _ => (),
         }
 

--- a/libwild/src/elf_loongarch64.rs
+++ b/libwild/src/elf_loongarch64.rs
@@ -3,6 +3,7 @@ use crate::elf::PLT_ENTRY_SIZE;
 use crate::error;
 use crate::error::Result;
 use crate::platform::Platform;
+use crate::platform::PreviousRelocationInfo;
 use itertools::AllEqualValueError;
 use itertools::Itertools;
 use linker_utils::elf::DynamicRelocationKind;
@@ -118,6 +119,10 @@ impl crate::platform::Arch for ElfLoongArch64 {
         section_flags: linker_utils::elf::SectionFlags,
         non_zero_address: bool,
         _relax_deltas: Option<&linker_utils::relaxation::SectionRelaxDeltas>,
+        _sym_addr: u64,
+        _section_address: u64,
+        _rel_addend: i64,
+        _previous_relocation: Option<PreviousRelocationInfo<object::elf::RelocationType>>,
     ) -> Option<Self::Relaxation>
     where
         Self: std::marker::Sized,

--- a/libwild/src/elf_ppc64.rs
+++ b/libwild/src/elf_ppc64.rs
@@ -3,6 +3,7 @@ use crate::elf::Elf64;
 use crate::error;
 use crate::error::Result;
 use crate::platform::Platform;
+use crate::platform::PreviousRelocationInfo;
 use linker_utils::bit_misc::BitExtraction;
 use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::RelocationKindInfo;
@@ -95,6 +96,10 @@ impl crate::platform::Arch for ElfPpc64 {
         section_flags: linker_utils::elf::SectionFlags,
         non_zero_address: bool,
         relax_deltas: Option<&linker_utils::relaxation::SectionRelaxDeltas>,
+        _sym_addr: u64,
+        _section_address: u64,
+        _rel_addend: i64,
+        _previous_relocation: Option<PreviousRelocationInfo<object::elf::RelocationType>>,
     ) -> Option<Self::Relaxation>
     where
         Self: std::marker::Sized,

--- a/libwild/src/elf_riscv64.rs
+++ b/libwild/src/elf_riscv64.rs
@@ -9,6 +9,7 @@ use crate::error::Context as _;
 use crate::error::Result;
 use crate::platform::ObjectFile as _;
 use crate::platform::Platform;
+use crate::platform::PreviousRelocationInfo;
 use crate::platform::RelaxSymbolInfo;
 use crate::platform::Relocation;
 use itertools::Itertools;
@@ -194,6 +195,10 @@ impl crate::platform::Arch for ElfRiscV64 {
         section_flags: linker_utils::elf::SectionFlags,
         non_zero_address: bool,
         relax_deltas: Option<&SectionRelaxDeltas>,
+        _sym_addr: u64,
+        _section_address: u64,
+        _rel_addend: i64,
+        _previous_relocation: Option<PreviousRelocationInfo<object::elf::RelocationType>>,
     ) -> Option<Self::Relaxation>
     where
         Self: std::marker::Sized,

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -72,6 +72,7 @@ use crate::platform::Arch;
 use crate::platform::Args as _;
 use crate::platform::ObjectFile;
 use crate::platform::Platform;
+use crate::platform::PreviousRelocationInfo;
 use crate::platform::RawSymbolName as _;
 use crate::platform::Relaxation as _;
 use crate::platform::Relocation;
@@ -3125,6 +3126,19 @@ fn apply_relocation<
         section_info.section_flags,
         resolution.raw_value != 0,
         relax_deltas,
+        resolution.raw_value,
+        section_address,
+        rel.addend(),
+        relocation_cache
+            .previous
+            .as_ref()
+            .filter(|r| r.symbol() == rel.symbol())
+            .map(|r| PreviousRelocationInfo {
+                kind: r.raw_type(),
+                offset: r.offset(),
+                symbol: r.symbol(),
+                addend: r.addend(),
+            }),
     )
     .filter(|relaxation| layout.args().relax || relaxation.is_mandatory());
 

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -11,6 +11,7 @@ use crate::error;
 use crate::error::Result;
 use crate::malfunction_point_ret;
 use crate::platform::Platform;
+use crate::platform::PreviousRelocationInfo;
 use crate::value_flags::ValueFlags;
 use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::RelocationKindInfo;
@@ -154,6 +155,10 @@ impl crate::platform::Arch for ElfX86_64 {
         section_flags: SectionFlags,
         _non_zero_address: bool,
         _relax_deltas: Option<&linker_utils::relaxation::SectionRelaxDeltas>,
+        _sym_addr: u64,
+        _section_address: u64,
+        _rel_addend: i64,
+        _previous_relocation: Option<PreviousRelocationInfo<object::elf::RelocationType>>,
     ) -> Option<Self::Relaxation> {
         let is_known_address = flags.is_address();
         let is_absolute = flags.is_absolute() && !flags.is_dynamic();
@@ -602,6 +607,10 @@ fn test_relaxation() {
             shf::EXECINSTR,
             true,
             None,
+            0,
+            0,
+            0,
+            None,
         ) {
             r.apply(&mut out, &mut offset, &mut 0);
 
@@ -618,6 +627,10 @@ fn test_relaxation() {
             OutputKind::StaticExecutable(RelocationModel::Relocatable),
             shf::EXECINSTR,
             true,
+            None,
+            0,
+            0,
+            0,
             None,
         ) {
             out.copy_from_slice(bytes_in);

--- a/libwild/src/macho_aarch64.rs
+++ b/libwild/src/macho_aarch64.rs
@@ -4,6 +4,7 @@
 use crate::bail;
 use crate::ensure;
 use crate::macho::MachO;
+use crate::platform::PreviousRelocationInfo;
 use linker_utils::elf::AArch64Instruction;
 use linker_utils::elf::AllowedRange;
 use linker_utils::elf::PAGE_MASK_4KB;
@@ -217,6 +218,10 @@ impl crate::platform::Arch for MachOAArch64 {
         section_flags: <Self::Platform as crate::platform::Platform>::SectionFlags,
         non_zero_address: bool,
         relax_deltas: Option<&linker_utils::relaxation::SectionRelaxDeltas>,
+        _sym_addr: u64,
+        _section_address: u64,
+        _rel_addend: i64,
+        _previous_relocation: Option<PreviousRelocationInfo<object::macho::RelocationInfo>>,
     ) -> Option<Self::Relaxation> {
         todo!()
     }

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -199,6 +199,12 @@ pub(crate) trait Arch: Send + Sync + 'static {
         section_flags: <Self::Platform as Platform>::SectionFlags,
         non_zero_address: bool,
         relax_deltas: Option<&SectionRelaxDeltas>,
+        sym_addr: u64,
+        section_address: u64,
+        rel_addend: i64,
+        previous_relocation: Option<
+            PreviousRelocationInfo<<Self::Platform as Platform>::RelocationInfo>,
+        >,
     ) -> Option<Self::Relaxation>;
 
     /// Fill `buf` with NOP padding.
@@ -258,6 +264,15 @@ pub(crate) struct RelaxSymbolInfo {
     pub output_address: u64,
     /// Whether the symbol may be interposed at runtime.
     pub is_interposable: bool,
+}
+
+/// Information about the previous relocation, used for pair-based relaxations.
+#[allow(dead_code)]
+pub(crate) struct PreviousRelocationInfo<RelInfo> {
+    pub kind: RelInfo,
+    pub offset: u64,
+    pub symbol: Option<object::SymbolIndex>,
+    pub addend: i64,
 }
 
 /// A platform for which we support writing producing linked outputs.

--- a/libwild/src/wasm_wasm32.rs
+++ b/libwild/src/wasm_wasm32.rs
@@ -1,3 +1,4 @@
+use crate::platform::PreviousRelocationInfo;
 use crate::wasm::Wasm;
 use crate::wasm::relocation_type_to_string;
 use wasmparser::RelocationType;
@@ -99,6 +100,10 @@ impl crate::platform::Arch for WasmWasm32 {
         _section_flags: <Self::Platform as crate::platform::Platform>::SectionFlags,
         _non_zero_address: bool,
         _relax_deltas: Option<&linker_utils::relaxation::SectionRelaxDeltas>,
+        _sym_addr: u64,
+        _section_address: u64,
+        _rel_addend: i64,
+        _previous_relocation: Option<PreviousRelocationInfo<RelocationType>>,
     ) -> Option<Self::Relaxation> {
         // Wasm doesn't currently support any relaxations.
         None

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -229,6 +229,9 @@ impl Config {
                 // LLD does some different relaxations to us
                 "rel.missing-opt.R_AARCH64_ADR_GOT_PAGE.ReplaceWithNop.*",
                 "rel.missing-opt.R_AARCH64_ADR_PREL_PG_HI21.ReplaceWithNop.*",
+                // Wild and lld relax ADRP+ADD to NOP+ADR, but GNU ld does not.
+                "rel.extra-opt.R_AARCH64_ADD_ABS_LO12_NC.AdrpAddToNopAdr.*",
+                "rel.extra-opt.R_AARCH64_ADR_PREL_PG_HI21.ReplaceWithNop.*",
                 // The other linkers set properties on sections if all input sections have that
                 // property. For sections like .rodata, this seems like an unimportant behaviour to
                 // replicate.

--- a/linker-utils/src/aarch64.rs
+++ b/linker-utils/src/aarch64.rs
@@ -44,6 +44,9 @@ pub enum RelaxationKind {
     /// Replace add with adr. We don't apply this, but lld does, so this is used by linker-diff.
     AddToAdr,
     LdrToAdr,
+    /// Relax ADRP+ADD pair to NOP+ADR. Applied at the ADD instruction position.
+    /// Writes NOP at ADRP position (offset-4) and ADR base at current position.
+    AdrpAddToNopAdr,
 }
 
 impl RelaxationKind {
@@ -94,6 +97,22 @@ impl RelaxationKind {
             }
             RelaxationKind::LdrToAdr => {
                 section_bytes[offset + 3] &= !0x89;
+            }
+            RelaxationKind::AdrpAddToNopAdr => {
+                let adrp_dest_reg = u64::from(u32_from_slice(&section_bytes[offset - 4..offset]))
+                    .extract_bit_range(0..5) as u8;
+                RelaxationKind::ReplaceWithNop.apply(
+                    section_bytes,
+                    &mut ((*offset_in_section).wrapping_sub(4)),
+                    _addend,
+                );
+                // Write ADR base at ADD position with same destination register.
+                section_bytes[offset..offset + 4].copy_from_slice(&[
+                    adrp_dest_reg,
+                    0x00,
+                    0x00,
+                    0x10,
+                ]);
             }
             RelaxationKind::AdrpX0 => {
                 section_bytes[offset..offset + 4].copy_from_slice(&[

--- a/wild/tests/sources/elf/aarch64-adrp-add-relax/aarch64-adrp-add-relax.s
+++ b/wild/tests/sources/elf/aarch64-adrp-add-relax/aarch64-adrp-add-relax.s
@@ -1,0 +1,36 @@
+// This verifies that Wild relaxes ADRP+ADD to NOP+ADR when the symbol is
+// within ADR range and registers match, but keeps ADRP+ADD when:
+// - the destination registers differ (x2 vs x3 in third pair)
+// - the second relocation references a different symbol (fourth pair)
+// - the second relocation is not ADD (fifth pair: ADRP+ADRP)
+// We use lld as reference linker since GNU ld does not implement this relaxation.
+//#Arch:aarch64
+//#Mode:static
+//#ReferenceLinkers:lld
+//#LinkArgs:--no-gc-sections -Ttext=0x200ffc
+//#RunEnabled:false
+//#DiffIgnore:file-header.entry
+//#ExpectSectionBytes:.text=0x1f2003d5 0..4
+//#ExpectSectionBytes:.text=0x1f2003d5 8..12
+
+.globl _start
+_start:
+    adrp x30, x
+    add  x30, x30, :lo12:x     // Relaxed (same register, same symbol, in range)
+    adrp x1, x
+    add  x1, x1, :lo12:x       // Relaxed (same register, same symbol, in range)
+    adrp x2, x
+    add  x3, x2, :lo12:x       // NOT relaxed (different dest register x3 vs x2)
+    adrp x4, x
+    add  x4, x4, :lo12:y       // NOT relaxed (different symbol: x vs y)
+    adrp x5, x
+    adrp x5, x                  // NOT relaxed (second reloc is not ADD)
+
+.globl x
+x:
+    .word 0
+
+.globl y
+y:
+    .word 0
+.data


### PR DESCRIPTION
When an ADRP+ADD pair references a symbol within ADR range (±1MB) and the instructions use the same register, relax to NOP+ADR.

This matches lld's `tryRelaxAdrpAdd` optimization and reduces code size for frequently accessed local symbols.

Issue #2247 