### PR TITLE
port(MachO): Add support for arbitrary segments

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -2354,6 +2354,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
         prelude: &mut layout::PreludeLayoutState<'data, Self>,
         sizes: &mut OutputSectionPartMap<u64>,
         header_info: &layout::HeaderInfo,
+        _program_segments: &ProgramSegments<Self::ProgramSegmentDef>,
         output_sections: &OutputSections<Self>,
         _resources: &layout::FinaliseSizesResources<'data, '_, Self>,
         _args: &Self::Args,
@@ -2439,6 +2440,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
         location_counters: &[crate::layout_rules::LocationCounter<'data>],
     ) -> (OutputOrder<'data>, ProgramSegments<Self::ProgramSegmentDef>) {
         let mut builder = OutputOrderBuilder::<Self>::new(
+            Self::program_segment_defs().to_vec(),
             output_kind,
             output_sections,
             secondary,
@@ -2515,6 +2517,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
         location_counters: &[crate::layout_rules::LocationCounter<'data>],
     ) -> Result<(OutputOrder<'data>, ProgramSegments<Self::ProgramSegmentDef>)> {
         let mut builder = OutputOrderBuilder::<Self>::new(
+            Self::program_segment_defs().to_vec(),
             output_kind,
             output_sections,
             secondary,

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3496,6 +3496,7 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
             self,
             extra_sizes,
             &header_info,
+            program_segments,
             output_sections,
             resources,
             resources.symbol_db.args,

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -22,7 +22,13 @@ use crate::layout::SymbolCopyInfo;
 use crate::layout::SymbolResolutions;
 use crate::layout_rules::SectionKind;
 use crate::layout_rules::SectionRule;
+use crate::macho::output_section_id::CHAINED_FIXUP_TABLE;
+use crate::macho::output_section_id::CODE_SIGNATURE;
+use crate::macho::output_section_id::LOAD_COMMANDS;
+use crate::macho::output_section_id::STRTAB;
+use crate::macho::output_section_id::SYMTAB_GLOBAL;
 use crate::macho_writer;
+use crate::output_section_id::FILE_HEADER;
 use crate::output_section_id::OrderEvent;
 use crate::output_section_id::OutputOrderBuilder;
 use crate::output_section_id::OutputSectionId;
@@ -34,6 +40,8 @@ use crate::part_id::PartId;
 use crate::platform;
 use crate::platform::Args;
 use crate::platform::ObjectFile;
+use crate::program_segments::ProgramSegmentId;
+use crate::program_segments::ProgramSegments;
 use crate::resolution;
 use crate::symbol_db::SymbolId;
 use crate::symbol_db::Visibility;
@@ -157,8 +165,6 @@ pub(crate) const CHAINED_FIXUP_PAGE_START_SIZE: u64 = size_of::<u16>() as u64;
 pub(crate) const GOT_ENTRY_SIZE: u64 = 8;
 pub(crate) const PLT_ENTRY_SIZE: u64 = 12;
 
-pub(crate) const SEG_DATA_CONST: &str = "__DATA_CONST";
-
 type SectionHeader = Section64<crate::macho::Endianness>;
 type SectionTable<'data> = &'data [Section64<crate::macho::Endianness>];
 type SymbolTable<'data> = object::read::macho::SymbolTable<'data, macho::MachHeader64<Endianness>>;
@@ -214,9 +220,16 @@ pub(crate) fn load_dylib_command_size(path: &[u8]) -> usize {
 pub(crate) struct SegmentName([u8; 16]);
 
 impl SegmentName {
-    const TEXT: Self = Self::from_bytes(b"__TEXT");
-    const DATA: Self = Self::from_bytes(b"__DATA");
-    const DATA_CONST: Self = Self::from_bytes(b"__DATA_CONST");
+    pub(crate) const PAGEZERO: Self = Self::from_bytes(b"__PAGEZERO");
+    pub(crate) const TEXT: Self = Self::from_bytes(b"__TEXT");
+    pub(crate) const DATA: Self = Self::from_bytes(b"__DATA");
+    pub(crate) const DATA_CONST: Self = Self::from_bytes(b"__DATA_CONST");
+    pub(crate) const LINKEDIT: Self = Self::from_bytes(b"__LINKEDIT");
+    pub(crate) const LLVM: Self = Self::from_bytes(b"__LLVM");
+
+    pub(crate) const fn into_bytes(self) -> [u8; 16] {
+        self.0
+    }
 
     const fn from_bytes(name: &[u8]) -> Self {
         assert!(name.len() <= 16);
@@ -226,7 +239,14 @@ impl SegmentName {
     }
 
     fn is_writable(self) -> bool {
-        matches!(self, Self::DATA | Self::DATA_CONST)
+        !matches!(self, Self::PAGEZERO | Self::TEXT | Self::LINKEDIT)
+    }
+}
+
+impl std::fmt::Display for SegmentName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = String::from_utf8_lossy(&self.0);
+        write!(f, "{}", name.trim_end_matches('\0'))
     }
 }
 
@@ -582,19 +602,21 @@ impl platform::SectionHeader for SectionHeader {
     }
 
     fn should_exclude(&self) -> bool {
-        // TODO: We only support these fixed segments for now. We also need support for sections
-        // backed by the Mach-O indirect symbol table for dynamic linking.
-        !matches!(
-            SegmentName::from_bytes(self.segment_name()),
-            SegmentName::DATA | SegmentName::DATA_CONST | SegmentName::TEXT
-        ) || matches!(
-            self.flags.get(LE).typ(),
-            macho::S_NON_LAZY_SYMBOL_POINTERS
-                | macho::S_LAZY_SYMBOL_POINTERS
-                | macho::S_SYMBOL_STUBS
-                | macho::S_LAZY_DYLIB_SYMBOL_POINTERS
-                | macho::S_THREAD_LOCAL_VARIABLE_POINTERS
-        )
+        // TODO: We need support for sections backed by the Mach-O indirect symbol table for dynamic
+        // linking.
+        self.flags.get(LE).intersects(macho::S_ATTR_DEBUG)
+            || matches!(
+                SegmentName::from_bytes(self.segment_name()),
+                SegmentName::PAGEZERO | SegmentName::LINKEDIT | SegmentName::LLVM
+            )
+            || matches!(
+                self.flags.get(LE).typ(),
+                macho::S_NON_LAZY_SYMBOL_POINTERS
+                    | macho::S_LAZY_SYMBOL_POINTERS
+                    | macho::S_SYMBOL_STUBS
+                    | macho::S_LAZY_DYLIB_SYMBOL_POINTERS
+                    | macho::S_THREAD_LOCAL_VARIABLE_POINTERS
+            )
     }
 
     fn is_group(&self) -> bool {
@@ -818,52 +840,56 @@ impl platform::NonAddressableIndexes for NonAddressableIndexes {
     }
 }
 
-// TODO: update comment
+impl platform::SegmentType for () {}
 
-#[derive(Debug, Copy, Clone, Default, PartialEq)]
-pub(crate) enum SegmentType {
-    Text,
-    LoadCommands,
-    TextSections,
-    DataSections,
-    DataConstSections,
-    LinkeditSections,
-    // The other ELF-specific (or unused) parts/sections will be collected here.
-    #[default]
-    Unused,
+/// Represents an actual segment.
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct ProgramSegmentDef {
+    // TODO: When we implement -segprot, we should support both initprot and maxprot here.
+    pub(crate) name: SegmentName,
+    pub(crate) prot: macho::VmProt,
+    pub(crate) flags: macho::SegmentFlags,
 }
 
-impl platform::SegmentType for SegmentType {}
+impl ProgramSegmentDef {
+    fn new(name: SegmentName) -> Self {
+        let (prot, flags) = match name {
+            SegmentName::TEXT => (
+                macho::VM_PROT_READ | macho::VM_PROT_EXECUTE,
+                macho::SegmentFlags::default(),
+            ),
+            SegmentName::DATA_CONST => (
+                macho::VM_PROT_READ | macho::VM_PROT_WRITE,
+                macho::SG_READ_ONLY,
+            ),
+            SegmentName::LINKEDIT => (macho::VM_PROT_READ, macho::SegmentFlags::default()),
+            _ => (
+                macho::VM_PROT_READ | macho::VM_PROT_WRITE,
+                macho::SegmentFlags::default(),
+            ),
+        };
 
-#[derive(Debug, Copy, Clone, Default, PartialEq)]
-pub(crate) struct ProgramSegmentDef {
-    pub(crate) segment_type: SegmentType,
-    pub(crate) count_as_segment: bool,
+        Self { name, prot, flags }
+    }
 }
 
 impl std::fmt::Display for ProgramSegmentDef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.segment_type)
+        std::fmt::Display::fmt(&self.name, f)
     }
 }
 
 impl platform::ProgramSegmentDef for ProgramSegmentDef {
     fn is_writable(self) -> bool {
-        false
+        self.prot.contains(macho::VM_PROT_WRITE)
     }
 
     fn is_executable(self) -> bool {
-        false
+        self.prot.contains(macho::VM_PROT_EXECUTE)
     }
 
     fn always_keep(self) -> bool {
-        matches!(
-            self.segment_type,
-            SegmentType::Text
-                | SegmentType::LoadCommands
-                | SegmentType::TextSections
-                | SegmentType::LinkeditSections
-        )
+        matches!(self.name, SegmentName::TEXT | SegmentName::LINKEDIT)
     }
 
     fn is_loadable(self) -> bool {
@@ -879,7 +905,13 @@ impl platform::ProgramSegmentDef for ProgramSegmentDef {
     }
 
     fn order_key(self) -> usize {
-        self.segment_type as usize
+        match self.name {
+            SegmentName::TEXT => 0,
+            SegmentName::DATA_CONST => 1,
+            SegmentName::DATA => 2,
+            SegmentName::LINKEDIT => 4,
+            _ => 3,
+        }
     }
 }
 
@@ -991,7 +1023,7 @@ impl platform::Platform for MachO {
     type SectionFlags = SectionFlags;
     type SectionAttributes = SectionAttributes;
     type SectionType = macho::SectionType;
-    type SegmentType = SegmentType;
+    type SegmentType = ();
     type ProgramSegmentDef = ProgramSegmentDef;
     type BuiltInSectionDetails = BuiltInSectionDetails;
     type RelocationSections = ();
@@ -1026,8 +1058,11 @@ impl platform::Platform for MachO {
     type VersionNames<'data> = ();
     type VerneedTable<'data> = VerneedTable<'data>;
     type ResolvedObjectExt<'data> = ();
-    type SectionIdentityExt = Option<SegmentName>;
     type GcUnit = crate::layout::SectionGcUnit;
+
+    /// Mach-O sections are associated with a SegmentName, while synthetic regions (FILE_HEADER,
+    /// LOAD_COMMANDS, etc.) are not.
+    type SectionIdentityExt = Option<SegmentName>;
 
     const HAS_NULL_SYMBOL_ENTRY: bool = true;
 
@@ -1225,7 +1260,7 @@ impl platform::Platform for MachO {
     }
 
     fn program_segment_defs() -> &'static [Self::ProgramSegmentDef] {
-        PROGRAM_SEGMENT_DEFS
+        &[]
     }
 
     fn unconditional_segment_defs() -> &'static [Self::ProgramSegmentDef] {
@@ -1238,28 +1273,15 @@ impl platform::Platform for MachO {
         section_id: crate::output_section_id::OutputSectionId,
         _rosegment: bool,
     ) -> bool {
-        let mapped_segment = match (section_id, section_info.kind) {
-            (crate::output_section_id::FILE_HEADER, _) => SegmentType::Text,
-            (output_section_id::LOAD_COMMANDS, _) => SegmentType::LoadCommands,
-            (
-                output_section_id::CHAINED_FIXUP_TABLE
-                | output_section_id::SYMTAB_GLOBAL
-                | output_section_id::STRTAB
-                | output_section_id::CODE_SIGNATURE,
-                _,
-            ) => SegmentType::LinkeditSections,
-            (_, SectionKind::Primary(identity)) => match identity.format_specific() {
-                Some(SegmentName::TEXT) => SegmentType::TextSections,
-                Some(SegmentName::DATA) => SegmentType::DataSections,
-                Some(SegmentName::DATA_CONST) => SegmentType::DataConstSections,
-                _ => SegmentType::Unused,
-            },
-            (_, _) => SegmentType::Unused,
-        };
-
-        match (segment_def.segment_type, mapped_segment) {
-            (SegmentType::Text, SegmentType::LoadCommands | SegmentType::TextSections) => true,
-            _ => segment_def.segment_type == mapped_segment,
+        match (section_id, section_info.kind) {
+            (FILE_HEADER | LOAD_COMMANDS, _) => segment_def.name == SegmentName::TEXT,
+            (STRTAB | CHAINED_FIXUP_TABLE | SYMTAB_GLOBAL | CODE_SIGNATURE, _) => {
+                segment_def.name == SegmentName::LINKEDIT
+            }
+            (_, SectionKind::Primary(identity)) => {
+                identity.format_specific() == Some(segment_def.name)
+            }
+            (_, SectionKind::Secondary(_)) => false,
         }
     }
 
@@ -1496,7 +1518,8 @@ impl platform::Platform for MachO {
     fn allocate_header_sizes<'data>(
         prelude: &mut crate::layout::PreludeLayoutState<'data, Self>,
         sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
-        _header_info: &crate::layout::HeaderInfo,
+        header_info: &crate::layout::HeaderInfo,
+        program_segments: &ProgramSegments<Self::ProgramSegmentDef>,
         output_sections: &crate::output_section_id::OutputSections<Self>,
         resources: &layout::FinaliseSizesResources<'data, '_, Self>,
         args: &Self::Args,
@@ -1508,21 +1531,18 @@ impl platform::Platform for MachO {
             prelude.format_specific.load_command_count += 1;
         };
 
+        // Separately emitted __PAGEZERO.
         allocate_load_cmd(size_of::<SegmentCommand>());
-        allocate_load_cmd(
-            size_of::<SegmentCommand>()
-                + size_of::<SectionEntry>()
-                    * count_sections_for_segment_type(output_sections, SegmentType::TextSections),
-        );
 
-        for segment_type in [SegmentType::DataSections, SegmentType::DataConstSections] {
-            let count = count_sections_for_segment_type(output_sections, segment_type);
-            if count > 0 {
-                allocate_load_cmd(size_of::<SegmentCommand>() + size_of::<SectionEntry>() * count);
-            }
+        for &segment_id in &header_info.active_segment_ids {
+            let segment = program_segments.segment_def(segment_id);
+            allocate_load_cmd(
+                size_of::<SegmentCommand>()
+                    + size_of::<SectionEntry>()
+                        * count_sections_for_segment(output_sections, *segment),
+            );
         }
 
-        allocate_load_cmd(size_of::<SegmentCommand>());
         if resources.symbol_db.output_kind.is_executable() {
             allocate_load_cmd(size_of::<EntryPointCommand>());
         }
@@ -1721,8 +1741,44 @@ impl platform::Platform for MachO {
         crate::program_segments::ProgramSegments<Self::ProgramSegmentDef>,
     ) {
         // TODO: Order sections within each segment according to Mach-O conventions.
-        let mut builder =
-            OutputOrderBuilder::<Self>::new(output_kind, output_sections, secondary, false, &[]);
+        let arbitrary_segments: Vec<SegmentName> = output_sections
+            .ids_with_info()
+            .filter_map(|(_, info)| match info.kind {
+                SectionKind::Primary(identity) => identity.format_specific(),
+                SectionKind::Secondary(_) => None,
+            })
+            .filter(|name| {
+                !matches!(
+                    *name,
+                    SegmentName::PAGEZERO
+                        | SegmentName::TEXT
+                        | SegmentName::DATA_CONST
+                        | SegmentName::DATA
+                        | SegmentName::LINKEDIT
+                )
+            })
+            .unique()
+            .collect();
+
+        let segment_defs = [
+            SegmentName::TEXT,
+            SegmentName::DATA_CONST,
+            SegmentName::DATA,
+        ]
+        .into_iter()
+        .chain(arbitrary_segments.iter().copied())
+        .chain([SegmentName::LINKEDIT])
+        .map(ProgramSegmentDef::new)
+        .collect();
+
+        let mut builder = OutputOrderBuilder::<Self>::new(
+            segment_defs,
+            output_kind,
+            output_sections,
+            secondary,
+            false,
+            &[],
+        );
 
         // File header and all load commands.
         builder.add_section(crate::output_section_id::FILE_HEADER);
@@ -1737,55 +1793,25 @@ impl platform::Platform for MachO {
         );
 
         builder.add_section(output_section_id::PLT_GOT);
-
         add_sections_in_segment(&mut builder, output_sections, &custom.ro, SegmentName::TEXT);
-
-        add_sections_in_segment(
-            &mut builder,
-            output_sections,
-            &custom.exec,
-            SegmentName::DATA,
-        );
-        add_sections_in_segment(&mut builder, output_sections, &custom.ro, SegmentName::DATA);
-        add_sections_in_segment(
-            &mut builder,
-            output_sections,
-            &custom.data,
-            SegmentName::DATA,
-        );
-        add_sections_in_segment(
-            &mut builder,
-            output_sections,
-            &custom.bss,
-            SegmentName::DATA,
-        );
-
         builder.add_section(output_section_id::GOT);
 
-        add_sections_in_segment(
-            &mut builder,
-            output_sections,
-            &custom.exec,
-            SegmentName::DATA_CONST,
-        );
-        add_sections_in_segment(
-            &mut builder,
-            output_sections,
-            &custom.ro,
-            SegmentName::DATA_CONST,
-        );
-        add_sections_in_segment(
-            &mut builder,
-            output_sections,
-            &custom.data,
-            SegmentName::DATA_CONST,
-        );
-        add_sections_in_segment(
-            &mut builder,
-            output_sections,
-            &custom.bss,
-            SegmentName::DATA_CONST,
-        );
+        for segment in [SegmentName::DATA_CONST, SegmentName::DATA] {
+            add_sections_in_segment(&mut builder, output_sections, &custom.exec, segment);
+            add_sections_in_segment(&mut builder, output_sections, &custom.ro, segment);
+            add_sections_in_segment(&mut builder, output_sections, &custom.data, segment);
+            add_sections_in_segment(&mut builder, output_sections, &custom.bss, segment);
+        }
+
+        // Arbitrary segment sections are added in first-seen order.
+        for segment in arbitrary_segments {
+            for (section_id, info) in output_sections.ids_with_info() {
+                if matches!(info.kind, SectionKind::Primary(identity) if identity.format_specific() == Some(segment))
+                {
+                    builder.add_section(section_id);
+                }
+            }
+        }
 
         // The rest (e.g. symbol table, string table).
         builder.add_section(output_section_id::STRTAB);
@@ -1797,21 +1823,13 @@ impl platform::Platform for MachO {
     }
 
     fn align_load_segment_start(
-        segment_def: ProgramSegmentDef,
+        _segment_def: ProgramSegmentDef,
         segment_alignment: Alignment,
         file_offset: &mut usize,
         mem_offset: &mut u64,
     ) {
-        match segment_def.segment_type {
-            SegmentType::Text
-            | SegmentType::DataSections
-            | SegmentType::DataConstSections
-            | SegmentType::LinkeditSections => {
-                *file_offset = segment_alignment.align_up(*file_offset as u64) as usize;
-                *mem_offset = segment_alignment.align_up(*mem_offset);
-            }
-            _ => {}
-        }
+        *file_offset = segment_alignment.align_up(*file_offset as u64) as usize;
+        *mem_offset = segment_alignment.align_up(*mem_offset);
     }
 
     fn default_symtab_entry() -> Self::SymtabEntry {
@@ -1855,11 +1873,7 @@ impl platform::Platform for MachO {
         f: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
         match segment_name {
-            Some(segment_name) => {
-                let segment_name = String::from_utf8_lossy(&segment_name.0);
-                let segment_name = segment_name.trim_end_matches('\0');
-                write!(f, "{segment_name},{section_name}")
-            }
+            Some(segment_name) => write!(f, "{segment_name},{section_name}"),
             None => write!(f, "{section_name}"),
         }
     }
@@ -2003,89 +2017,62 @@ const DEFAULT_SECTION_RULES: &[SectionRule<'static>] = &[
     // TODO: Add a Mach-O output section ID and rule for `__compact_unwind`.
 ];
 
-pub(crate) const PROGRAM_SEGMENT_DEFS: &[ProgramSegmentDef] = &[
-    ProgramSegmentDef {
-        segment_type: SegmentType::Text,
-        // Not a real segment from the Macho-O definition.
-        count_as_segment: true,
-    },
-    ProgramSegmentDef {
-        // Not a real segment from the Macho-O definition.
-        segment_type: SegmentType::LoadCommands,
-        // included in SegmentType::Text
-        count_as_segment: false,
-    },
-    ProgramSegmentDef {
-        segment_type: SegmentType::TextSections,
-        // included in SegmentType::Text
-        count_as_segment: false,
-    },
-    ProgramSegmentDef {
-        segment_type: SegmentType::DataSections,
-        count_as_segment: true,
-    },
-    ProgramSegmentDef {
-        segment_type: SegmentType::DataConstSections,
-        count_as_segment: true,
-    },
-    ProgramSegmentDef {
-        segment_type: SegmentType::LinkeditSections,
-        count_as_segment: true,
-    },
-];
+fn section_header_name_for_segment<'data>(
+    output_sections: &crate::output_section_id::OutputSections<'data, MachO>,
+    section_id: OutputSectionId,
+    segment_def: ProgramSegmentDef,
+) -> Option<SectionName<'data>> {
+    if !output_sections.will_emit_section(section_id) {
+        return None;
+    }
 
-fn count_sections_for_segment_type(
+    output_sections
+        .identity(section_id)
+        .filter(|identity| identity.format_specific().is_some())
+        .filter(|_| output_sections.should_include_in_segment(section_id, segment_def))
+        .map(|identity| identity.section_name())
+}
+
+fn count_sections_for_segment(
     output_sections: &crate::output_section_id::OutputSections<MachO>,
-    segment_type: SegmentType,
+    segment_def: ProgramSegmentDef,
 ) -> usize {
-    let segment_def = ProgramSegmentDef {
-        segment_type,
-        count_as_segment: false,
-    };
     output_sections
         .ids_with_info()
         .filter(|(section_id, _)| {
-            output_sections.will_emit_section(*section_id)
-                && output_sections.should_include_in_segment(*section_id, segment_def)
+            section_header_name_for_segment(output_sections, *section_id, segment_def).is_some()
         })
         .count()
 }
 
-pub(crate) struct SegmentSectionsInfo<'data> {
-    pub(crate) segment_size: OutputRecordLayout,
-    pub(crate) segment_sections:
-        Vec<(OutputRecordLayout, Option<SectionName<'data>>, SectionFlags)>,
-}
-
 pub(crate) fn get_segment_sections<'data>(
     layout: &Layout<'data, MachO>,
-    segment_type: SegmentType,
-) -> Option<SegmentSectionsInfo<'data>> {
+    segment_id: ProgramSegmentId,
+) -> Vec<(OutputRecordLayout, SectionName<'data>, SectionFlags)> {
     let mut in_matching_segment = false;
-    let mut sections = Vec::new();
-    let mut segment_id = None;
+    let mut segment_sections = Vec::new();
+    let segment_def = *layout.program_segments.segment_def(segment_id);
 
     for event in &layout.output_order {
         match event {
-            OrderEvent::SegmentStart(seg_id)
-                if layout.program_segments.segment_def(seg_id).segment_type == segment_type =>
-            {
-                segment_id = Some(seg_id);
+            OrderEvent::SegmentStart(seg_id) if seg_id == segment_id => {
                 in_matching_segment = true;
             }
-            OrderEvent::SegmentEnd(seg_id)
-                if layout.program_segments.segment_def(seg_id).segment_type == segment_type
-                    && in_matching_segment =>
-            {
+            OrderEvent::SegmentEnd(seg_id) if seg_id == segment_id && in_matching_segment => {
                 break;
             }
-            OrderEvent::Section(section_id)
-                if in_matching_segment && layout.output_sections.will_emit_section(section_id) =>
-            {
-                let sizes = *layout.section_layouts.get(section_id);
-                sections.push((
-                    sizes,
-                    layout.output_sections.name(section_id),
+            OrderEvent::Section(section_id) if in_matching_segment => {
+                let Some(section_name) = section_header_name_for_segment(
+                    &layout.output_sections,
+                    section_id,
+                    segment_def,
+                ) else {
+                    continue;
+                };
+
+                segment_sections.push((
+                    *layout.merged_section_layouts.get(section_id),
+                    section_name,
                     layout.output_sections.section_flags(section_id),
                 ));
             }
@@ -2093,18 +2080,7 @@ pub(crate) fn get_segment_sections<'data>(
         }
     }
 
-    let segment_id = segment_id?;
-    let segment_size = layout
-        .segment_layouts
-        .segments
-        .iter()
-        .find(|seg| seg.id == segment_id)
-        .map(|seg| seg.sizes);
-
-    segment_size.map(|segment_size| SegmentSectionsInfo {
-        segment_sections: sections,
-        segment_size,
-    })
+    segment_sections
 }
 
 fn add_sections_in_segment<'data>(

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -42,11 +42,9 @@ use crate::macho::MACHO_START_MEM_ADDRESS;
 use crate::macho::MAX_SEGMENT_COUNT;
 use crate::macho::MachO;
 use crate::macho::PLT_ENTRY_SIZE;
-use crate::macho::PROGRAM_SEGMENT_DEFS;
-use crate::macho::SEG_DATA_CONST;
 use crate::macho::SectionEntry;
 use crate::macho::SegmentCommand;
-use crate::macho::SegmentType;
+use crate::macho::SegmentName;
 use crate::macho::SymtabCommand;
 use crate::macho::UuidCommand;
 use crate::macho::code_signature_identifier;
@@ -54,6 +52,7 @@ use crate::macho::code_signature_padded_identifier_size;
 use crate::macho::get_segment_sections;
 use crate::macho::load_dylib_command_size;
 use crate::macho::output_section_id;
+use crate::macho::output_section_id::LOAD_COMMANDS;
 use crate::macho::part_id;
 use crate::output_section_id::OrderEvent;
 use crate::output_section_id::OutputSectionId;
@@ -106,10 +105,6 @@ use object::macho::N_ABS;
 use object::macho::N_SECT;
 use object::macho::PLATFORM_MACOS;
 use object::macho::RelocationInfo;
-use object::macho::SEG_DATA;
-use object::macho::SEG_LINKEDIT;
-use object::macho::SEG_PAGEZERO;
-use object::macho::SEG_TEXT;
 use object::macho::SegmentFlags;
 use object::slice_from_bytes_mut;
 use object::write::macho::CodeDirectory;
@@ -213,7 +208,7 @@ fn write_prelude<'data>(
     );
 
     let header_buffer = buffers.get_mut(crate::part_id::FILE_HEADER);
-    populate_file_header(layout, prelude, take_mut(header_buffer)?)?;
+    populate_file_header(layout, prelude, take_mut(header_buffer)?);
     ensure!(header_buffer.is_empty(), "Excess FILE_HEADER allocation");
 
     let mut load_command_buffer = slice_from_all_bytes_mut(buffers.get_mut(part_id::LOAD_COMMANDS));
@@ -341,9 +336,8 @@ fn populate_file_header(
     layout: &MachOLayout,
     prelude: &PreludeLayout<MachO>,
     header: &mut FileHeader,
-) -> Result {
-    let load_commands_info = get_segment_sections(layout, SegmentType::LoadCommands)
-        .ok_or_else(|| error!("LoadCommands segment is mandatory"))?;
+) {
+    let load_commands_info = layout.section_layouts.get(LOAD_COMMANDS);
 
     header.magic.set(BigEndian, MH_CIGAM_64);
     header.cputype.set(LE, CPU_TYPE_ARM64);
@@ -354,13 +348,12 @@ fn populate_file_header(
         .set(LE, prelude.format_specific.load_command_count as u32);
     header
         .sizeofcmds
-        .set(LE, load_commands_info.segment_size.file_size as u32);
+        .set(LE, load_commands_info.file_size as u32);
     header.flags.set(
         LE,
         macho::MH_PIE | macho::MH_DYLDLINK | macho::MH_NOUNDEFS | macho::MH_TWOLEVEL,
     );
     header.reserved.set(LE, 0);
-    Ok(())
 }
 
 fn split_segment_command_buffer(
@@ -381,7 +374,7 @@ fn write_segment_commands(layout: &MachOLayout, load_commands: &mut &mut [u8]) -
     let load_cmd_err = |()| error!("Invalid LOAD_COMMANDS allocation");
     let pagezero_segment = take_mut(load_commands)?;
     write_segment(
-        SEG_PAGEZERO,
+        SegmentName::PAGEZERO,
         macho::VmProt(0),
         pagezero_segment,
         0,
@@ -392,117 +385,41 @@ fn write_segment_commands(layout: &MachOLayout, load_commands: &mut &mut [u8]) -
         SegmentFlags::default(),
     );
 
-    let text_segment_sections = get_segment_sections(layout, SegmentType::TextSections)
-        .ok_or_else(|| error!("TextSections segment is mandatory"))?
-        .segment_sections;
-    // The __TEXT segment in the layout includes also all the commands!
-    let text_segment_size = get_segment_sections(layout, SegmentType::Text)
-        .ok_or_else(|| error!("Text segment is mandatory"))?
-        .segment_size;
-    let command_size =
-        size_of::<SegmentCommand>() + size_of::<SectionEntry>() * text_segment_sections.len();
-    let (text_segment, text_sections) = split_segment_command_buffer(
-        load_commands
-            .split_off_mut(..command_size)
-            .ok_or_else(|| load_cmd_err(()))?,
-        text_segment_sections.len(),
-    )?;
-    write_segment(
-        SEG_TEXT,
-        macho::VM_PROT_READ | macho::VM_PROT_EXECUTE,
-        text_segment,
-        text_segment_size.file_offset as u64,
-        text_segment_size.file_size as u64,
-        text_segment_size.mem_offset,
-        text_segment_size.mem_size,
-        text_segment_sections.len(),
-        SegmentFlags::default(),
-    );
-    write_sections(SEG_TEXT, text_sections, &text_segment_sections)?;
+    for segment_layout in &layout.segment_layouts.segments {
+        let segment_id = segment_layout.id;
+        let segment_def = *layout.program_segments.segment_def(segment_id);
 
-    if let Some(data_segment_info) = get_segment_sections(layout, SegmentType::DataSections) {
-        let data_segment_sections = data_segment_info.segment_sections;
-        let data_segment_size = data_segment_info.segment_size;
-        let command_size =
-            size_of::<SegmentCommand>() + size_of::<SectionEntry>() * data_segment_sections.len();
-        let (data_segment, data_sections) = split_segment_command_buffer(
+        let segment_sections = get_segment_sections(layout, segment_id);
+        let section_count = segment_sections.len();
+        let command_size = size_of::<SegmentCommand>() + size_of::<SectionEntry>() * section_count;
+
+        let (segment, sections) = split_segment_command_buffer(
             load_commands
                 .split_off_mut(..command_size)
                 .ok_or_else(|| load_cmd_err(()))?,
-            data_segment_sections.len(),
+            section_count,
         )?;
+
+        let size = segment_layout.sizes;
         write_segment(
-            SEG_DATA,
-            macho::VM_PROT_READ | macho::VM_PROT_WRITE,
-            data_segment,
-            data_segment_size.file_offset as u64,
-            data_segment_size.file_size as u64,
-            data_segment_size.mem_offset,
-            data_segment_size.mem_size,
-            data_segment_sections.len(),
-            SegmentFlags::default(),
+            segment_def.name,
+            segment_def.prot,
+            segment,
+            size.file_offset as u64,
+            size.file_size as u64,
+            size.mem_offset,
+            size.mem_size,
+            section_count,
+            segment_def.flags,
         );
-        write_sections(SEG_DATA, data_sections, &data_segment_sections)?;
+        write_sections(segment_def.name, sections, &segment_sections);
     }
 
-    if let Some(data_const_segment_info) =
-        get_segment_sections(layout, SegmentType::DataConstSections)
-    {
-        let data_const_segment_sections = data_const_segment_info.segment_sections;
-        let data_const_segment_size = data_const_segment_info.segment_size;
-        let command_size = size_of::<SegmentCommand>()
-            + size_of::<SectionEntry>() * data_const_segment_sections.len();
-        let (data_const_segment, data_const_sections) = split_segment_command_buffer(
-            load_commands
-                .split_off_mut(..command_size)
-                .ok_or_else(|| load_cmd_err(()))?,
-            data_const_segment_sections.len(),
-        )?;
-        write_segment(
-            SEG_DATA_CONST,
-            macho::VM_PROT_READ | macho::VM_PROT_WRITE,
-            data_const_segment,
-            data_const_segment_size.file_offset as u64,
-            data_const_segment_size.file_size as u64,
-            data_const_segment_size.mem_offset,
-            data_const_segment_size.mem_size,
-            data_const_segment_sections.len(),
-            macho::SG_READ_ONLY,
-        );
-        write_sections(
-            SEG_DATA_CONST,
-            data_const_sections,
-            &data_const_segment_sections,
-        )?;
-    }
-
-    let linkedit_segment_size = get_segment_sections(layout, SegmentType::LinkeditSections)
-        .ok_or_else(|| error!("LinkeditSections segment is mandatory"))?
-        .segment_size;
-    let linkedit_segment = from_bytes_mut(
-        load_commands
-            .split_off_mut(..size_of::<SegmentCommand>())
-            .ok_or_else(|| load_cmd_err(()))?,
-    )
-    .map_err(load_cmd_err)?
-    .0;
-    write_segment(
-        SEG_LINKEDIT,
-        macho::VM_PROT_READ,
-        linkedit_segment,
-        linkedit_segment_size.file_offset as u64,
-        linkedit_segment_size.file_size as u64,
-        linkedit_segment_size.mem_offset,
-        linkedit_segment_size.mem_size,
-        // The sections in the __LINKEDIT are "hidden".
-        0,
-        SegmentFlags::default(),
-    );
     Ok(())
 }
 
 fn write_segment(
-    seg_name: &str,
+    seg_name: SegmentName,
     prot_flags: object::macho::VmProt,
     segment_cmd: &mut SegmentCommand,
     file_offset: u64,
@@ -517,8 +434,7 @@ fn write_segment(
         LE,
         (size_of::<SegmentCommand>() + size_of::<SectionEntry>() * section_count) as u32,
     );
-    segment_cmd.segname[..seg_name.len()].copy_from_slice(seg_name.as_bytes());
-    segment_cmd.segname[seg_name.len()..].zero();
+    segment_cmd.segname = seg_name.into_bytes();
     segment_cmd.fileoff.set(LE, file_offset);
     segment_cmd.filesize.set(LE, file_size);
     segment_cmd.vmaddr.set(LE, mem_offset);
@@ -530,22 +446,19 @@ fn write_segment(
 }
 
 fn write_sections(
-    seg_name: &str,
+    seg_name: SegmentName,
     sections: &mut [SectionEntry],
     segment_sections: &[(
         OutputRecordLayout,
-        Option<SectionName<'_>>,
+        SectionName<'_>,
         crate::macho::SectionFlags,
     )],
-) -> Result {
+) {
     for (section, (size, section_name, section_flags)) in sections.iter_mut().zip(segment_sections)
     {
-        let section_name = section_name
-            .ok_or_else(|| error!("section name must be known"))?
-            .0;
+        let section_name = section_name.0;
 
-        section.segname[..seg_name.len()].copy_from_slice(seg_name.as_bytes());
-        section.segname[seg_name.len()..].zero();
+        section.segname = seg_name.into_bytes();
         section.sectname[..section_name.len()].copy_from_slice(section_name);
         section.sectname[section_name.len()..].zero();
         section.addr.set(LE, size.mem_offset);
@@ -566,8 +479,6 @@ fn write_sections(
         section.reserved2.set(LE, reserved2);
         section.reserved3.set(LE, 0);
     }
-
-    Ok(())
 }
 
 fn write_object<'data, A: Arch<Platform = MachO>>(
@@ -887,13 +798,8 @@ fn write_code_signature_command(layout: &MachOLayout, command: &mut CodeSignatur
 
 fn write_chained_fixup_table(layout: &MachOLayout, chained_fixup_table: &mut [u8]) -> Result {
     let symbols = &layout.format_specific.imported_symbols;
+    let active_segments = &layout.segment_layouts.segments;
 
-    let active_segments = PROGRAM_SEGMENT_DEFS
-        .iter()
-        .filter(|segment| {
-            segment.count_as_segment && get_segment_sections(layout, segment.segment_type).is_some()
-        })
-        .collect_vec();
     // The __PAGEZERO segment needs to be added manually.
     let segment_count = active_segments.len() + 1;
     ensure!(
@@ -934,9 +840,12 @@ fn write_chained_fixup_table(layout: &MachOLayout, chained_fixup_table: &mut [u8
         return Ok(());
     }
 
-    let data_const_segment_index = active_segments
+    let (data_const_segment_index, data_const_segment) = active_segments
         .iter()
-        .position(|segment| segment.segment_type == SegmentType::DataConstSections)
+        .enumerate()
+        .find(|(_, segment)| {
+            layout.program_segments.segment_def(segment.id).name == SegmentName::DATA_CONST
+        })
         .ok_or_else(|| error!("non-empty __got requires __DATA_CONST segment"))?;
 
     // Accounts for both seg_count and __PAGEZERO.
@@ -950,10 +859,6 @@ fn write_chained_fixup_table(layout: &MachOLayout, chained_fixup_table: &mut [u8
         .map_err(|_| error!("Invalid chained fixups imports allocation"))?;
 
     // 3) fill up DyldChainedStartsInSegment for the __got section
-    let data_const_segment = get_segment_sections(layout, SegmentType::DataConstSections)
-        .ok_or_else(|| error!("__DATA_CONST segment expected"))?
-        .segment_size;
-
     starts_in_segment.size.set(LE, starts_in_segment_len as u32);
     starts_in_segment
         .page_size
@@ -963,7 +868,7 @@ fn write_chained_fixup_table(layout: &MachOLayout, chained_fixup_table: &mut [u8
         .set(LE, DYLD_CHAINED_PTR_64_OFFSET);
     starts_in_segment
         .segment_offset
-        .set(LE, data_const_segment.file_offset as u64);
+        .set(LE, data_const_segment.sizes.file_offset as u64);
     starts_in_segment.max_valid_pointer.set(LE, 0);
     // TODO:
     starts_in_segment.page_count.set(LE, 1);
@@ -1076,9 +981,13 @@ fn write_code_signature_metadata(
         "Unexpected code directory size"
     );
 
-    let text_segment_size = get_segment_sections(layout, SegmentType::Text)
-        .ok_or_else(|| error!("Text segment is mandatory"))?
-        .segment_size;
+    let text_segment = layout
+        .segment_layouts
+        .segments
+        .iter()
+        .find(|segment| layout.program_segments.segment_def(segment.id).name == SegmentName::TEXT)
+        .ok_or_else(|| error!("__TEXT segment is mandatory"))?;
+
     let code_directory = CodeDirectory {
         length: (code_signature_section.file_size - CS_BLOB_HEADERS_SIZE as usize) as u32,
         version: CS_SUPPORTSEXECSEG,
@@ -1094,8 +1003,8 @@ fn write_code_signature_metadata(
         page_size: CS_BLOCK_SIZE_EXP,
         scatter_offset: 0,
         team_offset: 0,
-        exec_seg_base: text_segment_size.file_offset as u64,
-        exec_seg_limit: text_segment_size.file_size as u64,
+        exec_seg_base: text_segment.sizes.file_offset as u64,
+        exec_seg_limit: text_segment.sizes.file_size as u64,
         // TODO: change once shared libraries are supported
         exec_seg_flags: CS_EXECSEG_MAIN_BINARY,
     };
@@ -1273,25 +1182,14 @@ fn write_symbols<'data>(
 fn macho_section_index(layout: &MachOLayout<'_>, section_id: OutputSectionId) -> Result<u8> {
     // The section index is one-based.
     let mut section_idx = 1u8;
-    let mut in_section_segment = false;
     for event in &layout.output_order {
         match event {
-            OrderEvent::SegmentStart(segment_id) => {
-                let segment_type = layout.program_segments.segment_def(segment_id).segment_type;
-                // TODO: Right now, the various load commands are mapped as "sections", so we can't
-                // just take the mapped index of the output "section".
-                in_section_segment = matches!(
-                    segment_type,
-                    SegmentType::TextSections
-                        | SegmentType::DataSections
-                        | SegmentType::DataConstSections
-                );
-            }
-            OrderEvent::SegmentEnd(_) => {
-                in_section_segment = false;
-            }
             OrderEvent::Section(current)
-                if in_section_segment && layout.output_sections.will_emit_section(current) =>
+                if layout.output_sections.will_emit_section(current)
+                    && layout
+                        .output_sections
+                        .identity(current)
+                        .is_some_and(|identity| identity.format_specific().is_some()) =>
             {
                 if current == section_id {
                     return Ok(section_idx);

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -133,8 +133,10 @@ pub(crate) struct OutputOrderBuilder<'scope, 'data, P: Platform> {
     events: Vec<OrderEvent<'data>>,
 
     program_segments: ProgramSegments<P::ProgramSegmentDef>,
+    segment_defs: Vec<P::ProgramSegmentDef>,
 
-    /// Indexes correspond to elements of `PROGRAM_SEGMENT_DEFS`.
+    /// Indexes correspond to elements of `segment_defs`, which is typically
+    /// `PROGRAM_SEGMENT_DEFS`.
     active_segment_kinds: Vec<Option<ProgramSegmentId>>,
     active_segment_regions: Vec<Option<&'data [u8]>>,
 
@@ -148,18 +150,21 @@ pub(crate) struct OutputOrderBuilder<'scope, 'data, P: Platform> {
 
 impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
     pub(crate) fn new(
+        segment_defs: Vec<P::ProgramSegmentDef>,
         output_kind: OutputKind,
         output_sections: &'scope OutputSections<'data, P>,
         secondary: &'scope OutputSectionMap<Vec<OutputSectionId>>,
         has_custom_phdrs: bool,
         location_counters: &'scope [crate::layout_rules::LocationCounter<'data>],
     ) -> Self {
+        let segment_defs_count = segment_defs.len();
         Self {
             events: Vec::new(),
             program_segments: ProgramSegments::empty(has_custom_phdrs),
+            segment_defs,
             output_sections,
-            active_segment_kinds: vec![None; P::program_segment_defs().len()],
-            active_segment_regions: vec![None; P::program_segment_defs().len()],
+            active_segment_kinds: vec![None; segment_defs_count],
+            active_segment_regions: vec![None; segment_defs_count],
             secondary,
             output_kind,
             has_custom_phdrs,
@@ -266,20 +271,21 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
     fn should_end_current_rw_segment(&self, section_id: OutputSectionId) -> bool {
         self.active_segment_kinds
             .iter()
-            .zip(P::program_segment_defs())
+            .zip(self.segment_defs.iter().copied())
             .any(|(id, def)| {
                 id.is_some()
                     && def.should_cut_rw_segment_when_ending()
                     && !self
                         .output_sections
-                        .should_include_in_segment(section_id, *def)
+                        .should_include_in_segment(section_id, def)
             })
     }
 
     /// Ends the currently active RW LOAD segment, if any. This is used when the RELRO segment
     /// ends to force .data and other non-RELRO sections into a new LOAD segment.
     fn end_rw_load_segment(&mut self) {
-        let rw_load_def_index = P::program_segment_defs()
+        let rw_load_def_index = self
+            .segment_defs
             .iter()
             .position(|def| def.is_loadable() && def.is_writable() && !def.is_executable());
 
@@ -339,14 +345,14 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
 
         let section_region = section_info.region_name;
         multizip((
-            P::program_segment_defs(),
+            self.segment_defs.iter().copied(),
             self.active_segment_kinds.iter_mut(),
             self.active_segment_regions.iter_mut(),
         ))
         .for_each(|(segment_def, active_id, active_region)| {
             let should_be_active = self
                 .output_sections
-                .should_include_in_segment(section_id, *segment_def);
+                .should_include_in_segment(section_id, segment_def);
 
             match (active_id.as_ref(), should_be_active) {
                 // Remain inactive
@@ -356,7 +362,7 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
                 (Some(segment_id), true) => {
                     if *active_region != section_region {
                         stop.push(*segment_id);
-                        let new_segment_id = self.program_segments.add_segment(*segment_def);
+                        let new_segment_id = self.program_segments.add_segment(segment_def);
                         start.push(new_segment_id);
                         *active_id = Some(new_segment_id);
                         *active_region = section_region;
@@ -364,7 +370,7 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
                 }
                 // Start segment
                 (None, true) => {
-                    let segment_id = self.program_segments.add_segment(*segment_def);
+                    let segment_id = self.program_segments.add_segment(segment_def);
                     start.push(segment_id);
                     *active_id = Some(segment_id);
                     *active_region = section_region;

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -753,6 +753,7 @@ pub(crate) trait Platform:
         prelude: &mut PreludeLayoutState<'data, Self>,
         sizes: &mut OutputSectionPartMap<u64>,
         header_info: &layout::HeaderInfo,
+        program_segments: &ProgramSegments<Self::ProgramSegmentDef>,
         output_sections: &OutputSections<Self>,
         resources: &layout::FinaliseSizesResources<'data, '_, Self>,
         args: &Self::Args,

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -6474,6 +6474,7 @@ impl platform::Platform for Wasm {
         _prelude: &mut crate::layout::PreludeLayoutState<'data, Self>,
         sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         _header_info: &crate::layout::HeaderInfo,
+        _program_segments: &crate::program_segments::ProgramSegments<Self::ProgramSegmentDef>,
         _output_sections: &crate::output_section_id::OutputSections<Self>,
         _resources: &layout::FinaliseSizesResources<'data, '_, Self>,
         _args: &Self::Args,
@@ -6582,6 +6583,7 @@ impl platform::Platform for Wasm {
         use crate::wasm::output_section_id as osid;
 
         let mut builder = crate::output_section_id::OutputOrderBuilder::<Self>::new(
+            Self::program_segment_defs().to_vec(),
             output_kind,
             output_sections,
             secondary,

--- a/wild/tests/sources/macho/arbitrary-segments/arbitrary-segments.c
+++ b/wild/tests/sources/macho/arbitrary-segments/arbitrary-segments.c
@@ -1,0 +1,13 @@
+//#Object:runtime.c
+//#ExpectSym:_first section="__first",segment="__CUSTOM1"
+//#ExpectSym:_second section="__second",segment="__CUSTOM1"
+//#ExpectSym:_third section="__third",segment="__CUSTOM2"
+//#DiffIgnore:section.__unwind_info
+
+#include "../common/runtime.h"
+
+__attribute__((section("__CUSTOM1,__first"))) long first = 10;
+__attribute__((section("__CUSTOM1,__second"))) long second = 11;
+__attribute__((section("__CUSTOM2,__third"))) long third = 21;
+
+void main(void) { exit_syscall(first + second + third); }


### PR DESCRIPTION
Adds support for arbitrary segments. Segments and their sections are ordered from `__PAGEZERO` -> `__TEXT` -> `__DATA_CONST` -> `__DATA` -> arbitrary segments -> `__LINKEDIT`. For all arbitrary segments, we assign RW protections, matching ld and lld behavior.

I also (hopefully) simplified the design a bit. Since we have `SectionIdentityExt` to differentiate between actual section identities from synthetic output regions (such as `FILE_HEADER`, `LOAD_COMMANDS`), I replaced `SegmentType` and `count_as_segment` from `ProgramSegmentDef`, instead making `ProgramSegmentDefs` the source of truth for a single `LC_SEGMENT_64` with `SegmentName`, `VmProt`, and `SegmentFlags`.  Synthetic regions are still represented with `OutputSectionId` and explicitly associated with their corresponding segment.

I wanted to note:
* Since we have arbitrary segments, we can no longer use `P::program_segment_defs` in `OutputOrderBuilder` for Mach-O - this has been replaced with `self.segment_defs`, although ELF and Wasm still pass in `program_segment_defs`.
* Similarly, having arbitrary segments means that we need to use `layout.segment_layouts.segments` throughout various places in the Mach-O writer.
* This means we have direct access to the segment bounds/sizes, and we no longer need `get_segment_sections` to both return the sizes and the sections of the segment. `get_segment_sections` now only collects the section information for each segment, and I removed `SegmentSectionsInfo`.

Resolves #2248