### PR TITLE
port(MachO): drop unnecessary CodeSignature alignment

### DIFF
--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -183,8 +183,7 @@ pub(crate) const CS_SECTION_ALIGNMENT_EXP: u8 = 4;
 pub(crate) const CS_SECTION_ALIGNMENT: u64 = 2u64.pow(CS_SECTION_ALIGNMENT_EXP as u32);
 
 pub(crate) const CS_BLOB_HEADERS_SIZE: u64 =
-    (size_of::<macho::CsSuperBlob>() + size_of::<macho::CsBlobIndex>()).next_multiple_of(8) as u64;
-const _: () = assert!(CS_BLOB_HEADERS_SIZE.is_multiple_of(8));
+    (size_of::<macho::CsSuperBlob>() + size_of::<macho::CsBlobIndex>()) as u64;
 pub(crate) const CS_CODE_DIRECTORY_SIZE: u64 = (size_of::<macho::CsCodeDirectoryV0>()
     + size_of::<macho::CsCodeDirectoryV1>()
     + size_of::<macho::CsCodeDirectoryV2>()

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -1103,11 +1103,6 @@ fn write_code_signature_metadata(
     let mut rest: &mut [u8] = code_signature;
     encoder.signature_super_blob(&mut rest, code_signature_section.file_size as u32, 1);
     encoder.blob_index(&mut rest, CSSLOT_CODEDIRECTORY, CS_BLOB_HEADERS_SIZE as u32);
-    let padding_size = CS_BLOB_HEADERS_SIZE as usize
-        - encoder.super_blob_size() as usize
-        - encoder.blob_index_size() as usize;
-    let (padding, mut rest) = rest.split_at_mut(padding_size);
-    padding.zero();
     encoder.code_directory(&mut rest, &code_directory);
 
     let (identifier, hashes) = rest.split_at_mut(padded_identifier_size);


### PR DESCRIPTION
As mentioned in https://github.com/wild-linker/wild/pull/2369#discussion_r3742895580, we don't actually need the currently used extra alignment.

CC: @philipc

Issue: #757