### PR TITLE
chore(--help): align columns of all the help texts

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -885,7 +885,7 @@ impl<T: platform::Args> ArgumentParser<T> {
 
         // TODO: This is ad-hoc
         help.push_str(&format!(
-            "    {:<31} Read options from a file\n",
+            "    {:<30} Read options from a file\n",
             "@<VALUE>",
         ));
 
@@ -918,11 +918,8 @@ impl<T: platform::Args> ArgumentParser<T> {
 
         for (prefix, handler) in prefix_options {
             if !processed_short_options.contains(prefix) && !handler.help_text.is_empty() {
-                help.push_str(&format!(
-                    "    -{:<30} {}\n",
-                    format!("{prefix} <VALUE>"),
-                    handler.help_text
-                ));
+                let option_name = format!("-{prefix} <VALUE>");
+                help.push_str(&format!("    {option_name:<30} {}\n", handler.help_text));
 
                 // Add sub-options if they exist
                 let mut sub_options = handler.sub_options.iter().collect_vec();
@@ -935,8 +932,9 @@ impl<T: platform::Args> ArgumentParser<T> {
                     } else {
                         sub_name.to_string()
                     };
+                    let option_name = format!("-{prefix} {display_name}");
                     help.push_str(&format!(
-                        "      -{prefix} {display_name:<30} {sub_help}\n",
+                        "     {option_name:<29} {sub_help}\n",
                         sub_help = sub.help
                     ));
                 }

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -877,6 +877,7 @@ impl<T: platform::Args> ArgumentParser<T> {
 
     #[must_use]
     fn generate_help(&self) -> String {
+        const HELP_COL1_WIDTH: usize = 30;
         let mut help = String::new();
         help.push_str("USAGE:\n    wild [OPTIONS] [FILES...]\n\nOPTIONS:\n");
 
@@ -885,8 +886,9 @@ impl<T: platform::Args> ArgumentParser<T> {
 
         // TODO: This is ad-hoc
         help.push_str(&format!(
-            "    {:<30} Read options from a file\n",
+            "    {:<width$} Read options from a file\n",
             "@<VALUE>",
+            width = HELP_COL1_WIDTH
         ));
 
         let mut help_to_options: HashMap<&str, Vec<String>> = HashMap::new();
@@ -919,7 +921,11 @@ impl<T: platform::Args> ArgumentParser<T> {
         for (prefix, handler) in prefix_options {
             if !processed_short_options.contains(prefix) && !handler.help_text.is_empty() {
                 let option_name = format!("-{prefix} <VALUE>");
-                help.push_str(&format!("    {option_name:<30} {}\n", handler.help_text));
+                help.push_str(&format!(
+                    "    {option_name:<width$} {}\n",
+                    handler.help_text,
+                    width = HELP_COL1_WIDTH
+                ));
 
                 // Add sub-options if they exist
                 let mut sub_options = handler.sub_options.iter().collect_vec();
@@ -934,8 +940,9 @@ impl<T: platform::Args> ArgumentParser<T> {
                     };
                     let option_name = format!("-{prefix} {display_name}");
                     help.push_str(&format!(
-                        "     {option_name:<29} {sub_help}\n",
-                        sub_help = sub.help
+                        "     {option_name:<width$} {sub_help}\n",
+                        sub_help = sub.help,
+                        width = HELP_COL1_WIDTH - 1
                     ));
                 }
             }


### PR DESCRIPTION
Addresses:
```
OPTIONS:
    @<VALUE>                        Read options from a file
    -L <VALUE>                      Add directory to library search path
    -R <VALUE>                      Add runtime library search path
    -l <VALUE>                      Link with library
      -l :filename                      Link with specific file
      -l libname                        Link with library libname.so or libname.a
    -m <VALUE>                      Set target architecture
      -m aarch64elf                     AArch64 ELF target
      -m aarch64linux                   AArch64 ELF target (Linux)
      -m elf64loongarch                 LoongArch 64-bit ELF target
      -m elf64lppc                      PowerPC64 LE ELF target
```