### PR TITLE
port(wasm): Support `--export-memory`

### DIFF
--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -27,11 +27,15 @@ pub(crate) const DEFAULT_STACK_SIZE: u32 = 64 * 1024;
 /// Default entry symbol for Wasm command modules.
 pub(crate) const DEFAULT_ENTRY: &str = "_start";
 
+/// Default export name for the module's linear memory.
+pub(crate) const DEFAULT_MEMORY_EXPORT_NAME: &str = "memory";
+
 #[derive(Debug)]
 pub struct WasmArgs {
     pub(crate) common: super::CommonArgs,
     pub(crate) lib_search_path: Vec<Box<Path>>,
     pub(crate) export_symbols: Vec<String>,
+    pub(crate) export_memory: Option<String>,
     pub(crate) z_stack_size: u32,
     // Since LLVM 22, the default option is true.
     pub(crate) stack_first: bool,
@@ -50,6 +54,12 @@ impl WasmArgs {
             ..Default::default()
         })
     }
+
+    pub(crate) fn memory_export_name(&self) -> &str {
+        self.export_memory
+            .as_deref()
+            .unwrap_or(DEFAULT_MEMORY_EXPORT_NAME)
+    }
 }
 
 impl Default for WasmArgs {
@@ -62,6 +72,7 @@ impl Default for WasmArgs {
             stack_first: true,
             entry: Some(DEFAULT_ENTRY.to_owned()),
             initial_memory: None,
+            export_memory: None,
             gc_sections: true,
         }
     }
@@ -228,6 +239,15 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
         .help("Force a symbol to be exported")
         .execute(|args, _modifier_stack, value| {
             args.export_symbols.push(value.to_owned());
+            Ok(())
+        });
+
+    parser
+        .declare_with_optional_param()
+        .long("export-memory")
+        .help("Export the module's memory (default name \"memory\")")
+        .execute(|args, _modifier_stack, value| {
+            args.export_memory = Some(value.unwrap_or(DEFAULT_MEMORY_EXPORT_NAME).to_owned());
             Ok(())
         });
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -5148,15 +5148,7 @@ fn linker_output_memory_type(inputs: &[WasmObjectLayoutInput<'_>]) -> MemoryType
 }
 
 fn ensure_memory_export<'data>(exports: &mut Vec<OutputExport<'data>>, name: &'data str) {
-    if let Some(existing) = exports
-        .iter_mut()
-        .find(|export| matches!(export.kind, wasmparser::ExternalKind::Memory))
-    {
-        // Honour an explicit/custom export name even if an input already exported memory.
-        existing.name = name;
-        existing.index = 0;
-        return;
-    }
+    exports.retain(|export| !matches!(export.kind, wasmparser::ExternalKind::Memory));
     exports.push(OutputExport {
         name,
         kind: wasmparser::ExternalKind::Memory,

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -5147,15 +5147,18 @@ fn linker_output_memory_type(inputs: &[WasmObjectLayoutInput<'_>]) -> MemoryType
     }
 }
 
-fn ensure_memory_export(exports: &mut Vec<OutputExport<'_>>) {
-    if exports
-        .iter()
-        .any(|export| matches!(export.kind, wasmparser::ExternalKind::Memory))
+fn ensure_memory_export<'data>(exports: &mut Vec<OutputExport<'data>>, name: &'data str) {
+    if let Some(existing) = exports
+        .iter_mut()
+        .find(|export| matches!(export.kind, wasmparser::ExternalKind::Memory))
     {
+        // Honour an explicit/custom export name even if an input already exported memory.
+        existing.name = name;
+        existing.index = 0;
         return;
     }
     exports.push(OutputExport {
-        name: "memory",
+        name,
         kind: wasmparser::ExternalKind::Memory,
         index: 0,
     });
@@ -5536,7 +5539,9 @@ where
             layout
                 .memories
                 .push(linker_output_memory_type(&layout_inputs));
-            ensure_memory_export(&mut layout.exports);
+        }
+        if !layout.memories.is_empty() {
+            ensure_memory_export(&mut layout.exports, symbol_db.args.memory_export_name());
         }
         layout.data_end = memory_cursor;
         let initial_pages =

--- a/wild/tests/sources/wasm/export-memory-input/export-memory-input.wat
+++ b/wild/tests/sources/wasm/export-memory-input/export-memory-input.wat
@@ -1,0 +1,53 @@
+;;#Config:diff-name-default
+;;#Object:mem-diff-name.wat
+;;#ExpectSym: memory
+;;#ExpectSym: _start
+;;#NoSym: from_input
+
+;;#Config:diff-name-custom
+;;#Object:mem-diff-name.wat
+;;#LinkArgs: --export-memory=foo
+;;#ExpectSym: foo
+;;#ExpectSym: _start
+;;#NoSym: from_input
+;;#NoSym: memory
+
+;;#Config:same-name-default
+;;#Object:mem-same-name.wat
+;;#ExpectSym: memory
+;;#ExpectSym: _start
+
+;;#Config:same-name-custom
+;;#Object:mem-same-name.wat
+;;#LinkArgs: --export-memory=foo
+;;#ExpectSym: foo
+;;#ExpectSym: _start
+;;#NoSym: memory
+
+;;#Config:same-name-explicit-flag
+;;#Object:mem-same-name.wat
+;;#LinkArgs: --export-memory
+;;#ExpectSym: memory
+;;#ExpectSym: _start
+
+;;#Config:multi-default
+;;#Object:mem-multi-name.wat
+;;#ExpectSym: memory
+;;#ExpectSym: _start
+;;#NoSym: a
+;;#NoSym: b
+
+;;#Config:multi-custom
+;;#Object:mem-multi-name.wat
+;;#LinkArgs: --export-memory=foo
+;;#ExpectSym: foo
+;;#ExpectSym: _start
+;;#NoSym: a
+;;#NoSym: b
+;;#NoSym: memory
+
+(module
+  (func $start (export "_start")
+    nop
+  )
+)

--- a/wild/tests/sources/wasm/export-memory-input/mem-diff-name.wat
+++ b/wild/tests/sources/wasm/export-memory-input/mem-diff-name.wat
@@ -1,0 +1,3 @@
+(module
+  (memory (export "from_input") 1)
+)

--- a/wild/tests/sources/wasm/export-memory-input/mem-multi-name.wat
+++ b/wild/tests/sources/wasm/export-memory-input/mem-multi-name.wat
@@ -1,0 +1,5 @@
+(module
+  (memory 1)
+  (export "a" (memory 0))
+  (export "b" (memory 0))
+)

--- a/wild/tests/sources/wasm/export-memory-input/mem-same-name.wat
+++ b/wild/tests/sources/wasm/export-memory-input/mem-same-name.wat
@@ -1,0 +1,3 @@
+(module
+  (memory (export "memory") 1)
+)

--- a/wild/tests/sources/wasm/export-memory/export-memory.c
+++ b/wild/tests/sources/wasm/export-memory/export-memory.c
@@ -1,0 +1,16 @@
+//#Config:no-option
+//#ExpectSym: memory
+//#ExpectSym: _start
+
+//#Config:default-value
+//#LinkArgs: --export-memory
+//#ExpectSym: memory
+//#ExpectSym: _start
+
+//#Config:custom-name
+//#LinkArgs: --export-memory=foo
+//#ExpectSym: foo
+//#ExpectSym: _start
+//#NoSym: memory
+
+void _start(void) {}


### PR DESCRIPTION
This option defaults to exporting "memory" in wasm-ld:

```
（▰╹◡╹）❯  wasm-ld --help | rg export-memory
  --export-memory=<value> Export the module's memory with the passed name
  --export-memory         Export the module's memory with the default name of "memory"
```

Part of #1431