### PR TITLE
port(wasm): Error on undefined strong symbols by default and add `--allow-undefined`

### DIFF
--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -46,6 +46,7 @@ pub struct WasmArgs {
     pub(crate) initial_memory: Option<u64>,
     pub(crate) max_memory: Option<u64>,
     pub(crate) gc_sections: bool,
+    pub(crate) allow_undefined: bool,
 }
 
 impl WasmArgs {
@@ -76,6 +77,7 @@ impl Default for WasmArgs {
             max_memory: None,
             export_memory: None,
             gc_sections: true,
+            allow_undefined: false,
         }
     }
 }
@@ -330,6 +332,15 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
         .help("Initial size of the linear memory in bytes")
         .execute(|args, _modifier_stack, value| {
             args.initial_memory = Some(parse_number(value)?);
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("allow-undefined")
+        .help("Allow undefined symbols in the output")
+        .execute(|args, _modifier_stack| {
+            args.allow_undefined = true;
             Ok(())
         });
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3483,6 +3483,10 @@ fn report_disallowed_unresolved_imports<'data>(
     resolutions: &[ObjectImportResolutions],
     symbol_db: &SymbolDb<'data, Wasm>,
 ) -> Result {
+    if symbol_db.args.allow_undefined {
+        return Ok(());
+    }
+
     let mut errors: Vec<String> = Vec::new();
     let mut seen: HashSet<(String, String)> = HashSet::new();
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3521,6 +3521,7 @@ fn report_disallowed_unresolved_imports<'data>(
                 WasmSymbolKind::Data => {
                     let symbol_id = input.symbol_id_range.offset_to_id(sym_offset);
                     symbol_db.definition(symbol_id) == symbol_id
+                        && live_relocs_reference_symbol(input, sym_offset)
                 }
                 _ => false,
             };
@@ -3543,6 +3544,17 @@ fn report_disallowed_unresolved_imports<'data>(
         return Ok(());
     }
     bail!("{}", errors.join("\n"));
+}
+
+fn live_relocs_reference_symbol(input: &WasmObjectLayoutInput<'_>, sym_offset: usize) -> bool {
+    let Ok(idx) = u32::try_from(sym_offset) else {
+        return false;
+    };
+    input
+        .code_relocations
+        .iter()
+        .chain(input.data_relocations.iter())
+        .any(|reloc| reloc.index == idx)
 }
 
 fn collect_shared_unresolved_imports<'data>(

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3518,11 +3518,6 @@ fn report_disallowed_unresolved_imports<'data>(
                             .get(idx)
                             .is_some_and(|r| matches!(r, ImportResolution::Unresolved))
                 }
-                WasmSymbolKind::Data => {
-                    let symbol_id = input.symbol_id_range.offset_to_id(sym_offset);
-                    symbol_db.definition(symbol_id) == symbol_id
-                        && live_relocs_reference_symbol(input, sym_offset)
-                }
                 _ => false,
             };
             if !is_unresolved {
@@ -3544,17 +3539,6 @@ fn report_disallowed_unresolved_imports<'data>(
         return Ok(());
     }
     bail!("{}", errors.join("\n"));
-}
-
-fn live_relocs_reference_symbol(input: &WasmObjectLayoutInput<'_>, sym_offset: usize) -> bool {
-    let Ok(idx) = u32::try_from(sym_offset) else {
-        return false;
-    };
-    input
-        .code_relocations
-        .iter()
-        .chain(input.data_relocations.iter())
-        .any(|reloc| reloc.index == idx)
 }
 
 fn collect_shared_unresolved_imports<'data>(
@@ -4269,6 +4253,44 @@ fn resolve_got_mem_def(
     )
 }
 
+fn note_undefined_data_from_reloc(
+    input: &WasmObjectLayoutInput<'_>,
+    symbol_db: &SymbolDb<'_, Wasm>,
+    reloc: &WasmRelocation,
+    seen: &mut HashSet<(String, String)>,
+    errors: &mut Vec<String>,
+) -> Result {
+    if symbol_db.args.allow_undefined || reloc.ty == RelocationType::TypeIndexLeb {
+        return Ok(());
+    }
+    let Some(sym) = input.symbols.get(reloc.index as usize) else {
+        return Ok(());
+    };
+    if sym.kind != WasmSymbolKind::Data
+        || !sym.is_undefined()
+        || sym.is_weak()
+        || sym.is_explicit_name()
+    {
+        return Ok(());
+    }
+    let symbol_id = input.symbol_id_range.offset_to_id(reloc.index as usize);
+    if !symbol_db.is_undefined(symbol_db.definition(symbol_id)) {
+        return Ok(());
+    }
+
+    let file_display = symbol_db.file(input.file_id).to_string();
+    let Some(name) = wasm_symbol_name_str(input.data, sym) else {
+        bail!(
+            "{file_display}: undefined symbol with no name (linking symbol index {})",
+            reloc.index
+        );
+    };
+    if seen.insert((file_display.clone(), name.to_owned())) {
+        errors.push(format!("{file_display}: undefined symbol: {name}"));
+    }
+    Ok(())
+}
+
 fn scan_layout_relocations(
     layout_inputs: &[WasmObjectLayoutInput<'_>],
     symbol_db: &SymbolDb<'_, Wasm>,
@@ -4288,6 +4310,8 @@ fn scan_layout_relocations(
         .iter()
         .any(|input| !input.table_imports.is_empty());
     let mut table_index_symbol_indices = vec![Vec::new(); layout_inputs.len()];
+    let mut undefined_data_errors: Vec<String> = Vec::new();
+    let mut seen_undefined_data: HashSet<(String, String)> = HashSet::new();
 
     for (obj_idx, input) in layout_inputs.iter().enumerate() {
         let mut got_mem_hits: Vec<(usize, usize)> = Vec::new();
@@ -4300,6 +4324,13 @@ fn scan_layout_relocations(
             .iter()
             .chain(input.data_relocations.iter())
         {
+            note_undefined_data_from_reloc(
+                input,
+                symbol_db,
+                reloc,
+                &mut seen_undefined_data,
+                &mut undefined_data_errors,
+            )?;
             match reloc.ty {
                 RelocationType::MemoryAddrRelSleb => {
                     needs_memory_base = true;
@@ -4402,6 +4433,10 @@ fn scan_layout_relocations(
             per_object_got_func_slots[obj_idx] = obj_map;
         }
         table_index_symbol_indices[obj_idx] = table_syms;
+    }
+
+    if !undefined_data_errors.is_empty() {
+        bail!("{}", undefined_data_errors.join("\n"));
     }
 
     Ok(LayoutRelocScan {

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -4171,6 +4171,7 @@ fn resolve_got_mem_def(
         && matches!(
             known,
             WasmLinkerSymbol::DataEnd
+                | WasmLinkerSymbol::GlobalBase
                 | WasmLinkerSymbol::HeapBase
                 | WasmLinkerSymbol::HeapEnd
                 | WasmLinkerSymbol::WasmFirstPageEnd
@@ -4578,6 +4579,7 @@ fn fill_got_mem_inits(
     layout: &mut WasmLayout<'_>,
     indices: &LinkerDefinedIndices,
     got_mem: &GotMem,
+    data_start: u32,
     data_end: u32,
     stack_size: u32,
     heap_end: Option<u32>,
@@ -4599,7 +4601,7 @@ fn fill_got_mem_inits(
                 .copied()
                 .ok_or_else(|| crate::error!("GOT.mem missing data address for definition"))?,
             GotMemDef::LinkerDefined(known) => known
-                .data_address(data_end, stack_size, heap_end, stack_first)?
+                .data_address(data_start, data_end, stack_size, heap_end, stack_first)?
                 .ok_or_else(|| {
                     crate::error!(
                         "GOT.mem linker-defined symbol `{}` has no data address",
@@ -5538,11 +5540,12 @@ where
         },
         ..WasmLayout::default()
     };
-    let mut memory_cursor = if stack_first {
+    let data_start = if stack_first {
         stack_size
     } else {
         layout.memory_base
     };
+    let mut memory_cursor = data_start;
     {
         timing_phase!("Merge Wasm object layouts");
         let n_objects = object_layouts.len();
@@ -5672,6 +5675,7 @@ where
             &layout_inputs,
             symbol_db,
             &file_id_to_index,
+            data_start,
             data_end,
             stack_size,
             heap_end,
@@ -5681,6 +5685,7 @@ where
             &mut layout,
             &indices,
             got_mem,
+            data_start,
             data_end,
             stack_size,
             heap_end,
@@ -5905,6 +5910,8 @@ pub(crate) enum WasmLinkerSymbol {
     // Data
     #[strum(serialize = "__data_end")]
     DataEnd,
+    #[strum(serialize = "__global_base")]
+    GlobalBase,
     #[strum(serialize = "__heap_base")]
     HeapBase,
     #[strum(serialize = "__heap_end")]
@@ -5940,13 +5947,18 @@ impl WasmLinkerSymbol {
             Self::MemoryBase | Self::TableBase | Self::StackPointer | Self::TlsBase => {
                 kind == WasmSymbolKind::Global
             }
-            Self::DataEnd | Self::HeapBase | Self::HeapEnd | Self::WasmFirstPageEnd => false,
+            Self::DataEnd
+            | Self::GlobalBase
+            | Self::HeapBase
+            | Self::HeapEnd
+            | Self::WasmFirstPageEnd => false,
         }
     }
 
     /// Data-symbol address after memory layout. `None` for non-data variants or absent memory.
     fn data_address(
         self,
+        data_start: u32,
         data_end: u32,
         stack_size: u32,
         heap_end: Option<u32>,
@@ -5954,6 +5966,7 @@ impl WasmLinkerSymbol {
     ) -> Result<Option<u32>> {
         Ok(match self {
             Self::DataEnd => Some(data_end),
+            Self::GlobalBase => Some(data_start),
             Self::HeapBase => Some(heap_base_address(data_end, stack_size, stack_first)?),
             Self::WasmFirstPageEnd => Some(u32::try_from(wasm_page_size())?),
             Self::HeapEnd => heap_end,
@@ -5973,6 +5986,7 @@ fn compute_data_addresses(
     layout_inputs: &[WasmObjectLayoutInput<'_>],
     symbol_db: &SymbolDb<'_, Wasm>,
     file_id_to_index: &HashMap<crate::input_data::FileId, usize>,
+    data_start: u32,
     data_end: u32,
     stack_size: u32,
     heap_end: Option<u32>,
@@ -6026,7 +6040,7 @@ fn compute_data_addresses(
                 && let crate::parsing::SymbolPlacement::PlatformSpecific(known) =
                     &def_info.placement
                 && let Some(address) =
-                    known.data_address(data_end, stack_size, heap_end, stack_first)?
+                    known.data_address(data_start, data_end, stack_size, heap_end, stack_first)?
             {
                 data_addresses[sym_idx] = address;
             }
@@ -7480,17 +7494,42 @@ mod tests {
 
     #[test]
     fn linker_defined_data_symbol_addresses() {
+        let data_start = 1024u32;
         let data_end = 1024u32;
         let page = wasm_page_size();
         let heap_end = heap_end_from_initial_pages(2).unwrap();
         let de = WasmLinkerSymbol::DataEnd
-            .data_address(data_end, DEFAULT_STACK_SIZE, Some(heap_end), false)
+            .data_address(
+                data_start,
+                data_end,
+                DEFAULT_STACK_SIZE,
+                Some(heap_end),
+                false,
+            )
             .unwrap()
             .expect("__data_end");
         assert_eq!(de, data_end);
 
+        let gb = WasmLinkerSymbol::GlobalBase
+            .data_address(
+                data_start,
+                data_end,
+                DEFAULT_STACK_SIZE,
+                Some(heap_end),
+                false,
+            )
+            .unwrap()
+            .expect("__global_base");
+        assert_eq!(gb, data_start);
+
         let hb = WasmLinkerSymbol::HeapBase
-            .data_address(data_end, DEFAULT_STACK_SIZE, Some(heap_end), false)
+            .data_address(
+                data_start,
+                data_end,
+                DEFAULT_STACK_SIZE,
+                Some(heap_end),
+                false,
+            )
             .unwrap()
             .expect("__heap_base");
         assert_eq!(
@@ -7499,13 +7538,25 @@ mod tests {
         );
 
         let page_end = WasmLinkerSymbol::WasmFirstPageEnd
-            .data_address(data_end, DEFAULT_STACK_SIZE, Some(heap_end), false)
+            .data_address(
+                data_start,
+                data_end,
+                DEFAULT_STACK_SIZE,
+                Some(heap_end),
+                false,
+            )
             .unwrap()
             .expect("__wasm_first_page_end");
         assert_eq!(u64::from(page_end), page);
 
         let he = WasmLinkerSymbol::HeapEnd
-            .data_address(data_end, DEFAULT_STACK_SIZE, Some(heap_end), false)
+            .data_address(
+                data_start,
+                data_end,
+                DEFAULT_STACK_SIZE,
+                Some(heap_end),
+                false,
+            )
             .unwrap()
             .expect("__heap_end");
         assert_eq!(he, heap_end);
@@ -7515,13 +7566,13 @@ mod tests {
         // If there is no output memory, `__heap_end` is not synthesised.
         assert!(
             WasmLinkerSymbol::HeapEnd
-                .data_address(data_end, DEFAULT_STACK_SIZE, None, false)
+                .data_address(data_start, data_end, DEFAULT_STACK_SIZE, None, false)
                 .unwrap()
                 .is_none()
         );
         assert!(
             WasmLinkerSymbol::WasmFirstPageEnd
-                .data_address(data_end, DEFAULT_STACK_SIZE, None, false)
+                .data_address(data_start, data_end, DEFAULT_STACK_SIZE, None, false)
                 .unwrap()
                 .is_some()
         );
@@ -7529,14 +7580,20 @@ mod tests {
 
     #[test]
     fn stack_first_heap_base_follows_data_not_stack() {
+        let data_start = 1_048_576u32;
         let data_end = 1_048_576 + 100;
         let stack_size = 1_048_576u32;
         let hb = WasmLinkerSymbol::HeapBase
-            .data_address(data_end, stack_size, Some(2 * 65_536), true)
+            .data_address(data_start, data_end, stack_size, Some(2 * 65_536), true)
             .unwrap()
             .expect("__heap_base");
         assert_eq!(hb, heap_base_after_data(data_end).unwrap());
         assert!(hb - data_end < 16);
+        let gb = WasmLinkerSymbol::GlobalBase
+            .data_address(data_start, data_end, stack_size, Some(2 * 65_536), true)
+            .unwrap()
+            .expect("__global_base");
+        assert_eq!(gb, data_start);
         // Without stack-first, heap would be roughly data_end + stack_size.
         let post_data = stack_high_after_data(data_end, stack_size).unwrap();
         assert!(post_data > hb + stack_size / 2);

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -352,6 +352,10 @@ impl WasmSymbol {
         self.raw_flags().contains(SymbolFlags::VISIBILITY_HIDDEN)
     }
 
+    pub(crate) fn is_explicit_name(&self) -> bool {
+        self.raw_flags().contains(SymbolFlags::EXPLICIT_NAME)
+    }
+
     fn has_name(&self) -> bool {
         self.name_len != 0
     }
@@ -3474,6 +3478,57 @@ impl<'data> SharedUnresolvedImports<'data> {
     }
 }
 
+fn report_disallowed_unresolved_imports<'data>(
+    inputs: &[WasmObjectLayoutInput<'data>],
+    resolutions: &[ObjectImportResolutions],
+    symbol_db: &SymbolDb<'data, Wasm>,
+) -> Result {
+    let mut errors: Vec<String> = Vec::new();
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+
+    for (input, res) in inputs.iter().zip(resolutions.iter()) {
+        let file_display = symbol_db.file(input.file_id).to_string();
+        for (sym_offset, sym) in input.symbols.iter().enumerate() {
+            if !sym.is_undefined() || sym.is_weak() || sym.is_explicit_name() {
+                continue;
+            }
+
+            let is_unresolved = match sym.kind {
+                WasmSymbolKind::Func => res
+                    .function_resolutions
+                    .get(sym.index as usize)
+                    .is_some_and(|r| matches!(r, ImportResolution::Unresolved)),
+                WasmSymbolKind::Global => res
+                    .global_resolutions
+                    .get(sym.index as usize)
+                    .is_some_and(|r| matches!(r, ImportResolution::Unresolved)),
+                WasmSymbolKind::Data => {
+                    let symbol_id = input.symbol_id_range.offset_to_id(sym_offset);
+                    symbol_db.definition(symbol_id) == symbol_id
+                }
+                _ => false,
+            };
+            if !is_unresolved {
+                continue;
+            }
+            let Some(name) = wasm_symbol_name_str(input.data, sym) else {
+                bail!(
+                    "{file_display}: undefined symbol with no name (linking symbol index {sym_offset})"
+                );
+            };
+            if !seen.insert((file_display.clone(), name.to_owned())) {
+                continue;
+            }
+            errors.push(format!("{file_display}: undefined symbol: {name}"));
+        }
+    }
+
+    if errors.is_empty() {
+        return Ok(());
+    }
+    bail!("{}", errors.join("\n"));
+}
+
 fn collect_shared_unresolved_imports<'data>(
     inputs: &[WasmObjectLayoutInput<'data>],
     resolutions: &[ObjectImportResolutions],
@@ -3983,7 +4038,7 @@ fn setup_got_mem_and_indices<'data>(
         absorb_got_func_imports(&scan.got_func, layout_inputs, resolutions, symbol_db)?;
         weak_undef_stubs
     };
-
+    report_disallowed_unresolved_imports(layout_inputs, resolutions, symbol_db)?;
     let shared_imports = collect_shared_unresolved_imports(layout_inputs, resolutions)?;
 
     let indices = {

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3512,11 +3512,7 @@ fn report_disallowed_unresolved_imports<'data>(
                 }
                 WasmSymbolKind::Global => {
                     let idx = sym.index as usize;
-                    input
-                        .live_global_imports
-                        .get(idx)
-                        .copied()
-                        .unwrap_or(false)
+                    input.live_global_imports.get(idx).copied().unwrap_or(false)
                         && res
                             .global_resolutions
                             .get(idx)

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3498,14 +3498,30 @@ fn report_disallowed_unresolved_imports<'data>(
             }
 
             let is_unresolved = match sym.kind {
-                WasmSymbolKind::Func => res
-                    .function_resolutions
-                    .get(sym.index as usize)
-                    .is_some_and(|r| matches!(r, ImportResolution::Unresolved)),
-                WasmSymbolKind::Global => res
-                    .global_resolutions
-                    .get(sym.index as usize)
-                    .is_some_and(|r| matches!(r, ImportResolution::Unresolved)),
+                WasmSymbolKind::Func => {
+                    let idx = sym.index as usize;
+                    input
+                        .live_function_imports
+                        .get(idx)
+                        .copied()
+                        .unwrap_or(false)
+                        && res
+                            .function_resolutions
+                            .get(idx)
+                            .is_some_and(|r| matches!(r, ImportResolution::Unresolved))
+                }
+                WasmSymbolKind::Global => {
+                    let idx = sym.index as usize;
+                    input
+                        .live_global_imports
+                        .get(idx)
+                        .copied()
+                        .unwrap_or(false)
+                        && res
+                            .global_resolutions
+                            .get(idx)
+                            .is_some_and(|r| matches!(r, ImportResolution::Unresolved))
+                }
                 WasmSymbolKind::Data => {
                     let symbol_id = input.symbol_id_range.offset_to_id(sym_offset);
                     symbol_db.definition(symbol_id) == symbol_id
@@ -4212,10 +4228,10 @@ fn resolve_got_mem_def(
         let def_ok = def_input
             .symbols
             .get(def_off)
-            .is_some_and(|s| s.kind == WasmSymbolKind::Data && !s.is_undefined());
+            .is_some_and(|s| s.kind == WasmSymbolKind::Data);
         ensure!(
             def_ok,
-            "GOT.mem for `{}` requires a defined data symbol in the link",
+            "GOT.mem for `{}` requires a data symbol in the link",
             symbol_db.symbol_name_for_display(def_id)
         );
         return Ok(GotMemDef::Object {

--- a/wild/tests/sources/wasm/allow-undefined/allow-undefined.c
+++ b/wild/tests/sources/wasm/allow-undefined/allow-undefined.c
@@ -10,6 +10,19 @@
 //#RunEnabled: false
 //#ExpectFuncImportCount: 0
 
+//#Config:function-pic
+//#CompArgs: -fPIC
+//#LinkArgs: --allow-undefined
+//#RunEnabled: false
+//#ExpectFuncImport: env/missing_host_fn=1
+//#ExpectFuncImportCount: 1
+
+//#Config:data-pic
+//#CompArgs: -DTEST_DATA -fPIC
+//#LinkArgs: --allow-undefined
+//#RunEnabled: false
+//#ExpectFuncImportCount: 0
+
 #ifdef TEST_DATA
 extern int missing_data;
 

--- a/wild/tests/sources/wasm/allow-undefined/allow-undefined.c
+++ b/wild/tests/sources/wasm/allow-undefined/allow-undefined.c
@@ -1,0 +1,21 @@
+//#Config:function
+//#LinkArgs: --allow-undefined
+//#RunEnabled: false
+//#ExpectFuncImport: env/missing_host_fn=1
+//#ExpectFuncImportCount: 1
+
+//#Config:data
+//#CompArgs: -DTEST_DATA
+//#LinkArgs: --allow-undefined
+//#RunEnabled: false
+//#ExpectFuncImportCount: 0
+
+#ifdef TEST_DATA
+extern int missing_data;
+
+void _start(void) { missing_data = 1; }
+#else
+void missing_host_fn(void);
+
+void _start(void) { missing_host_fn(); }
+#endif

--- a/wild/tests/sources/wasm/data-end-heap-base/data-end-heap-base.c
+++ b/wild/tests/sources/wasm/data-end-heap-base/data-end-heap-base.c
@@ -2,25 +2,33 @@
 //#LinkArgs:--no-stack-first
 //#RequiresLinkerFlags: --no-stack-first
 
+extern char __global_base;
 extern char __data_end;
 extern char __heap_base;
 extern int y;
+extern unsigned long global_base_from_other_tu(void);
 extern unsigned long data_end_from_other_tu(void);
 extern unsigned long heap_base_from_other_tu(void);
 
 int x = 1;
 
 void _start(void) {
+  unsigned long global_base = (unsigned long)&__global_base;
   unsigned long data_end = (unsigned long)&__data_end;
   unsigned long heap_base = (unsigned long)&__heap_base;
+  unsigned long global_base2 = global_base_from_other_tu();
   unsigned long data_end2 = data_end_from_other_tu();
   unsigned long heap_base2 = heap_base_from_other_tu();
 
-  // Static data starts above LINKER_MEMORY_BASE. exact end can differ by linker packing.
-  if (data_end <= 1024 || heap_base < data_end + 64 * 1024) {
+  // Without --stack-first, static data starts at LINKER_MEMORY_BASE (1024).
+  if (global_base != 1024) {
     __builtin_trap();
   }
-  if (data_end2 != data_end || heap_base2 != heap_base) {
+  // Static data starts at __global_base. exact end can differ by linker packing.
+  if (data_end <= global_base || heap_base < data_end + 64 * 1024) {
+    __builtin_trap();
+  }
+  if (global_base2 != global_base || data_end2 != data_end || heap_base2 != heap_base) {
     __builtin_trap();
   }
   if (x != 1 || y != 2) {

--- a/wild/tests/sources/wasm/data-end-heap-base/data-end-heap-base2.c
+++ b/wild/tests/sources/wasm/data-end-heap-base/data-end-heap-base2.c
@@ -1,7 +1,9 @@
+extern char __global_base;
 extern char __data_end;
 extern char __heap_base;
 
 int y = 2;
 
+unsigned long global_base_from_other_tu(void) { return (unsigned long)&__global_base; }
 unsigned long data_end_from_other_tu(void) { return (unsigned long)&__data_end; }
 unsigned long heap_base_from_other_tu(void) { return (unsigned long)&__heap_base; }

--- a/wild/tests/sources/wasm/pic-got-heap-base/pic-got-heap-base.c
+++ b/wild/tests/sources/wasm/pic-got-heap-base/pic-got-heap-base.c
@@ -1,12 +1,17 @@
 //#CompArgs:-fPIC
-// PIC `GLOBAL_INDEX` / GOT.mem against linker-defined data (`__data_end`, `__heap_base`).
+// PIC `GLOBAL_INDEX` / GOT.mem against linker-defined data.
 
+extern char __global_base;
 extern char __data_end;
 extern char __heap_base;
 
 void _start(void) {
+  unsigned long global_base = (unsigned long)&__global_base;
   unsigned long data_end = (unsigned long)&__data_end;
   unsigned long heap_base = (unsigned long)&__heap_base;
+  if (global_base < 1024 || global_base > data_end) {
+    __builtin_trap();
+  }
   if (data_end < 1024) {
     __builtin_trap();
   }

--- a/wild/tests/sources/wasm/stack-first/stack-first.c
+++ b/wild/tests/sources/wasm/stack-first/stack-first.c
@@ -2,16 +2,21 @@
 
 int payload[8] = {1, 2, 3, 4, 5, 6, 7, 8};
 
+extern char __global_base;
 extern char __data_end;
 extern char __heap_base;
 
 void _start(void) {
+  unsigned long global_base = (unsigned long)&__global_base;
   unsigned long data_end = (unsigned long)&__data_end;
   unsigned long heap_base = (unsigned long)&__heap_base;
   unsigned long stack_size = 1048576;
 
   // With --stack-first, static data starts at stack_size.
-  if (data_end <= stack_size) {
+  if (global_base != stack_size) {
+    __builtin_trap();
+  }
+  if (data_end <= global_base) {
     __builtin_trap();
   }
   // Heap immediately follows data (at most 16-byte alignment padding).

--- a/wild/tests/sources/wasm/undefined-data-cross-object/undefined-data-cross-object.c
+++ b/wild/tests/sources/wasm/undefined-data-cross-object/undefined-data-cross-object.c
@@ -1,0 +1,6 @@
+//#Object:undefined-data-cross-object2.c
+//#ExpectError: undefined symbol: missing_data
+
+extern int missing_data;
+
+void _start(void) { missing_data = 1; }

--- a/wild/tests/sources/wasm/undefined-data-cross-object/undefined-data-cross-object2.c
+++ b/wild/tests/sources/wasm/undefined-data-cross-object/undefined-data-cross-object2.c
@@ -1,0 +1,3 @@
+extern int missing_data;
+
+void dead_function(void) { missing_data = 2; }

--- a/wild/tests/sources/wasm/undefined-gc-dead-fn/undefined-gc-dead-fn.c
+++ b/wild/tests/sources/wasm/undefined-gc-dead-fn/undefined-gc-dead-fn.c
@@ -1,0 +1,12 @@
+//#Config:default
+//#ExpectFuncImportCount: 0
+
+//#Config:no-gc
+//#LinkArgs: --no-gc-sections
+//#ExpectError: undefined symbol: missing_host_fn
+
+void missing_host_fn(void);
+
+void dead_function(void) { missing_host_fn(); }
+
+void _start(void) {}

--- a/wild/tests/sources/wasm/undefined-gc-dead/undefined-gc-dead.c
+++ b/wild/tests/sources/wasm/undefined-gc-dead/undefined-gc-dead.c
@@ -1,0 +1,20 @@
+// A reference from a GC'd function is not a link error.
+//#Config:data
+
+//#Config:data-pic
+//#CompArgs: -fPIC
+
+//#Config:data-no-gc
+//#LinkArgs: --no-gc-sections
+//#ExpectError: undefined symbol: missing_data
+
+//#Config:data-pic-no-gc
+//#CompArgs: -fPIC
+//#LinkArgs: --no-gc-sections
+//#ExpectError: undefined symbol: missing_data
+
+extern int missing_data;
+
+void dead_function(void) { missing_data = 1; }
+
+void _start(void) {}

--- a/wild/tests/sources/wasm/undefined-strong/undefined-strong.c
+++ b/wild/tests/sources/wasm/undefined-strong/undefined-strong.c
@@ -1,0 +1,16 @@
+//#Config:function
+//#ExpectError: undefined symbol: missing_host_fn
+
+//#Config:data
+//#CompArgs: -DTEST_DATA
+//#ExpectError: undefined symbol: missing_data
+
+#ifdef TEST_DATA
+extern int missing_data;
+
+void _start(void) { missing_data = 1; }
+#else
+void missing_host_fn(void);
+
+void _start(void) { missing_host_fn(); }
+#endif

--- a/wild/tests/sources/wasm/undefined-strong/undefined-strong.c
+++ b/wild/tests/sources/wasm/undefined-strong/undefined-strong.c
@@ -5,6 +5,14 @@
 //#CompArgs: -DTEST_DATA
 //#ExpectError: undefined symbol: missing_data
 
+//#Config:function-pic
+//#CompArgs: -fPIC
+//#ExpectError: undefined symbol: missing_host_fn
+
+//#Config:data-pic
+//#CompArgs: -DTEST_DATA -fPIC
+//#ExpectError: undefined symbol: missing_data
+
 #ifdef TEST_DATA
 extern int missing_data;
 

--- a/wild/tests/sources/wasm/undefined-strong/undefined-strong.c
+++ b/wild/tests/sources/wasm/undefined-strong/undefined-strong.c
@@ -13,50 +13,12 @@
 //#CompArgs: -DTEST_DATA -fPIC
 //#ExpectError: undefined symbol: missing_data
 
-// GC'd references to undefined symbols are not link errors.
-//#Config:function-gc-dead
-//#CompArgs: -DTEST_GC_DEAD
-//#ExpectFuncImportCount: 0
-
-//#Config:data-gc-dead
-//#CompArgs: -DTEST_DATA -DTEST_GC_DEAD
-
-//#Config:data-pic-gc-dead
-//#CompArgs: -DTEST_DATA -DTEST_GC_DEAD -fPIC
-
-//#Config:function-gc-dead-no-gc
-//#CompArgs: -DTEST_GC_DEAD
-//#LinkArgs: --no-gc-sections
-//#ExpectError: undefined symbol: missing_host_fn
-
-//#Config:data-gc-dead-no-gc
-//#CompArgs: -DTEST_DATA -DTEST_GC_DEAD
-//#LinkArgs: --no-gc-sections
-//#ExpectError: undefined symbol: missing_data
-
-//#Config:data-pic-gc-dead-no-gc
-//#CompArgs: -DTEST_DATA -DTEST_GC_DEAD -fPIC
-//#LinkArgs: --no-gc-sections
-//#ExpectError: undefined symbol: missing_data
-
 #ifdef TEST_DATA
 extern int missing_data;
 
-#ifdef TEST_GC_DEAD
-void dead_function(void) { missing_data = 1; }
-
-void _start(void) {}
-#else
 void _start(void) { missing_data = 1; }
-#endif
 #else
 void missing_host_fn(void);
 
-#ifdef TEST_GC_DEAD
-void dead_function(void) { missing_host_fn(); }
-
-void _start(void) {}
-#else
 void _start(void) { missing_host_fn(); }
-#endif
 #endif

--- a/wild/tests/sources/wasm/undefined-strong/undefined-strong.c
+++ b/wild/tests/sources/wasm/undefined-strong/undefined-strong.c
@@ -13,12 +13,50 @@
 //#CompArgs: -DTEST_DATA -fPIC
 //#ExpectError: undefined symbol: missing_data
 
+// GC'd references to undefined symbols are not link errors.
+//#Config:function-gc-dead
+//#CompArgs: -DTEST_GC_DEAD
+//#ExpectFuncImportCount: 0
+
+//#Config:data-gc-dead
+//#CompArgs: -DTEST_DATA -DTEST_GC_DEAD
+
+//#Config:data-pic-gc-dead
+//#CompArgs: -DTEST_DATA -DTEST_GC_DEAD -fPIC
+
+//#Config:function-gc-dead-no-gc
+//#CompArgs: -DTEST_GC_DEAD
+//#LinkArgs: --no-gc-sections
+//#ExpectError: undefined symbol: missing_host_fn
+
+//#Config:data-gc-dead-no-gc
+//#CompArgs: -DTEST_DATA -DTEST_GC_DEAD
+//#LinkArgs: --no-gc-sections
+//#ExpectError: undefined symbol: missing_data
+
+//#Config:data-pic-gc-dead-no-gc
+//#CompArgs: -DTEST_DATA -DTEST_GC_DEAD -fPIC
+//#LinkArgs: --no-gc-sections
+//#ExpectError: undefined symbol: missing_data
+
 #ifdef TEST_DATA
 extern int missing_data;
 
+#ifdef TEST_GC_DEAD
+void dead_function(void) { missing_data = 1; }
+
+void _start(void) {}
+#else
 void _start(void) { missing_data = 1; }
+#endif
 #else
 void missing_host_fn(void);
 
+#ifdef TEST_GC_DEAD
+void dead_function(void) { missing_host_fn(); }
+
+void _start(void) {}
+#else
 void _start(void) { missing_host_fn(); }
+#endif
 #endif


### PR DESCRIPTION
commits:

1. Define the linker-defined `__global_base` at the start of static data (after the stack when `--stack-first`), as expected by wasi-libc and similar inputs once undefined symbols are enforced.

2. Non-weak undefined functions/globals without `EXPLICIT_NAME`, and unresolved data symbols, are link errors by default.

3. Support `--allow-undefined` which leave unresolved strong functions (as host imports) / undefined data.

Part of #1431