### PR TITLE
chore: fix new assert_is_empty clippy warning

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -1490,7 +1490,7 @@ mod tests {
         assert_matches!(args, Args::Elf(_));
         args.parse(|| ["wild", "-flavor", "gnu"].into_iter())
             .unwrap();
-        assert!(args.common().inputs.is_empty());
+        assert_eq!(args.common().inputs, []);
 
         let args = Args::new(|| ["wild", "-flavor", "darwin"].into_iter()).unwrap();
         assert_matches!(args, Args::MachO(_));

--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -2351,9 +2351,12 @@ mod tests {
     fn test_arguments_from_string() {
         use crate::args::arguments_from_string;
 
-        assert!(arguments_from_string("").unwrap().is_empty());
-        assert!(arguments_from_string("''").unwrap().is_empty());
-        assert!(arguments_from_string("\"\"").unwrap().is_empty());
+        assert_eq!(arguments_from_string("").unwrap(), Vec::<String>::new());
+        assert_eq!(arguments_from_string("''").unwrap(), Vec::<String>::new());
+        assert_eq!(
+            arguments_from_string("\"\"").unwrap(),
+            Vec::<String>::new()
+        );
         assert_eq!(
             arguments_from_string(r#""foo" "bar""#).unwrap(),
             ["foo", "bar"]

--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -2353,10 +2353,7 @@ mod tests {
 
         assert_eq!(arguments_from_string("").unwrap(), Vec::<String>::new());
         assert_eq!(arguments_from_string("''").unwrap(), Vec::<String>::new());
-        assert_eq!(
-            arguments_from_string("\"\"").unwrap(),
-            Vec::<String>::new()
-        );
+        assert_eq!(arguments_from_string("\"\"").unwrap(), Vec::<String>::new());
         assert_eq!(
             arguments_from_string(r#""foo" "bar""#).unwrap(),
             ["foo", "bar"]

--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -395,6 +395,6 @@ mod tests {
     fn export_is_not_treated_as_input_path() {
         let args = parse_args(["--export", "__main_void", "-o", "out.wasm"]);
         assert_eq!(args.export_symbols, ["__main_void"]);
-        assert!(args.common.inputs.is_empty());
+        assert_eq!(args.common.inputs, []);
     }
 }

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -4476,7 +4476,7 @@ fn write_sysv_hash_table<C: ElfClass>(
     let (chains, rest) = object::slice_from_bytes_mut::<u32>(rest, chain_count)
         .map_err(|_| error!("Insufficient bytes for .hash chains"))?;
 
-    debug_assert!(rest.is_empty());
+    debug_assert_eq!(rest, []);
 
     buckets.fill(0);
     chains.fill(0);


### PR DESCRIPTION
It's questionable whether we want to keep the new clippy lint enabled or not:
https://rust-lang.github.io/rust-clippy/master/index.html#assert_is_empty.

In any case, the PR addresses warnings of this type:
```
warning: used `debug_assert!` to check that a value is empty
    --> libwild/src/elf_writer.rs:4479:5
     |
4479 |     debug_assert!(rest.is_empty());
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assert_is_empty
     = note: `-W clippy::assert-is-empty` implied by `-W clippy::pedantic`
     = help: to override `-W clippy::pedantic` add `#[allow(clippy::assert_is_empty)]`
help: use `debug_assert_eq!` to show the value on failure
     |
4479 -     debug_assert!(rest.is_empty());
4479 +     debug_assert_eq!(rest, []);
```