### PR TITLE
feat: support compound assignment operators in linker scripts

### DIFF
--- a/LINKER_SCRIPT_SUPPORT.md
+++ b/LINKER_SCRIPT_SUPPORT.md
@@ -30,7 +30,7 @@ end lists the features required to link the Linux kernel.
 | `NOCROSSREFS(sections...)` | ❌ | |
 | `INSERT [AFTER\|BEFORE] section` | ❌ | |
 | Top-level symbol assignment (`sym = expr`) | ✅ | |
-| Compound assignment operators (`+=`, `-=`, etc.) | ❌ | |
+| Compound assignment operators (`+=`, `-=`, etc.) | ✅ | |
 | `PHDRS` command for explicit program header definition | 🧪 | The `AT` attribute is not yet supported |
 
 ## SECTIONS Block

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -418,14 +418,16 @@ fn parse_command<'input>(input: &mut &'input BStr) -> winnow::Result<Command<'in
         b"MEMORY" => Command::Memory(parse_memory(input)?),
         b"PHDRS" => Command::Phdrs(parse_phdrs(input)?),
         other => {
-            if input.starts_with(b"=") {
+            if let Some(op) = opt(parse_assignment_op).parse_next(input)? {
                 // Symbol definition
-                '='.parse_next(input)?;
                 skip_comments_and_whitespace(input)?;
                 let value = parse_expression.parse_next(input)?;
                 skip_comments_and_whitespace(input)?;
                 opt(';').parse_next(input)?;
-                Command::SymbolDefinition { name: other, value }
+                Command::SymbolDefinition {
+                    name: other,
+                    value: op.expand(other, value),
+                }
             } else {
                 Command::Arg(other)
             }
@@ -1059,9 +1061,60 @@ enum MulOp {
     Modulo,
 }
 
-fn parse_location<'input>(input: &mut &'input BStr) -> winnow::Result<Location<'input>> {
-    let address = parse_expression.parse_next(input)?;
-    Ok(Location { address })
+#[derive(Debug, Clone, Copy)]
+enum AssignmentOp {
+    Assign,
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+    LeftShift,
+    RightShift,
+    BitwiseAnd,
+    BitwiseOr,
+    BitwiseXor,
+}
+
+fn parse_assignment_op(input: &mut &BStr) -> winnow::Result<AssignmentOp> {
+    alt((
+        alt((
+            "+=".value(AssignmentOp::Add),
+            "-=".value(AssignmentOp::Subtract),
+            "*=".value(AssignmentOp::Multiply),
+            "/=".value(AssignmentOp::Divide),
+            "<<=".value(AssignmentOp::LeftShift),
+        )),
+        alt((
+            ">>=".value(AssignmentOp::RightShift),
+            "&=".value(AssignmentOp::BitwiseAnd),
+            "|=".value(AssignmentOp::BitwiseOr),
+            "^=".value(AssignmentOp::BitwiseXor),
+            ("=", winnow::combinator::not('=')).value(AssignmentOp::Assign),
+        )),
+    ))
+    .parse_next(input)
+}
+
+impl AssignmentOp {
+    fn expand<'a>(self, name: &'a [u8], rhs: Expression<'a>) -> Expression<'a> {
+        let lhs = if name == b"." {
+            Expression::LocationCounter
+        } else {
+            Expression::Symbol(name)
+        };
+        match self {
+            AssignmentOp::Assign => rhs,
+            AssignmentOp::Add => Expression::Add(Box::new(lhs), Box::new(rhs)),
+            AssignmentOp::Subtract => Expression::Subtract(Box::new(lhs), Box::new(rhs)),
+            AssignmentOp::Multiply => Expression::Multiply(Box::new(lhs), Box::new(rhs)),
+            AssignmentOp::Divide => Expression::Divide(Box::new(lhs), Box::new(rhs)),
+            AssignmentOp::LeftShift => Expression::LeftShift(Box::new(lhs), Box::new(rhs)),
+            AssignmentOp::RightShift => Expression::RightShift(Box::new(lhs), Box::new(rhs)),
+            AssignmentOp::BitwiseAnd => Expression::BitwiseAnd(Box::new(lhs), Box::new(rhs)),
+            AssignmentOp::BitwiseOr => Expression::BitwiseOr(Box::new(lhs), Box::new(rhs)),
+            AssignmentOp::BitwiseXor => Expression::BitwiseXor(Box::new(lhs), Box::new(rhs)),
+        }
+    }
 }
 
 fn parse_commands<'input>(input: &mut &'input BStr) -> winnow::Result<Vec<Command<'input>>> {
@@ -1140,24 +1193,19 @@ fn parse_section_command<'input>(
         _ => {}
     }
 
-    if opt("=").parse_next(input)?.is_some() {
+    if let Some(op) = opt(parse_assignment_op).parse_next(input)? {
         skip_comments_and_whitespace(input)?;
-        if name == b"." {
-            let location = parse_location.parse_next(input)?;
-
-            skip_comments_and_whitespace(input)?;
-            ';'.parse_next(input)?;
-            skip_comments_and_whitespace(input)?;
-
-            return Ok(SectionCommand::SetLocation(location));
-        }
         let expr = parse_expression.parse_next(input)?;
         skip_comments_and_whitespace(input)?;
         ';'.parse_next(input)?;
         skip_comments_and_whitespace(input)?;
+        let expanded = op.expand(name, expr);
+        if name == b"." {
+            return Ok(SectionCommand::SetLocation(Location { address: expanded }));
+        }
         return Ok(SectionCommand::SymbolAssignment(SymbolAssignment {
             name,
-            expr,
+            expr: op.expand(name, expanded),
         }));
     }
 
@@ -1302,15 +1350,19 @@ fn parse_contents_provide<'input>(
 fn parse_assignment<'input>(input: &mut &'input BStr) -> winnow::Result<ContentsCommand<'input>> {
     let name = parse_token(input)?;
     skip_comments_and_whitespace(input)?;
-    '='.parse_next(input)?;
+    let op = parse_assignment_op.parse_next(input)?;
     skip_comments_and_whitespace(input)?;
 
     let expr = parse_expression.parse_next(input)?;
 
+    let expanded = op.expand(name, expr);
     let cmd = if name == b"." {
-        ContentsCommand::SetLocation(Location { address: (expr) })
+        ContentsCommand::SetLocation(Location { address: expanded })
     } else {
-        ContentsCommand::SymbolAssignment(SymbolAssignment { name, expr })
+        ContentsCommand::SymbolAssignment(SymbolAssignment {
+            name,
+            expr: expanded,
+        })
     };
 
     opt(';').parse_next(input)?;

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -1205,7 +1205,7 @@ fn parse_section_command<'input>(
         }
         return Ok(SectionCommand::SymbolAssignment(SymbolAssignment {
             name,
-            expr: op.expand(name, expanded),
+            expr: expanded,
         }));
     }
 

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.c
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.c
@@ -4,6 +4,7 @@
 //#Object:runtime.c
 // RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
 //#SkipArch:riscv64
+//#ExpectSym:symbol11 address=0x80
 
 #include "../common/runtime.h"
 

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
@@ -5,7 +5,16 @@ SECTIONS {
         *(.text*)
         symbol3 = 0x3000;
     }
-    .data : { *(.data*) }
+    symbol11 = 0x100;
+    symbol11 -= 0x20;
+    symbol11 &= 0x80;
+    .data : {
+        *(.data*)
+        symbol10 = 0x100;
+        symbol10 *= 0x100;
+        symbol10 ^= 0x40;
+        ASSERT(symbol10 == 0x10040, "symbol10 must be 0x100");
+    }
     .bss  : { *(.bss*)  }
 }
 
@@ -46,9 +55,9 @@ ASSERT(DEFINED(symbol6), "symbol6 must be defined");
 ASSERT(DEFINED(symbol7), "symbol7 must be defined");
 ASSERT(!DEFINED(symbol8), "symbol8 should not be defined");
 
-symbol9 = 0;
+symbol9 = 0x8;
 symbol9 += 0x10;
 symbol9 /= 0x2;
 symbol9 <<= 0x3;
 symbol9 |= 0x100;
-ASSERT(symbol9 == 0x140, "symbol9 must be 0x140");
+ASSERT(symbol9 == 0x160, "symbol9 must be 0x140");

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
@@ -45,3 +45,10 @@ ASSERT(!DEFINED(symbol5), "symbol5 should not be defined");
 ASSERT(DEFINED(symbol6), "symbol6 must be defined");
 ASSERT(DEFINED(symbol7), "symbol7 must be defined");
 ASSERT(!DEFINED(symbol8), "symbol8 should not be defined");
+
+symbol9 = 0;
+symbol9 += 0x10;
+symbol9 /= 0x2;
+symbol9 <<= 0x3;
+symbol9 |= 0x100;
+ASSERT(symbol9 == 0x140, "symbol9 must be 0x140");

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
@@ -13,7 +13,7 @@ SECTIONS {
         symbol10 = 0x100;
         symbol10 *= 0x100;
         symbol10 ^= 0x40;
-        ASSERT(symbol10 == 0x10040, "symbol10 must be 0x100");
+        ASSERT(symbol10 == 0x10040, "symbol10 must be 0x10040");
     }
     .bss  : { *(.bss*)  }
 }
@@ -60,4 +60,4 @@ symbol9 += 0x10;
 symbol9 /= 0x2;
 symbol9 <<= 0x3;
 symbol9 |= 0x100;
-ASSERT(symbol9 == 0x160, "symbol9 must be 0x140");
+ASSERT(symbol9 == 0x160, "symbol9 must be 0x160");


### PR DESCRIPTION
Support the use of complex assignment operators such as `+=` and `-=` in linker scripts, when defining a symbol/location counter.