### PR TITLE
port(wasm): Support `--max-memory`

### DIFF
--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -44,6 +44,7 @@ pub struct WasmArgs {
     // When set, the output `memory.initial` is raised to at least this many bytes (must be
     // page-aligned). `None` means size is derived from data / stack layout only.
     pub(crate) initial_memory: Option<u64>,
+    pub(crate) max_memory: Option<u64>,
     pub(crate) gc_sections: bool,
 }
 
@@ -72,6 +73,7 @@ impl Default for WasmArgs {
             stack_first: true,
             entry: Some(DEFAULT_ENTRY.to_owned()),
             initial_memory: None,
+            max_memory: None,
             export_memory: None,
             gc_sections: true,
         }
@@ -328,6 +330,15 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
         .help("Initial size of the linear memory in bytes")
         .execute(|args, _modifier_stack, value| {
             args.initial_memory = Some(parse_number(value)?);
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("max-memory")
+        .help("Maximum size of the linear memory in bytes")
+        .execute(|args, _modifier_stack, value| {
+            args.max_memory = Some(parse_number(value)?);
             Ok(())
         });
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -5059,11 +5059,14 @@ const fn wasm_page_size() -> u64 {
 /// Maximum linear-memory size in bytes for wasm32.
 const WASM32_MAX_MEMORY_BYTES: u64 = (1u64 << 32) - wasm_page_size();
 
+const WASM32_MAX_MEMORY_LIMIT_BYTES: u64 = 1u64 << 32;
+
 fn ensure_memory_covers(
     layout: &mut WasmLayout<'_>,
     stack_size: u32,
     stack_first: bool,
     initial_memory: Option<u64>,
+    max_memory: Option<u64>,
 ) -> Result<u64> {
     let page = wasm_page_size();
     let mut bytes_needed = u64::from(layout.data_end.max(layout.memory_base));
@@ -5096,7 +5099,30 @@ fn ensure_memory_covers(
             memory.initial = memory.initial.max(pages_needed);
         }
     }
-    Ok(layout.memories.iter().map(|m| m.initial).max().unwrap_or(0))
+
+    let initial_pages = layout.memories.iter().map(|m| m.initial).max().unwrap_or(0);
+    let initial_bytes = initial_pages.saturating_mul(page);
+
+    if let Some(requested) = max_memory {
+        ensure!(
+            requested.is_multiple_of(page),
+            "maximum memory must be aligned to the page size ({page} bytes)"
+        );
+        ensure!(
+            requested <= WASM32_MAX_MEMORY_LIMIT_BYTES,
+            "maximum memory too large, cannot be greater than {WASM32_MAX_MEMORY_LIMIT_BYTES}"
+        );
+        ensure!(
+            initial_bytes <= requested,
+            "maximum memory too small, {initial_bytes} bytes needed"
+        );
+        let max_pages = requested / page;
+        for memory in &mut layout.memories {
+            memory.maximum = Some(max_pages);
+        }
+    }
+
+    Ok(initial_pages)
 }
 
 /// `__heap_end` = end of initial linear memory (`memory.initial * page_size`).
@@ -5412,6 +5438,7 @@ where
     let stack_size = symbol_db.args.z_stack_size;
     let stack_first = symbol_db.args.stack_first;
     let initial_memory = symbol_db.args.initial_memory;
+    let max_memory = symbol_db.args.max_memory;
     if stack_size > 0 {
         ensure_stack_size_aligned(stack_size)?;
     }
@@ -5536,8 +5563,13 @@ where
             ensure_memory_export(&mut layout.exports, symbol_db.args.memory_export_name());
         }
         layout.data_end = memory_cursor;
-        let initial_pages =
-            ensure_memory_covers(&mut layout, stack_size, stack_first, initial_memory)?;
+        let initial_pages = ensure_memory_covers(
+            &mut layout,
+            stack_size,
+            stack_first,
+            initial_memory,
+            max_memory,
+        )?;
         // wasm-ld only defines `__heap_end` when linear memory exists (end of `memory.initial`).
         let heap_end = if layout.memories.is_empty() {
             None
@@ -7458,11 +7490,14 @@ mod tests {
             ..Default::default()
         };
 
-        let pages = ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, true, None).unwrap();
+        let pages =
+            ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, true, None, None).unwrap();
         assert_eq!(pages, 1);
         assert_eq!(layout.memories[0].initial, 1);
+        assert_eq!(layout.memories[0].maximum, None);
 
-        let pages = ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, false, None).unwrap();
+        let pages =
+            ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, false, None, None).unwrap();
         let expected_pages = (u64::from(data_end) + u64::from(DEFAULT_STACK_SIZE))
             .div_ceil(wasm_page_size())
             .max(1);

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -5056,10 +5056,11 @@ const fn wasm_page_size() -> u64 {
     crate::args::wasm::WASM_PAGE_SIZE
 }
 
-/// Maximum linear-memory size in bytes for wasm32.
-const WASM32_MAX_MEMORY_BYTES: u64 = (1u64 << 32) - wasm_page_size();
+/// Size of the wasm32 linear-memory address space.
+const WASM32_ADDRESS_SPACE_BYTES: u64 = 1u64 << 32;
 
-const WASM32_MAX_MEMORY_LIMIT_BYTES: u64 = 1u64 << 32;
+/// Largest initial memory size.
+const WASM32_MAX_INITIAL_MEMORY_BYTES: u64 = WASM32_ADDRESS_SPACE_BYTES - wasm_page_size();
 
 fn ensure_memory_covers(
     layout: &mut WasmLayout<'_>,
@@ -5083,8 +5084,8 @@ fn ensure_memory_covers(
             "initial memory must be aligned to the page size ({page} bytes)"
         );
         ensure!(
-            requested <= WASM32_MAX_MEMORY_BYTES,
-            "initial memory too large, cannot be greater than {WASM32_MAX_MEMORY_BYTES}"
+            requested <= WASM32_MAX_INITIAL_MEMORY_BYTES,
+            "initial memory too large, cannot be greater than {WASM32_MAX_INITIAL_MEMORY_BYTES}"
         );
         ensure!(
             bytes_needed <= requested,
@@ -5109,8 +5110,8 @@ fn ensure_memory_covers(
             "maximum memory must be aligned to the page size ({page} bytes)"
         );
         ensure!(
-            requested <= WASM32_MAX_MEMORY_LIMIT_BYTES,
-            "maximum memory too large, cannot be greater than {WASM32_MAX_MEMORY_LIMIT_BYTES}"
+            requested <= WASM32_ADDRESS_SPACE_BYTES,
+            "maximum memory too large, cannot be greater than {WASM32_ADDRESS_SPACE_BYTES}"
         );
         ensure!(
             initial_bytes <= requested,

--- a/wild/tests/sources/wasm/max-memory/max-memory.c
+++ b/wild/tests/sources/wasm/max-memory/max-memory.c
@@ -1,0 +1,32 @@
+//#Config:default
+//#LinkArgs: --initial-memory=131072 --max-memory=196608 -z stack-size=65536 --stack-first
+//#CompArgs: -DGROW_ONCE
+
+//#Config:max
+//#LinkArgs: --max-memory=4294967296 -z stack-size=65536 --stack-first
+
+//#Config:unaligned
+//#LinkArgs: --max-memory=1000
+//#ExpectError: maximum memory must be aligned
+
+//#Config:too-small
+//#LinkArgs: --max-memory=65536 -z stack-size=1048576 --stack-first
+//#ExpectError: maximum memory too small
+
+//#Config:too-large
+//#LinkArgs: --max-memory=4295032832
+//#ExpectError: maximum memory too large
+
+void _start(void) {
+  unsigned long first = __builtin_wasm_memory_grow(0, 1);
+  if (first == (unsigned long)-1) {
+    __builtin_trap();
+  }
+#ifdef GROW_ONCE
+  unsigned long second = __builtin_wasm_memory_grow(0, 1);
+  // The initial memory is 2 pages and the max is 3 pages, so the second grow should fail.
+  if (second != (unsigned long)-1) {
+    __builtin_trap();
+  }
+#endif
+}


### PR DESCRIPTION
This option allows specifying the maximum size of linear memory.

Part of #1431