### PR TITLE
port(coff): add MSVC link.exe-style argument parsing

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -27,6 +27,7 @@ use itertools::Itertools;
 use jobserver::Acquired;
 use jobserver::Client;
 use rayon::ThreadPoolBuilder;
+use std::borrow::Cow;
 use std::fmt::Display;
 use std::io::Write;
 use std::num::NonZeroUsize;
@@ -635,10 +636,62 @@ pub(crate) enum UnresolvedSymbols {
     IgnoreAll,
 }
 
+/// Describes how a platform spells its options. GNU-style platforms use the default, whereas
+/// link.exe-style platforms accept a `/` prefix, ignore case and attach values with `:`.
+#[derive(Clone, Copy)]
+struct OptionSyntax {
+    /// Prefixes that introduce an option. Matched in order, so longer prefixes must come first.
+    prefixes: &'static [&'static str],
+
+    /// The character that attaches a value to an option name, e.g. `=` in `--foo=bar`.
+    value_separator: char,
+
+    case_insensitive: bool,
+
+    /// Whether an option that takes a value may instead take it from the following token. When
+    /// false, as for link.exe, the value must be attached to the option name, so a missing value is
+    /// an error, as is a value supplied to an option that doesn't take one.
+    allows_separate_value: bool,
+}
+
+impl Default for OptionSyntax {
+    fn default() -> Self {
+        Self {
+            prefixes: &["--", "-"],
+            value_separator: '=',
+            case_insensitive: false,
+            allows_separate_value: true,
+        }
+    }
+}
+
+impl OptionSyntax {
+    /// Strips the first matching option prefix from `arg`, returning the rest of the argument.
+    fn strip_prefix<'a>(&self, arg: &'a str) -> Option<&'a str> {
+        self.prefixes
+            .iter()
+            .find_map(|prefix| arg.strip_prefix(prefix))
+    }
+
+    fn starts_with_prefix(&self, arg: &str) -> bool {
+        self.strip_prefix(arg).is_some()
+    }
+
+    /// Returns the key under which an option with this name should be stored and looked up.
+    fn lookup_key<'a>(&self, name: &'a str) -> Cow<'a, str> {
+        if self.case_insensitive {
+            Cow::Owned(name.to_ascii_lowercase())
+        } else {
+            Cow::Borrowed(name)
+        }
+    }
+}
+
 struct ArgumentParser<T> {
-    options: HashMap<&'static str, OptionHandler<T>>, // Long option lookup
-    short_options: HashMap<&'static str, OptionHandler<T>>, // Short option lookup
+    options: HashMap<String, OptionHandler<T>>, // Long option lookup
+    short_options: HashMap<String, OptionHandler<T>>, // Short option lookup
     prefix_options: HashMap<&'static str, PrefixOptionHandler<T>>, // For options like -L, -l, etc.
+    syntax: OptionSyntax,
 }
 
 impl<T: platform::Args> Default for ArgumentParser<T> {
@@ -650,10 +703,16 @@ impl<T: platform::Args> Default for ArgumentParser<T> {
 impl<T: platform::Args> ArgumentParser<T> {
     #[must_use]
     fn new() -> Self {
+        Self::with_syntax(OptionSyntax::default())
+    }
+
+    #[must_use]
+    fn with_syntax(syntax: OptionSyntax) -> Self {
         Self {
             options: HashMap::new(),
             short_options: HashMap::new(),
             prefix_options: HashMap::new(),
+            syntax,
         }
     }
 
@@ -723,101 +782,67 @@ impl<T: platform::Args> ArgumentParser<T> {
             return Ok(());
         }
 
-        if let Some(stripped) = strip_option(arg) {
-            // Check for option with '=' syntax
-            if let Some(eq_pos) = stripped.find('=') {
-                let option_name = &stripped[..eq_pos];
-                let value = &stripped[eq_pos + 1..];
+        if let Some(stripped) = self.syntax.strip_prefix(arg) {
+            // Check for an option that carries its value attached, e.g. `--foo=bar` or `/FOO:bar`.
+            if let Some(sep_pos) = stripped.find(self.syntax.value_separator) {
+                let option_name = &stripped[..sep_pos];
+                let value = &stripped[sep_pos + self.syntax.value_separator.len_utf8()..];
 
-                if let Some(handler) = self.options.get(option_name) {
+                // The option as the user wrote it, without the value, for error messages.
+                let arg_name = &arg[..arg.len() - stripped.len() + sep_pos];
+
+                if let Some(handler) = self
+                    .options
+                    .get(self.syntax.lookup_key(option_name).as_ref())
+                {
                     match &handler.handler {
-                        OptionHandlerFn::WithParam(f) => f(args, modifier_stack, value)?,
+                        OptionHandlerFn::WithParam(f) => {
+                            ensure!(
+                                !value.is_empty() || self.syntax.allows_separate_value,
+                                "missing value for {arg_name}"
+                            );
+                            f(args, modifier_stack, value)?;
+                        }
                         OptionHandlerFn::WithThreeParams(_) => {
-                            bail!("multi-argument option cannot use the '=' syntax")
+                            bail!(
+                                "multi-argument option cannot use the '{}' syntax",
+                                self.syntax.value_separator
+                            )
                         }
                         OptionHandlerFn::OptionalParam(f) => f(args, modifier_stack, Some(value))?,
-                        OptionHandlerFn::NoParam(_) => return Ok(()),
+                        OptionHandlerFn::NoParam(_) => {
+                            ensure!(
+                                self.syntax.allows_separate_value,
+                                "{arg} does not take a value"
+                            );
+                            return Ok(());
+                        }
                     }
                     return Ok(());
                 }
             } else {
-                if stripped == "build-id"
-                    && let Some(handler) = self.options.get(stripped)
-                    && let OptionHandlerFn::WithParam(f) = &handler.handler
-                {
-                    f(args, modifier_stack, "fast")?;
-                    return Ok(());
-                }
+                let key = self.syntax.lookup_key(stripped);
 
-                if let Some(handler) = self.options.get(stripped) {
-                    match &handler.handler {
-                        OptionHandlerFn::NoParam(f) => f(args, modifier_stack)?,
-                        OptionHandlerFn::WithParam(f) => {
-                            let next_arg = input
-                                .next()
-                                .with_context(|| format!("Missing argument to {arg}"))?;
-                            f(args, modifier_stack, next_arg.as_ref())?;
-                        }
-                        OptionHandlerFn::WithThreeParams(f) => {
-                            let first_arg = input
-                                .next()
-                                .with_context(|| format!("Missing first argument to {arg}"))?;
-                            let second_arg = input
-                                .next()
-                                .with_context(|| format!("Missing second argument to {arg}"))?;
-                            let third_arg = input
-                                .next()
-                                .with_context(|| format!("Missing third argument to {arg}"))?;
-                            f(
-                                args,
-                                modifier_stack,
-                                first_arg.as_ref(),
-                                second_arg.as_ref(),
-                                third_arg.as_ref(),
-                            )?;
-                        }
-                        OptionHandlerFn::OptionalParam(f) => {
-                            f(args, modifier_stack, None)?;
-                        }
+                if let Some(handler) = self.options.get(key.as_ref()) {
+                    // `--build-id` on its own means `--build-id=fast` rather than taking the
+                    // following token as its value.
+                    if key.as_ref() == "build-id"
+                        && let OptionHandlerFn::WithParam(f) = &handler.handler
+                    {
+                        f(args, modifier_stack, "fast")?;
+                        return Ok(());
                     }
+
+                    self.invoke_handler(args, modifier_stack, arg, &handler.handler, input)?;
                     return Ok(());
                 }
             }
         }
 
         if arg.starts_with('-') && !arg.starts_with("--") && arg.len() > 1 {
-            let option_name = &arg[1..];
-            if let Some(handler) = self.short_options.get(option_name) {
-                match &handler.handler {
-                    OptionHandlerFn::NoParam(f) => f(args, modifier_stack)?,
-                    OptionHandlerFn::WithParam(f) => {
-                        let next_arg = input
-                            .next()
-                            .with_context(|| format!("Missing argument to {arg}"))?;
-                        f(args, modifier_stack, next_arg.as_ref())?;
-                    }
-                    OptionHandlerFn::WithThreeParams(f) => {
-                        let first_arg = input
-                            .next()
-                            .with_context(|| format!("Missing first argument to {arg}"))?;
-                        let second_arg = input
-                            .next()
-                            .with_context(|| format!("Missing second argument to {arg}"))?;
-                        let third_arg = input
-                            .next()
-                            .with_context(|| format!("Missing third argument to {arg}"))?;
-                        f(
-                            args,
-                            modifier_stack,
-                            first_arg.as_ref(),
-                            second_arg.as_ref(),
-                            third_arg.as_ref(),
-                        )?;
-                    }
-                    OptionHandlerFn::OptionalParam(f) => {
-                        f(args, modifier_stack, None)?;
-                    }
-                }
+            let option_name = self.syntax.lookup_key(&arg[1..]);
+            if let Some(handler) = self.short_options.get(option_name.as_ref()) {
+                self.invoke_handler(args, modifier_stack, arg, &handler.handler, input)?;
                 return Ok(());
             }
         }
@@ -866,8 +891,8 @@ impl<T: platform::Args> ArgumentParser<T> {
             }
         }
 
-        if arg.starts_with('-') {
-            if let Some(stripped) = strip_option(arg)
+        if self.syntax.starts_with_prefix(arg) {
+            if let Some(stripped) = self.syntax.strip_prefix(arg)
                 && args.is_ignored_flag(stripped)
             {
                 args.warn_unsupported(arg)?;
@@ -885,6 +910,59 @@ impl<T: platform::Args> ArgumentParser<T> {
             search_first: None,
             modifiers: *modifier_stack.last().unwrap(),
         });
+
+        Ok(())
+    }
+
+    /// Runs `handler`, taking any values it needs from `input`. `arg` is the argument as it was
+    /// written, for use in error messages.
+    fn invoke_handler<S: AsRef<str>, I: Iterator<Item = S>>(
+        &self,
+        args: &mut T,
+        modifier_stack: &mut Vec<Modifiers>,
+        arg: &str,
+        handler: &OptionHandlerFn<T>,
+        input: &mut I,
+    ) -> Result<()> {
+        if !self.syntax.allows_separate_value
+            && matches!(
+                handler,
+                OptionHandlerFn::WithParam(_) | OptionHandlerFn::WithThreeParams(_)
+            )
+        {
+            bail!("missing value for {arg}");
+        }
+
+        match handler {
+            OptionHandlerFn::NoParam(f) => f(args, modifier_stack)?,
+            OptionHandlerFn::WithParam(f) => {
+                let next_arg = input
+                    .next()
+                    .with_context(|| format!("Missing argument to {arg}"))?;
+                f(args, modifier_stack, next_arg.as_ref())?;
+            }
+            OptionHandlerFn::WithThreeParams(f) => {
+                let first_arg = input
+                    .next()
+                    .with_context(|| format!("Missing first argument to {arg}"))?;
+                let second_arg = input
+                    .next()
+                    .with_context(|| format!("Missing second argument to {arg}"))?;
+                let third_arg = input
+                    .next()
+                    .with_context(|| format!("Missing third argument to {arg}"))?;
+                f(
+                    args,
+                    modifier_stack,
+                    first_arg.as_ref(),
+                    second_arg.as_ref(),
+                    third_arg.as_ref(),
+                )?;
+            }
+            OptionHandlerFn::OptionalParam(f) => {
+                f(args, modifier_stack, None)?;
+            }
+        }
 
         Ok(())
     }
@@ -964,7 +1042,9 @@ impl<T: platform::Args> ArgumentParser<T> {
 
         // Add short-only options
         for (short_char, handler) in &self.short_options {
-            if !processed_short_options.contains(short_char) && !handler.help_text.is_empty() {
+            if !processed_short_options.contains(short_char.as_str())
+                && !handler.help_text.is_empty()
+            {
                 let short_suffix = handler.handler.help_suffix_short();
                 help_to_options
                     .entry(handler.help_text)
@@ -999,10 +1079,16 @@ impl<T: platform::Args> ArgumentParser<T> {
 
 impl<T> ArgumentParser<T> {
     fn insert_long_option(&mut self, name: &'static str, handler: OptionHandler<T>) {
+        let key = self.syntax.lookup_key(name).into_owned();
         assert!(
-            self.options.insert(name, handler).is_none(),
+            self.options.insert(key, handler).is_none(),
             "Option --{name} registered more than once"
         );
+    }
+
+    fn insert_short_option(&mut self, name: &'static str, handler: OptionHandler<T>) {
+        let key = self.syntax.lookup_key(name).into_owned();
+        self.short_options.insert(key, handler);
     }
 }
 
@@ -1188,8 +1274,7 @@ impl<'a, T> OptionDeclaration<'a, T, NoParam> {
 
         for option in self.short_names {
             self.parser
-                .short_options
-                .insert(option, option_handler.clone());
+                .insert_short_option(option, option_handler.clone());
         }
     }
 }
@@ -1211,8 +1296,7 @@ impl<'a, T> OptionDeclaration<'a, T, WithParam> {
 
         for option in self.short_names {
             self.parser
-                .short_options
-                .insert(option, option_handler.clone());
+                .insert_short_option(option, option_handler.clone());
         }
 
         for prefix in self.prefixes {
@@ -1241,8 +1325,7 @@ impl<'a, T> OptionDeclaration<'a, T, WithThreeParams> {
 
         for option in self.short_names {
             self.parser
-                .short_options
-                .insert(option, option_handler.clone());
+                .insert_short_option(option, option_handler.clone());
         }
     }
 }
@@ -1261,14 +1344,9 @@ impl<'a, T> OptionDeclaration<'a, T, WithOptionalParam> {
 
         for option in self.short_names {
             self.parser
-                .short_options
-                .insert(option, option_handler.clone());
+                .insert_short_option(option, option_handler.clone());
         }
     }
-}
-
-fn strip_option(arg: &str) -> Option<&str> {
-    arg.strip_prefix("--").or(arg.strip_prefix('-'))
 }
 
 pub(crate) fn parse_number(s: &str) -> Result<u64> {

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -34,6 +34,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+pub mod coff;
 pub mod elf;
 pub mod macho;
 pub mod wasm;
@@ -140,6 +141,7 @@ impl Args {
         };
 
         let mut args = match platform {
+            PlatformKind::Coff => Args::Coff(coff::CoffArgs::new()?),
             PlatformKind::Elf => Args::Elf(elf::ElfArgs::new()?),
             PlatformKind::MachO => Args::MachO(macho::MachOArgs::new()?),
             PlatformKind::Wasm => Args::Wasm(wasm::WasmArgs::new()?),
@@ -171,6 +173,7 @@ impl Args {
         }
 
         match self {
+            Args::Coff(args) => args.parse(input),
             Args::Elf(args) => args.parse(input),
             Args::MachO(args) => args.parse(input),
             Args::Wasm(args) => args.parse(input),
@@ -193,6 +196,7 @@ impl Args {
 
     pub(crate) fn common(&self) -> &CommonArgs {
         match self {
+            Args::Coff(coff_args) => &coff_args.common,
             Args::Elf(elf_args) => &elf_args.common,
             Args::MachO(macho_args) => &macho_args.common,
             Args::Wasm(wasm_args) => &wasm_args.common,
@@ -201,6 +205,7 @@ impl Args {
 
     pub(crate) fn common_mut(&mut self) -> &mut CommonArgs {
         match self {
+            Args::Coff(coff_args) => &mut coff_args.common,
             Args::Elf(elf_args) => &mut elf_args.common,
             Args::MachO(macho_args) => &mut macho_args.common,
             Args::Wasm(wasm_args) => &mut wasm_args.common,
@@ -216,13 +221,14 @@ impl Args {
                     crate::arch::SUPPORTED_EMULATIONS
                 )?;
             }
-            Args::MachO(_) | Args::Wasm(_) => (),
+            Args::Coff(_) | Args::MachO(_) | Args::Wasm(_) => (),
         }
         Ok(())
     }
 }
 
 enum PlatformKind {
+    Coff,
     Elf,
     MachO,
     Wasm,
@@ -241,7 +247,7 @@ impl PlatformKind {
         match flavor {
             "gnu" | "ld" => Ok(PlatformKind::Elf),
             "darwin" | "ld64" => Ok(PlatformKind::MachO),
-            "link" => bail!("Windows (link flavor) is not yet supported"),
+            "link" => Ok(PlatformKind::Coff),
             "wasm" | "ld-wasm" => Ok(PlatformKind::Wasm),
             _ => bail!(
                 "Unknown flavor '{}'. Valid flavors: gnu, darwin, link",
@@ -252,6 +258,12 @@ impl PlatformKind {
 
     fn from_executable_name(name: &str) -> Option<Self> {
         let base_name = Path::new(name).file_stem().and_then(|n| n.to_str())?;
+
+        // MSVC-world tools are commonly invoked as `LINK.EXE`, so match those names without regard
+        // to case.
+        if base_name.eq_ignore_ascii_case("link") || base_name.eq_ignore_ascii_case("lld-link") {
+            return Some(PlatformKind::Coff);
+        }
 
         match base_name {
             "ld" => Some(PlatformKind::Elf),
@@ -501,6 +513,7 @@ pub struct ThreadPool {
 // TODO: remove
 #[allow(clippy::large_enum_variant)]
 pub enum Args {
+    Coff(coff::CoffArgs),
     Elf(elf::ElfArgs),
     MachO(macho::MachOArgs),
     Wasm(wasm::WasmArgs),
@@ -509,6 +522,7 @@ pub enum Args {
 impl std::fmt::Debug for Args {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Args::Coff(args) => args.fmt(f),
             Args::Elf(args) => args.fmt(f),
             Args::MachO(args) => args.fmt(f),
             Args::Wasm(args) => args.fmt(f),
@@ -1501,6 +1515,9 @@ mod tests {
 
         let args = Args::new(|| ["ld64.wild", "-flavor", "gnu"].into_iter()).unwrap();
         assert_matches!(args, Args::Elf(_));
+
+        let args = Args::new(|| ["wild", "-flavor", "link"].into_iter()).unwrap();
+        assert_matches!(args, Args::Coff(_));
 
         assert!(Args::new(|| ["ld.wild", "-flavor", "invalid"].into_iter()).is_err());
         assert!(Args::new(|| ["ld.wild", "-flavor"].into_iter()).is_err());

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -649,8 +649,8 @@ struct OptionSyntax {
     case_insensitive: bool,
 
     /// Whether an option that takes a value may instead take it from the following token. When
-    /// false, as for link.exe, the value must be attached to the option name, so a missing value is
-    /// an error, as is a value supplied to an option that doesn't take one.
+    /// false, as for link.exe, the value must be attached to the option name, so a missing value
+    /// is an error, as is a value supplied to an option that doesn't take one.
     allows_separate_value: bool,
 }
 
@@ -688,8 +688,8 @@ impl OptionSyntax {
 }
 
 struct ArgumentParser<T> {
-    options: HashMap<String, OptionHandler<T>>, // Long option lookup
-    short_options: HashMap<String, OptionHandler<T>>, // Short option lookup
+    options: HashMap<&'static str, OptionHandler<T>>, // Long option lookup
+    short_options: HashMap<&'static str, OptionHandler<T>>, // Short option lookup
     prefix_options: HashMap<&'static str, PrefixOptionHandler<T>>, // For options like -L, -l, etc.
     syntax: OptionSyntax,
 }
@@ -1042,9 +1042,7 @@ impl<T: platform::Args> ArgumentParser<T> {
 
         // Add short-only options
         for (short_char, handler) in &self.short_options {
-            if !processed_short_options.contains(short_char.as_str())
-                && !handler.help_text.is_empty()
-            {
+            if !processed_short_options.contains(short_char) && !handler.help_text.is_empty() {
                 let short_suffix = handler.handler.help_suffix_short();
                 help_to_options
                     .entry(handler.help_text)
@@ -1079,16 +1077,27 @@ impl<T: platform::Args> ArgumentParser<T> {
 
 impl<T> ArgumentParser<T> {
     fn insert_long_option(&mut self, name: &'static str, handler: OptionHandler<T>) {
-        let key = self.syntax.lookup_key(name).into_owned();
+        self.assert_valid_key(name);
         assert!(
-            self.options.insert(key, handler).is_none(),
+            self.options.insert(name, handler).is_none(),
             "Option --{name} registered more than once"
         );
     }
 
     fn insert_short_option(&mut self, name: &'static str, handler: OptionHandler<T>) {
-        let key = self.syntax.lookup_key(name).into_owned();
-        self.short_options.insert(key, handler);
+        self.assert_valid_key(name);
+        self.short_options.insert(name, handler);
+    }
+
+    /// Options on case-insensitive platforms must be declared in lowercase, since arguments are
+    /// lowercased before they're looked up.
+    fn assert_valid_key(&self, name: &'static str) {
+        if self.syntax.case_insensitive {
+            assert!(
+                !name.contains(|c: char| c.is_ascii_uppercase()),
+                "Option {name} must be declared in lowercase"
+            );
+        }
     }
 }
 

--- a/libwild/src/args/coff.rs
+++ b/libwild/src/args/coff.rs
@@ -1,0 +1,616 @@
+use crate::args::CommonArgs;
+use crate::args::Input;
+use crate::args::InputSpec;
+use crate::args::Modifiers;
+use crate::bail;
+use crate::error::Result;
+use crate::platform;
+use std::path::Path;
+use std::sync::Arc;
+
+/// The only machine type we currently support.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CoffMachine {
+    X86_64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Subsystem {
+    Console,
+    Windows,
+}
+
+#[derive(Debug)]
+pub struct CoffArgs {
+    pub(crate) common: CommonArgs,
+    pub(crate) entry: Option<String>,
+    pub(crate) subsystem: Option<Subsystem>,
+    pub(crate) is_dll: bool,
+    pub(crate) machine: CoffMachine,
+    pub(crate) lib_search_path: Vec<Box<Path>>,
+    pub(crate) default_libraries: Vec<String>,
+    /// Libraries named by `/NODEFAULTLIB:name`.
+    pub(crate) excluded_default_libraries: Vec<String>,
+    /// Set by a bare `/NODEFAULTLIB`, which ignores every default library.
+    pub(crate) no_default_libraries: bool,
+}
+
+impl CoffArgs {
+    pub(crate) fn new() -> Result<Self> {
+        Ok(Self {
+            common: CommonArgs::from_env()?,
+            ..Default::default()
+        })
+    }
+}
+
+impl Default for CoffArgs {
+    fn default() -> Self {
+        Self {
+            common: CommonArgs::default(),
+            entry: None,
+            subsystem: None,
+            is_dll: false,
+            machine: CoffMachine::X86_64,
+            lib_search_path: Vec::new(),
+            default_libraries: Vec::new(),
+            excluded_default_libraries: Vec::new(),
+            no_default_libraries: false,
+        }
+    }
+}
+
+impl platform::Args for CoffArgs {
+    fn parse<S, I>(&mut self, input: I) -> Result
+    where
+        S: AsRef<str>,
+        I: Iterator<Item = S>,
+    {
+        parse(self, input)
+    }
+
+    fn should_strip_debug(&self) -> bool {
+        todo!()
+    }
+
+    fn should_strip_all(&self) -> bool {
+        false
+    }
+
+    fn entry_point<'a>(
+        &'a self,
+        _linker_script_entry: Option<&'a [u8]>,
+    ) -> platform::EntryPoint<'a> {
+        self.entry
+            .as_deref()
+            .map_or(platform::EntryPoint::None, |entry| {
+                platform::EntryPoint::Symbol(entry.as_bytes())
+            })
+    }
+
+    fn lib_search_path(&self) -> &[Box<Path>] {
+        &self.lib_search_path
+    }
+
+    fn common(&self) -> &CommonArgs {
+        &self.common
+    }
+
+    fn common_mut(&mut self) -> &mut CommonArgs {
+        &mut self.common
+    }
+
+    fn should_export_all_dynamic_symbols(&self) -> bool {
+        todo!()
+    }
+
+    fn should_export_dynamic(&self, _lib_name: &[u8]) -> bool {
+        todo!()
+    }
+
+    fn loadable_segment_alignment(&self) -> crate::alignment::Alignment {
+        todo!()
+    }
+
+    fn should_merge_sections(&self) -> bool {
+        // TODO
+        true
+    }
+
+    fn should_output_executable(&self) -> bool {
+        // TODO
+        true
+    }
+
+    fn is_ignored_flag(&self, _flag: &str) -> bool {
+        false
+    }
+}
+
+// Parse the supplied input arguments, which should not include the program name.
+pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(args: &mut CoffArgs, input: I) -> Result {
+    let tokens = input.map(|arg| arg.as_ref().to_owned()).collect::<Vec<_>>();
+
+    parse_tokens(args, tokens.iter().map(String::as_str))?;
+
+    args.common.report_unrecognized()
+}
+
+/// Options that rustc's MSVC linker driver emits that we recognise but ignore, because they only
+/// affect outputs we don't produce yet or optimisations we don't implement.
+const IGNORED_OPTIONS: &[&str] = &[
+    // Debug info, PDB paths, import library, visualisers, module definition file and
+    // optimisations.
+    "debug",
+    "pdb",
+    "pdbaltpath",
+    "implib",
+    "natvis",
+    "def",
+    "opt",
+    // Control-flow guard, e.g. `/guard:cf`, and archive member handling.
+    "guard",
+    "wholearchive",
+    // Take an optional `:NO` value, e.g. `/NXCOMPAT:NO`.
+    "nxcompat",
+    "dynamicbase",
+    // Manifest generation and warnings-as-errors, e.g. `/MANIFEST:EMBED`, `/MANIFESTUAC:NO`,
+    // `/MANIFESTINPUT:foo.manifest`, `/WX:NO`.
+    "manifest",
+    "manifestinput",
+    "manifestuac",
+    "wx",
+];
+
+/// Ignored options that take no value, so `/NOLOGO:x` is an error just like `/DLL:x` is.
+const IGNORED_NO_VALUE_OPTIONS: &[&str] = &["nologo"];
+
+/// MSVC options don't fit the GNU-style declarative parser used by the other platforms: names are
+/// case-insensitive, take either a `/` or a `-` prefix and carry their value as `NAME:value`.
+fn parse_tokens<'a, I: Iterator<Item = &'a str>>(args: &mut CoffArgs, input: I) -> Result {
+    for arg in input {
+        let Some(option) = arg.strip_prefix('/').or_else(|| arg.strip_prefix('-')) else {
+            add_input(args, arg);
+            continue;
+        };
+
+        let (name, value) = option
+            .split_once(':')
+            .map_or((option, None), |(name, value)| (name, Some(value)));
+
+        match name.to_ascii_lowercase().as_str() {
+            "out" => {
+                let value = required_value("/OUT", value)?;
+                args.common.output = Arc::from(Path::new(value));
+            }
+            "entry" => {
+                args.entry = Some(required_value("/ENTRY", value)?.to_owned());
+            }
+            "subsystem" => {
+                let value = required_value("/SUBSYSTEM", value)?;
+                args.subsystem = Some(parse_subsystem(value)?);
+            }
+            "dll" => {
+                no_value("/DLL", value)?;
+                args.is_dll = true;
+            }
+            "machine" => {
+                let value = required_value("/MACHINE", value)?;
+                if !value.eq_ignore_ascii_case("x64") && !value.eq_ignore_ascii_case("amd64") {
+                    bail!("unsupported /MACHINE value `{value}`; only X64 is supported");
+                }
+                args.machine = CoffMachine::X86_64;
+            }
+            "libpath" => {
+                let value = required_value("/LIBPATH", value)?;
+                args.common.save_dir.handle_file(value);
+                args.lib_search_path.push(Box::from(Path::new(value)));
+            }
+            "defaultlib" => {
+                let value = required_value("/DEFAULTLIB", value)?;
+                args.default_libraries.push(value.to_owned());
+            }
+            // `/NODEFAULTLIB:lib` excludes one library, a bare `/NODEFAULTLIB` excludes all of
+            // them. Precedence over `/DEFAULTLIB` is applied when default libraries are resolved.
+            "nodefaultlib" => match value {
+                Some(value) if !value.is_empty() => {
+                    args.excluded_default_libraries.push(value.to_owned());
+                }
+                _ => args.no_default_libraries = true,
+            },
+            name if IGNORED_NO_VALUE_OPTIONS.contains(&name) => {
+                no_value(arg, value)?;
+            }
+            name if IGNORED_OPTIONS.contains(&name) => {}
+            // A prefixed token whose name isn't in the table above is an input only if that name
+            // looks like a path, since on Unix hosts absolute paths begin with `/` too.
+            _ if name.contains(['/', '\\']) => add_input(args, arg),
+            _ => args.common.unrecognized_options.push(arg.to_owned()),
+        }
+    }
+
+    Ok(())
+}
+
+/// Returns the non-empty value attached to an option with `:`. link.exe has no separate-token form.
+fn required_value<'a>(option: &str, value: Option<&'a str>) -> Result<&'a str> {
+    match value {
+        Some(value) if !value.is_empty() => Ok(value),
+        _ => bail!("missing value for {option}"),
+    }
+}
+
+/// Rejects `NAME:value` for options that take no value.
+fn no_value(option: &str, value: Option<&str>) -> Result {
+    if value.is_some() {
+        bail!("{option} does not take a value");
+    }
+    Ok(())
+}
+
+/// Parses `/SUBSYSTEM:name[,major[.minor]]`. The version only sets optional-header fields we don't
+/// emit yet, so it's validated and ignored.
+fn parse_subsystem(value: &str) -> Result<Subsystem> {
+    let (name, version) = value
+        .split_once(',')
+        .map_or((value, None), |(name, version)| (name, Some(version)));
+
+    if let Some(version) = version {
+        let (major, minor) = version
+            .split_once('.')
+            .map_or((version, None), |(major, minor)| (major, Some(minor)));
+
+        if major.is_empty()
+            || !major.bytes().all(|b| b.is_ascii_digit())
+            || minor
+                .is_some_and(|minor| minor.is_empty() || !minor.bytes().all(|b| b.is_ascii_digit()))
+        {
+            bail!("invalid /SUBSYSTEM version `{version}`; expected `major[.minor]`");
+        }
+    }
+
+    match name.to_ascii_lowercase().as_str() {
+        "console" => Ok(Subsystem::Console),
+        "windows" => Ok(Subsystem::Windows),
+        _ => bail!("unsupported subsystem `{name}`; only CONSOLE and WINDOWS are supported"),
+    }
+}
+
+fn add_input(args: &mut CoffArgs, value: &str) {
+    args.common.save_dir.handle_file(value);
+    args.common.inputs.push(Input {
+        spec: InputSpec::File(Box::from(Path::new(value))),
+        search_first: None,
+        modifiers: Modifiers::default(),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CoffArgs;
+    use super::Subsystem;
+    use super::parse;
+    use crate::args::InputSpec;
+    use std::path::Path;
+
+    /// A link line of the shape that rustc emits when targeting `x86_64-pc-windows-msvc`.
+    const RUSTC_LINK_LINE: &[&str] = &[
+        "/NOLOGO",
+        "/OUT:target\\debug\\hello.exe",
+        "/LIBPATH:sdk\\lib\\x64",
+        "/DEFAULTLIB:msvcrt.lib",
+        "/NODEFAULTLIB:libcmt.lib",
+        "/SUBSYSTEM:CONSOLE",
+        "/MACHINE:X64",
+        "hello.o",
+        "kernel32.lib",
+    ];
+
+    fn parse_args<'a>(args: impl IntoIterator<Item = &'a str>) -> CoffArgs {
+        let mut coff_args = CoffArgs::default();
+        parse(&mut coff_args, args.into_iter()).unwrap();
+        coff_args
+    }
+
+    fn input_paths(args: &CoffArgs) -> Vec<&Path> {
+        args.common
+            .inputs
+            .iter()
+            .map(|input| match &input.spec {
+                InputSpec::File(path) => path.as_ref(),
+                InputSpec::Lib(_) | InputSpec::Search(_) => panic!("unexpected input spec"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn parses_rustc_link_line() {
+        let args = parse_args(RUSTC_LINK_LINE.iter().copied());
+
+        assert_eq!(&*args.common.output, Path::new("target\\debug\\hello.exe"));
+        assert_eq!(args.subsystem, Some(Subsystem::Console));
+        assert_eq!(args.lib_search_path[0].as_ref(), Path::new("sdk\\lib\\x64"));
+        assert_eq!(args.default_libraries, ["msvcrt.lib"]);
+        assert_eq!(args.excluded_default_libraries, ["libcmt.lib"]);
+        assert!(!args.no_default_libraries);
+        assert!(!args.is_dll);
+        assert_eq!(
+            input_paths(&args),
+            [Path::new("hello.o"), Path::new("kernel32.lib")]
+        );
+    }
+
+    #[test]
+    fn option_names_are_case_insensitive() {
+        let args = parse_args(["/oUt:a.exe", "-ENTRY:main", "/dll"]);
+
+        assert_eq!(&*args.common.output, Path::new("a.exe"));
+        assert_eq!(args.entry.as_deref(), Some("main"));
+        assert!(args.is_dll);
+    }
+
+    #[test]
+    fn accepts_both_slash_and_dash_prefixes() {
+        let slash = parse_args(["/OUT:a.exe", "/LIBPATH:lib"]);
+        let dash = parse_args(["-OUT:a.exe", "-LIBPATH:lib"]);
+
+        assert_eq!(slash.common.output, dash.common.output);
+        assert_eq!(slash.lib_search_path, dash.lib_search_path);
+    }
+
+    fn parse_error<'a>(args: impl IntoIterator<Item = &'a str>) -> String {
+        let mut coff_args = CoffArgs::default();
+        parse(&mut coff_args, args.into_iter())
+            .unwrap_err()
+            .to_string()
+    }
+
+    #[test]
+    fn values_must_be_attached_to_the_option() {
+        for arg in ["/OUT", "/ENTRY", "/LIBPATH", "/DEFAULTLIB", "/SUBSYSTEM"] {
+            let message = parse_error([arg, "main.obj"]);
+            assert!(
+                message.contains("missing value for"),
+                "for {arg}: {message}"
+            );
+        }
+
+        let message = parse_error(["/OUT:", "/DLL", "main.obj"]);
+        assert!(message.contains("missing value for /OUT"), "{message}");
+    }
+
+    #[test]
+    fn empty_value_does_not_consume_the_following_token() {
+        let message = parse_error(["/LIBPATH:", "main.obj"]);
+
+        assert!(message.contains("missing value for /LIBPATH"), "{message}");
+    }
+
+    #[test]
+    fn options_taking_no_value_reject_one() {
+        for arg in ["/DLL:x", "/NOLOGO:x"] {
+            let message = parse_error([arg]);
+            assert!(
+                message.contains("does not take a value"),
+                "for {arg}: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_options_with_a_dot_are_not_treated_as_inputs() {
+        let message = parse_error(["/DEBUG.FOO"]);
+
+        assert!(message.contains("unrecognized option(s)"), "{message}");
+    }
+
+    #[test]
+    fn parses_subsystem_with_optional_version() {
+        for arg in [
+            "/SUBSYSTEM:windows",
+            "/SUBSYSTEM:WINDOWS,6",
+            "/SUBSYSTEM:windows,6.2",
+        ] {
+            assert_eq!(
+                parse_args([arg]).subsystem,
+                Some(Subsystem::Windows),
+                "{arg}"
+            );
+        }
+        for arg in ["/SUBSYSTEM:CONSOLE", "/subsystem:console,10.0"] {
+            assert_eq!(
+                parse_args([arg]).subsystem,
+                Some(Subsystem::Console),
+                "{arg}"
+            );
+        }
+
+        let mut args = CoffArgs::default();
+        let message = parse(&mut args, ["/SUBSYSTEM:CONSOLE,x"].into_iter())
+            .unwrap_err()
+            .to_string();
+        assert!(message.contains("invalid /SUBSYSTEM version"), "{message}");
+    }
+
+    #[test]
+    fn other_subsystems_are_unsupported_rather_than_unrecognized() {
+        for name in ["NATIVE", "EFI_APPLICATION", "BOOT_APPLICATION", "POSIX"] {
+            let mut args = CoffArgs::default();
+            let message = parse(&mut args, [&format!("/SUBSYSTEM:{name}")].into_iter())
+                .unwrap_err()
+                .to_string();
+
+            assert!(
+                message.contains("unsupported subsystem"),
+                "unexpected error for {name}: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_machines_other_than_x64() {
+        for machine in [
+            "/MACHINE:X64",
+            "/MACHINE:x64",
+            "/MACHINE:amd64",
+            "/machine:AMD64",
+        ] {
+            let mut args = CoffArgs::default();
+            parse(&mut args, [machine].into_iter()).unwrap();
+        }
+
+        for machine in ["X86", "arm64", "ARM64EC", "arm64x", "ARM", "mips"] {
+            let mut args = CoffArgs::default();
+            let message = parse(&mut args, [&format!("/MACHINE:{machine}")].into_iter())
+                .unwrap_err()
+                .to_string();
+
+            assert!(
+                message.contains("only X64 is supported"),
+                "unexpected error for {machine}: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn bare_nodefaultlib_excludes_all_default_libraries() {
+        let args = parse_args(["/NODEFAULTLIB"]);
+
+        assert!(args.no_default_libraries);
+        assert!(args.excluded_default_libraries.is_empty());
+    }
+
+    #[test]
+    fn unknown_options_are_an_error() {
+        for arg in ["/FOO", "-FOO:bar"] {
+            let mut args = CoffArgs::default();
+            let message = parse(&mut args, [arg].into_iter()).unwrap_err().to_string();
+
+            assert!(
+                message.contains("unrecognized option(s)"),
+                "unexpected error for {arg}: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_options_are_reported_together_with_valid_ones() {
+        let mut args = CoffArgs::default();
+        let message = parse(&mut args, ["/OUT:a.exe", "/FOO", "main.obj"].into_iter())
+            .unwrap_err()
+            .to_string();
+
+        assert!(message.contains("/FOO"), "{message}");
+    }
+
+    #[test]
+    fn rustc_ignored_options_are_accepted() {
+        let ignored = [
+            "/NOLOGO",
+            "/DEBUG",
+            "/DEBUG:FULL",
+            "/NXCOMPAT",
+            "/NXCOMPAT:NO",
+            "/DYNAMICBASE:NO",
+            "/OPT:REF,NOICF",
+            "/PDBALTPATH:%_PDB%",
+            "/PDB:out.pdb",
+            "/IMPLIB:out.lib",
+            "/NATVIS:types.natvis",
+            "/DEF:exports.def",
+            "/WHOLEARCHIVE",
+            "/WHOLEARCHIVE:foo.lib",
+            "/guard:cf",
+            "/DYNAMICBASE",
+            "/MANIFEST",
+            "/MANIFEST:EMBED",
+            "/MANIFEST:NO",
+            "/MANIFESTINPUT:x/y.xml",
+            "/MANIFESTUAC:NO",
+            "/WX",
+            "/WX:NO",
+        ];
+
+        for arg in ignored {
+            let args = parse_args([arg, "main.obj"]);
+
+            assert_eq!(input_paths(&args), [Path::new("main.obj")], "for {arg}");
+            assert!(args.common.unrecognized_options.is_empty(), "for {arg}");
+        }
+    }
+
+    #[test]
+    fn unknown_options_with_a_path_like_value_are_not_treated_as_inputs() {
+        for arg in ["/BOGUSFLAG:a/b", "/BOGUSFLAG:a\\b"] {
+            let message = parse_error([arg]);
+
+            assert!(
+                message.contains("unrecognized option(s)"),
+                "unexpected error for {arg}: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn options_whose_value_contains_a_separator_are_still_options() {
+        let args = parse_args(["/LIBPATH:some/dir"]);
+
+        assert_eq!(args.lib_search_path[0].as_ref(), Path::new("some/dir"));
+        assert!(args.common.inputs.is_empty());
+    }
+
+    #[test]
+    fn path_shaped_tokens_are_inputs_not_options() {
+        let args = parse_args([
+            "/tmp/foo.obj",
+            "/usr/lib/bar.lib",
+            "./x.obj",
+            "foo.lib",
+            "/OUT:a.exe",
+        ]);
+
+        assert_eq!(
+            input_paths(&args),
+            [
+                Path::new("/tmp/foo.obj"),
+                Path::new("/usr/lib/bar.lib"),
+                Path::new("./x.obj"),
+                Path::new("foo.lib")
+            ]
+        );
+        assert_eq!(&*args.common.output, Path::new("a.exe"));
+    }
+
+    #[test]
+    fn bare_inputs_are_literal_paths() {
+        // rustc passes libraries with the `.lib` suffix already applied, so we never append one.
+        let args = parse_args(["foo", "foo.lib"]);
+
+        assert_eq!(input_paths(&args), [Path::new("foo"), Path::new("foo.lib")]);
+    }
+
+    #[test]
+    fn parses_full_rustc_style_link_line() {
+        let args = parse_args([
+            "/NOLOGO",
+            "/NXCOMPAT",
+            "/LIBPATH:C:\\lib",
+            "main.o",
+            "/OUT:main.exe",
+            "/DEBUG",
+            "/OPT:REF,NOICF",
+            "/SUBSYSTEM:CONSOLE",
+            "foo.lib",
+        ]);
+
+        assert_eq!(&*args.common.output, Path::new("main.exe"));
+        assert_eq!(args.subsystem, Some(Subsystem::Console));
+        assert_eq!(args.lib_search_path[0].as_ref(), Path::new("C:\\lib"));
+        assert_eq!(
+            input_paths(&args),
+            [Path::new("main.o"), Path::new("foo.lib")]
+        );
+        assert!(args.common.unrecognized_options.is_empty());
+        assert!(!args.is_dll);
+    }
+}

--- a/libwild/src/args/coff.rs
+++ b/libwild/src/args/coff.rs
@@ -1,10 +1,11 @@
+use crate::args::ArgumentParser;
 use crate::args::CommonArgs;
-use crate::args::Input;
-use crate::args::InputSpec;
 use crate::args::Modifiers;
+use crate::args::OptionSyntax;
 use crate::bail;
 use crate::error::Result;
 use crate::platform;
+use crate::platform::Args as _;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -122,130 +123,205 @@ impl platform::Args for CoffArgs {
         true
     }
 
-    fn is_ignored_flag(&self, _flag: &str) -> bool {
-        false
+    fn is_ignored_flag(&self, flag: &str) -> bool {
+        // `flag` has had its prefix stripped, but still carries any attached value and the case the
+        // user wrote, e.g. `WHOLEARCHIVE:foo.lib`.
+        let name = flag.split_once(':').map_or(flag, |(name, _value)| name);
+
+        IGNORED_FLAGS.contains(&name.to_ascii_lowercase().as_str())
     }
 }
 
 // Parse the supplied input arguments, which should not include the program name.
-pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(args: &mut CoffArgs, input: I) -> Result {
-    let tokens = input.map(|arg| arg.as_ref().to_owned()).collect::<Vec<_>>();
+pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(
+    args: &mut CoffArgs,
+    mut input: I,
+) -> Result {
+    let mut modifier_stack = vec![Modifiers::default()];
 
-    parse_tokens(args, tokens.iter().map(String::as_str))?;
+    let arg_parser = setup_argument_parser();
+    while let Some(arg) = input.next() {
+        let arg = arg.as_ref();
 
-    args.common.report_unrecognized()
+        arg_parser.handle_argument(args, &mut modifier_stack, arg, &mut input)?;
+    }
+
+    args.common.report_unrecognized()?;
+
+    Ok(())
 }
 
-/// Options that rustc's MSVC linker driver emits that we recognise but ignore, because they only
-/// affect outputs we don't produce yet or optimisations we don't implement.
-const IGNORED_OPTIONS: &[&str] = &[
-    // Debug info, PDB paths, import library, visualisers, module definition file and
-    // optimisations.
-    "debug",
+/// link.exe spells its options differently to the GNU-style linkers: names are case-insensitive,
+/// take either a `/` or a `-` prefix and carry their value as `NAME:value`, with no separate-token
+/// form.
+const COFF_OPTION_SYNTAX: OptionSyntax = OptionSyntax {
+    prefixes: &["/", "-"],
+    value_separator: ':',
+    case_insensitive: true,
+    allows_separate_value: false,
+};
+
+/// Options that rustc's MSVC linker driver emits that we ignore without comment, because they
+/// affect only outputs we don't produce yet, or because ignoring them already matches what we do.
+/// These appear on virtually every link line, so warning about them would be pure noise. The value,
+/// if any, is ignored too.
+const SILENTLY_IGNORED_FLAGS: &[&str] = &[
+    // PDB paths and debugger visualisers, which relate to debug info we don't emit.
     "pdb",
     "pdbaltpath",
-    "implib",
     "natvis",
-    "def",
+    // Optimisations we don't implement, e.g. `/OPT:REF,NOICF`.
     "opt",
-    // Control-flow guard, e.g. `/guard:cf`, and archive member handling.
-    "guard",
-    "wholearchive",
-    // Take an optional `:NO` value, e.g. `/NXCOMPAT:NO`.
-    "nxcompat",
-    "dynamicbase",
     // Manifest generation and warnings-as-errors, e.g. `/MANIFEST:EMBED`, `/MANIFESTUAC:NO`,
     // `/MANIFESTINPUT:foo.manifest`, `/WX:NO`.
     "manifest",
     "manifestinput",
     "manifestuac",
     "wx",
+    // Take an optional `:NO` value, e.g. `/NXCOMPAT:NO`. These request PE header bits that we
+    // don't emit yet, so ignoring them doesn't change the set of linked inputs.
+    "nxcompat",
+    "dynamicbase",
+];
+
+/// Options that we accept but that change either the output or the set of linked inputs when
+/// ignored, so we warn rather than silently dropping them. These deliberately aren't declared on
+/// the parser: leaving them undeclared routes them through the unrecognized-option fallback, which
+/// reports them via [`platform::Args::is_ignored_flag`] with the spelling the user wrote. That
+/// fallback passes the name with its value still attached, so `is_ignored_flag` splits it itself.
+const IGNORED_FLAGS: &[&str] = &[
+    // Control-flow guard, which we don't emit. `/DEBUG` is handled separately, since its `NONE`
+    // value requests exactly what we do.
+    "guard",
+    // An import library and a module definition file, which we don't produce.
+    "implib",
+    "def",
+    // Changes which archive members get linked, e.g. `/WHOLEARCHIVE:foo.lib`.
+    "wholearchive",
 ];
 
 /// Ignored options that take no value, so `/NOLOGO:x` is an error just like `/DLL:x` is.
-const IGNORED_NO_VALUE_OPTIONS: &[&str] = &["nologo"];
+const IGNORED_NO_VALUE_FLAGS: &[&str] = &["nologo"];
 
-/// MSVC options don't fit the GNU-style declarative parser used by the other platforms: names are
-/// case-insensitive, take either a `/` or a `-` prefix and carry their value as `NAME:value`.
-fn parse_tokens<'a, I: Iterator<Item = &'a str>>(args: &mut CoffArgs, input: I) -> Result {
-    for arg in input {
-        let Some(option) = arg.strip_prefix('/').or_else(|| arg.strip_prefix('-')) else {
-            add_input(args, arg);
-            continue;
-        };
+fn setup_argument_parser() -> ArgumentParser<CoffArgs> {
+    let mut parser = ArgumentParser::<CoffArgs>::with_syntax(COFF_OPTION_SYNTAX);
 
-        let (name, value) = option
-            .split_once(':')
-            .map_or((option, None), |(name, value)| (name, Some(value)));
+    parser
+        .declare_with_param()
+        .long("out")
+        .help("Set the output filename")
+        .execute(|args, _modifier_stack, value| {
+            args.common.output = Arc::from(Path::new(value));
+            Ok(())
+        });
 
-        match name.to_ascii_lowercase().as_str() {
-            "out" => {
-                let value = required_value("/OUT", value)?;
-                args.common.output = Arc::from(Path::new(value));
-            }
-            "entry" => {
-                args.entry = Some(required_value("/ENTRY", value)?.to_owned());
-            }
-            "subsystem" => {
-                let value = required_value("/SUBSYSTEM", value)?;
-                args.subsystem = Some(parse_subsystem(value)?);
-            }
-            "dll" => {
-                no_value("/DLL", value)?;
-                args.is_dll = true;
-            }
-            "machine" => {
-                let value = required_value("/MACHINE", value)?;
-                if !value.eq_ignore_ascii_case("x64") && !value.eq_ignore_ascii_case("amd64") {
-                    bail!("unsupported /MACHINE value `{value}`; only X64 is supported");
-                }
-                args.machine = CoffMachine::X86_64;
-            }
-            "libpath" => {
-                let value = required_value("/LIBPATH", value)?;
-                args.common.save_dir.handle_file(value);
-                args.lib_search_path.push(Box::from(Path::new(value)));
-            }
-            "defaultlib" => {
-                let value = required_value("/DEFAULTLIB", value)?;
-                args.default_libraries.push(value.to_owned());
-            }
-            // `/NODEFAULTLIB:lib` excludes one library, a bare `/NODEFAULTLIB` excludes all of
-            // them. Precedence over `/DEFAULTLIB` is applied when default libraries are resolved.
-            "nodefaultlib" => match value {
-                Some(value) if !value.is_empty() => {
-                    args.excluded_default_libraries.push(value.to_owned());
-                }
-                _ => args.no_default_libraries = true,
-            },
-            name if IGNORED_NO_VALUE_OPTIONS.contains(&name) => {
-                no_value(arg, value)?;
-            }
-            name if IGNORED_OPTIONS.contains(&name) => {}
-            // A prefixed token whose name isn't in the table above is an input only if that name
-            // looks like a path, since on Unix hosts absolute paths begin with `/` too.
-            _ if name.contains(['/', '\\']) => add_input(args, arg),
-            _ => args.common.unrecognized_options.push(arg.to_owned()),
-        }
-    }
+    parser
+        .declare_with_param()
+        .long("entry")
+        .help("Set the entry point symbol")
+        .execute(|args, _modifier_stack, value| {
+            args.entry = Some(value.to_owned());
+            Ok(())
+        });
 
-    Ok(())
+    parser
+        .declare_with_param()
+        .long("subsystem")
+        .help("Set the subsystem, optionally with a version")
+        .execute(|args, _modifier_stack, value| {
+            args.subsystem = Some(parse_subsystem(value)?);
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("dll")
+        .help("Build a DLL rather than an executable")
+        .execute(|args, _modifier_stack| {
+            args.is_dll = true;
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("machine")
+        .help("Set the target machine")
+        .execute(|args, _modifier_stack, value| {
+            if !value.eq_ignore_ascii_case("x64") && !value.eq_ignore_ascii_case("amd64") {
+                bail!("unsupported /MACHINE value `{value}`; only X64 is supported");
+            }
+            args.machine = CoffMachine::X86_64;
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("libpath")
+        .help("Add directory to library search path")
+        .execute(|args, _modifier_stack, value| {
+            args.common.save_dir.handle_file(value);
+            args.lib_search_path.push(Box::from(Path::new(value)));
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("defaultlib")
+        .help("Add a default library")
+        .execute(|args, _modifier_stack, value| {
+            args.default_libraries.push(value.to_owned());
+            Ok(())
+        });
+
+    // `/NODEFAULTLIB:lib` excludes one library, a bare `/NODEFAULTLIB` excludes all of them.
+    // Precedence over `/DEFAULTLIB` is applied when default libraries are resolved.
+    parser
+        .declare_with_optional_param()
+        .long("nodefaultlib")
+        .help("Ignore one default library, or all of them if no library is named")
+        .execute(|args, _modifier_stack, value| {
+            match value {
+                // An empty value is a malformed library name rather than a bare `/NODEFAULTLIB`.
+                Some("") => bail!("missing value for /NODEFAULTLIB"),
+                Some(value) => args.excluded_default_libraries.push(value.to_owned()),
+                None => args.no_default_libraries = true,
+            }
+            Ok(())
+        });
+
+    // `/DEBUG:NONE` asks for no debug info, which is what we produce, so only the forms that
+    // request a PDB warn.
+    parser
+        .declare_with_optional_param()
+        .long("debug")
+        .execute(|args, _modifier_stack, value| {
+            match value {
+                Some(value) if value.eq_ignore_ascii_case("none") => {}
+                Some(value) => args.warn_unsupported(&format!("/DEBUG:{value}"))?,
+                None => args.warn_unsupported("/DEBUG")?,
+            }
+            Ok(())
+        });
+
+    add_silently_ignored_flags(&mut parser);
+
+    parser
 }
 
-/// Returns the non-empty value attached to an option with `:`. link.exe has no separate-token form.
-fn required_value<'a>(option: &str, value: Option<&'a str>) -> Result<&'a str> {
-    match value {
-        Some(value) if !value.is_empty() => Ok(value),
-        _ => bail!("missing value for {option}"),
+fn add_silently_ignored_flags(parser: &mut ArgumentParser<CoffArgs>) {
+    for flag in SILENTLY_IGNORED_FLAGS {
+        parser
+            .declare_with_optional_param()
+            .long(flag)
+            .execute(|_args, _modifier_stack, _value| Ok(()));
     }
-}
 
-/// Rejects `NAME:value` for options that take no value.
-fn no_value(option: &str, value: Option<&str>) -> Result {
-    if value.is_some() {
-        bail!("{option} does not take a value");
+    for flag in IGNORED_NO_VALUE_FLAGS {
+        parser
+            .declare()
+            .long(flag)
+            .execute(|_args, _modifier_stack| Ok(()));
     }
-    Ok(())
 }
 
 /// Parses `/SUBSYSTEM:name[,major[.minor]]`. The version only sets optional-header fields we don't
@@ -276,15 +352,6 @@ fn parse_subsystem(value: &str) -> Result<Subsystem> {
     }
 }
 
-fn add_input(args: &mut CoffArgs, value: &str) {
-    args.common.save_dir.handle_file(value);
-    args.common.inputs.push(Input {
-        spec: InputSpec::File(Box::from(Path::new(value))),
-        search_first: None,
-        modifiers: Modifiers::default(),
-    });
-}
-
 #[cfg(test)]
 mod tests {
     use super::CoffArgs;
@@ -292,6 +359,8 @@ mod tests {
     use super::parse;
     use crate::args::InputSpec;
     use std::path::Path;
+    use std::sync::Arc;
+    use std::sync::Mutex;
 
     /// A link line of the shape that rustc emits when targeting `x86_64-pc-windows-msvc`.
     const RUSTC_LINK_LINE: &[&str] = &[
@@ -480,6 +549,14 @@ mod tests {
         assert!(args.excluded_default_libraries.is_empty());
     }
 
+    /// An empty value is a malformed library name, not the bare form, so link.exe rejects it.
+    #[test]
+    fn nodefaultlib_rejects_an_empty_value() {
+        let message = parse_error(["/NODEFAULTLIB:"]);
+
+        assert!(message.contains("missing value"), "{message}");
+    }
+
     #[test]
     fn unknown_options_are_an_error() {
         for arg in ["/FOO", "-FOO:bar"] {
@@ -503,25 +580,39 @@ mod tests {
         assert!(message.contains("/FOO"), "{message}");
     }
 
+    /// Parses `args`, returning the parsed arguments along with any warnings that were emitted.
+    fn parse_capturing_warnings<'a>(
+        args: impl IntoIterator<Item = &'a str>,
+    ) -> (CoffArgs, Vec<String>) {
+        let mut coff_args = CoffArgs::default();
+        let warnings = Arc::new(Mutex::new(Vec::new()));
+        let warnings_clone = warnings.clone();
+        coff_args.common.warning_callback = Box::new(move |warning| {
+            warnings_clone
+                .lock()
+                .unwrap()
+                .push(warning.warning().to_owned());
+        });
+
+        parse(&mut coff_args, args.into_iter()).unwrap();
+
+        let warnings = warnings.lock().unwrap().clone();
+        (coff_args, warnings)
+    }
+
     #[test]
-    fn rustc_ignored_options_are_accepted() {
+    fn rustc_silently_ignored_options_are_accepted() {
         let ignored = [
             "/NOLOGO",
-            "/DEBUG",
-            "/DEBUG:FULL",
+            "/DEBUG:NONE",
             "/NXCOMPAT",
             "/NXCOMPAT:NO",
+            "/DYNAMICBASE",
             "/DYNAMICBASE:NO",
             "/OPT:REF,NOICF",
             "/PDBALTPATH:%_PDB%",
             "/PDB:out.pdb",
-            "/IMPLIB:out.lib",
             "/NATVIS:types.natvis",
-            "/DEF:exports.def",
-            "/WHOLEARCHIVE",
-            "/WHOLEARCHIVE:foo.lib",
-            "/guard:cf",
-            "/DYNAMICBASE",
             "/MANIFEST",
             "/MANIFEST:EMBED",
             "/MANIFEST:NO",
@@ -532,11 +623,61 @@ mod tests {
         ];
 
         for arg in ignored {
-            let args = parse_args([arg, "main.obj"]);
+            let (args, warnings) = parse_capturing_warnings([arg, "main.obj"]);
 
             assert_eq!(input_paths(&args), [Path::new("main.obj")], "for {arg}");
             assert!(args.common.unrecognized_options.is_empty(), "for {arg}");
+            assert!(
+                warnings.is_empty(),
+                "unexpected warning for {arg}: {warnings:?}"
+            );
         }
+    }
+
+    #[test]
+    fn unsupported_options_warn() {
+        let unsupported = [
+            "/DEBUG",
+            "/DEBUG:FULL",
+            "/IMPLIB:out.lib",
+            "/DEF:exports.def",
+            "/WHOLEARCHIVE",
+            "/WHOLEARCHIVE:foo.lib",
+            "/guard:cf",
+        ];
+
+        for arg in unsupported {
+            let (args, warnings) = parse_capturing_warnings([arg, "main.obj"]);
+
+            assert_eq!(input_paths(&args), [Path::new("main.obj")], "for {arg}");
+            assert!(args.common.unrecognized_options.is_empty(), "for {arg}");
+            // These spellings are already canonical, so both warning paths agree on the text.
+            assert_eq!(
+                warnings,
+                [format!("{arg} is not yet supported")],
+                "for {arg}"
+            );
+        }
+    }
+
+    /// The two warning paths quote the option differently. Flags in `IGNORED_FLAGS` reach
+    /// `warn_unsupported` through the unrecognized-option fallback, which still has the whole
+    /// argument, so they echo the user's spelling. `/DEBUG` is declared, so its handler sees only
+    /// the value and has to rebuild the name in canonical form.
+    #[test]
+    fn warnings_quote_the_users_spelling_except_for_debug() {
+        let (_args, warnings) = parse_capturing_warnings(["/wholearchive:Foo.lib"]);
+        assert_eq!(warnings, ["/wholearchive:Foo.lib is not yet supported"]);
+
+        let (_args, warnings) = parse_capturing_warnings(["/debug:full"]);
+        assert_eq!(warnings, ["/DEBUG:full is not yet supported"]);
+    }
+
+    #[test]
+    fn unsupported_options_warn_with_a_dash_prefix() {
+        let (_args, warnings) = parse_capturing_warnings(["-WHOLEARCHIVE:foo.lib"]);
+
+        assert_eq!(warnings, ["-WHOLEARCHIVE:foo.lib is not yet supported"]);
     }
 
     #[test]
@@ -560,25 +701,27 @@ mod tests {
     }
 
     #[test]
-    fn path_shaped_tokens_are_inputs_not_options() {
-        let args = parse_args([
-            "/tmp/foo.obj",
-            "/usr/lib/bar.lib",
-            "./x.obj",
-            "foo.lib",
-            "/OUT:a.exe",
-        ]);
+    fn unprefixed_tokens_are_inputs() {
+        let args = parse_args(["./x.obj", "foo.lib", "sub\\dir\\y.obj", "/OUT:a.exe"]);
 
         assert_eq!(
             input_paths(&args),
             [
-                Path::new("/tmp/foo.obj"),
-                Path::new("/usr/lib/bar.lib"),
                 Path::new("./x.obj"),
-                Path::new("foo.lib")
+                Path::new("foo.lib"),
+                Path::new("sub\\dir\\y.obj")
             ]
         );
         assert_eq!(&*args.common.output, Path::new("a.exe"));
+    }
+
+    /// On Unix hosts, an absolute path starts with the same character as an option. link.exe has no
+    /// such ambiguity, so we treat these as options and report them as unrecognized.
+    #[test]
+    fn unix_absolute_paths_are_treated_as_options() {
+        let message = parse_error(["/tmp/foo.obj"]);
+
+        assert!(message.contains("unrecognized option(s)"), "{message}");
     }
 
     #[test]

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -265,6 +265,7 @@ impl<F: FileSystem> Linker<F> {
         }
 
         match args {
+            Args::Coff(_) => crate::bail!("PE/COFF (Windows) support is not yet implemented"),
             Args::Elf(elf_args) => crate::elf::link_for_arch(self, elf_args),
             Args::MachO(macho_args) => crate::macho::link_for_arch(self, macho_args),
             Args::Wasm(wasm_args) => crate::wasm::link_for_arch(self, wasm_args),


### PR DESCRIPTION
First step toward Windows PE/COFF support as discussed in #2320. This is argument parsing only, no linking yet (`Args::Coff` bails with "not yet implemented").

* Adds a `Coff` platform flavor, selected via `-flavor link` or a `link`/`lld-link` executable name.
* Parses the core link.exe style options: `/OUT`, `/ENTRY`, `/SUBSYSTEM`, `/DLL`, `/MACHINE` (X64 only), `/LIBPATH`, `/DEFAULTLIB` and `/NODEFAULTLIB`. Option names and values are case insensitive and accept either `/` or `-` prefixes, with values attached as `NAME:value`.
* The remaining options that rustc emits for `x86_64-pc-windows-msvc` (`/DEBUG`, `/OPT`, `/NXCOMPAT`, `/PDBALTPATH`, `/IMPLIB`, `/WHOLEARCHIVE`, `/NATVIS`, `/DEF`, `/guard` and so on) are recognised and currently ignored, so a real rustc link line parses cleanly. Anything else is reported through the shared `report_unrecognized()` path.
* MSVC options don't fit the declarative GNU style parser, so this uses a small hand rolled token loop. Happy to restructure if you'd prefer a different shape.
* I went with MSVC style first per the discussion in #2320. GNU style (MinGW) args can be added later.
* Not included yet: `@file` response files (rustc emits them on long link lines) and everything past parsing.

Tested beyond the unit tests by replaying real link invocations through the parser: a captured rustc hello world link line for `x86_64-pc-windows-msvc`, and the response files from four real release links (Rust std, ripgrep, rust-analyzer and uv, up to ~250 arguments) previously captured with lld-link's `/reproduce`. All of them parse cleanly and reach the intended "not yet implemented" bail, while injected bogus flags are still reported as unrecognized.
