### PR TITLE
fix: Follow GNU ld mandatory relaxations logic better

### DIFF
--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -212,7 +212,7 @@ impl crate::platform::Arch for ElfX86_64 {
                             return Some(Relaxation {
                                 kind: RelaxationKind::RexMovIndirectToAbsolute(inst_offset),
                                 rel_info: rel_info_from_type!(object::elf::R_X86_64_32),
-                                mandatory: output_kind.is_static_executable(),
+                                mandatory: output_kind.is_static_executable() && is_absolute,
                             });
                         }
                         // sub *x(%rip), reg
@@ -220,7 +220,7 @@ impl crate::platform::Arch for ElfX86_64 {
                             return Some(Relaxation {
                                 kind: RelaxationKind::RexSubIndirectToAbsolute(inst_offset),
                                 rel_info: rel_info_from_type!(object::elf::R_X86_64_32),
-                                mandatory: output_kind.is_static_executable(),
+                                mandatory: output_kind.is_static_executable() && is_absolute,
                             });
                         }
                         // cmp *x(%rip), reg
@@ -228,7 +228,7 @@ impl crate::platform::Arch for ElfX86_64 {
                             return Some(Relaxation {
                                 kind: RelaxationKind::RexCmpIndirectToAbsolute(inst_offset),
                                 rel_info: rel_info_from_type!(object::elf::R_X86_64_32),
-                                mandatory: output_kind.is_static_executable(),
+                                mandatory: output_kind.is_static_executable() && is_absolute,
                             });
                         }
                         _ => return None,

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -275,7 +275,7 @@ impl crate::platform::Arch for ElfX86_64 {
                             return Some(Relaxation {
                                 kind: RelaxationKind::CallIndirectToRelative,
                                 rel_info: rel_info_from_type!(object::elf::R_X86_64_PC32),
-                                mandatory: output_kind.is_static_executable(),
+                                mandatory: output_kind.is_static_executable() && !non_relocatable,
                             });
                         }
                         // jmp *x(%rip)
@@ -284,7 +284,7 @@ impl crate::platform::Arch for ElfX86_64 {
                             return Some(Relaxation {
                                 kind: RelaxationKind::JmpIndirectToRelative,
                                 rel_info: rel_info_from_type!(object::elf::R_X86_64_PC32),
-                                mandatory: output_kind.is_static_executable(),
+                                mandatory: output_kind.is_static_executable() && !non_relocatable,
                             });
                         }
                         _ => return None,

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -325,7 +325,7 @@ impl crate::platform::Arch for ElfX86_64 {
                         return Some(Relaxation {
                             kind: RelaxationKind::RexMovIndirectToAbsolute(inst_offset),
                             rel_info: rel_info_from_type!(object::elf::R_X86_64_TPOFF32),
-                            mandatory: false,
+                            mandatory: output_kind.is_executable(),
                         });
                     }
                     // add *x(%rip), reg1, reg2

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -325,7 +325,7 @@ impl crate::platform::Arch for ElfX86_64 {
                         return Some(Relaxation {
                             kind: RelaxationKind::RexMovIndirectToAbsolute(inst_offset),
                             rel_info: rel_info_from_type!(object::elf::R_X86_64_TPOFF32),
-                            mandatory: output_kind.is_executable(),
+                            mandatory: output_kind.is_static_executable(),
                         });
                     }
                     // add *x(%rip), reg1, reg2

--- a/wild/tests/sources/elf/cpp-integration/cpp-integration.cc
+++ b/wild/tests/sources/elf/cpp-integration/cpp-integration.cc
@@ -38,9 +38,6 @@
 //#DiffIgnore:rel.match_failed.R_X86_64_GOTPCRELX
 //#DiffIgnore:rel.match_failed.R_X86_64_REX_GOTPCRELX
 //#DiffIgnore:literal-byte-mismatch
-// TODO: Some conditions for required relaxations are wrong.
-//#DiffIgnore:rel.extra-opt.R_X86_64_REX_GOTPCRELX.RexCmpIndirectToAbsolute*
-//#DiffIgnore:rel.extra-opt.R_X86_64_REX_GOTPCRELX.RexMovIndirectToAbsolute*
 //#Arch: x86_64
 
 //#Config:clang-pie:default

--- a/wild/tests/sources/elf/cpp-integration/cpp-integration.cc
+++ b/wild/tests/sources/elf/cpp-integration/cpp-integration.cc
@@ -37,7 +37,6 @@
 // TODO: Missing `endbr64` relaxations.
 //#DiffIgnore:rel.match_failed.R_X86_64_GOTPCRELX
 //#DiffIgnore:rel.match_failed.R_X86_64_REX_GOTPCRELX
-//#DiffIgnore:rel.match_failed.R_X86_64_PLT32
 //#DiffIgnore:literal-byte-mismatch
 // TODO: Some conditions for required relaxations are wrong.
 //#DiffIgnore:rel.extra-opt.R_X86_64_GOTPCRELX.JmpIndirectToRelative*

--- a/wild/tests/sources/elf/cpp-integration/cpp-integration.cc
+++ b/wild/tests/sources/elf/cpp-integration/cpp-integration.cc
@@ -37,6 +37,7 @@
 // TODO: We probably picked weak symbols from different objects than GNU ld.
 //#DiffIgnore:rel.match_failed.R_X86_64_GOTPCRELX
 //#DiffIgnore:rel.match_failed.R_X86_64_REX_GOTPCRELX
+//#DiffIgnore:rel.match_failed.R_X86_64_PLT32
 //#DiffIgnore:literal-byte-mismatch
 //#Arch: x86_64
 

--- a/wild/tests/sources/elf/cpp-integration/cpp-integration.cc
+++ b/wild/tests/sources/elf/cpp-integration/cpp-integration.cc
@@ -42,7 +42,6 @@
 //#DiffIgnore:rel.extra-opt.R_X86_64_GOTPCRELX.JmpIndirectToRelative*
 //#DiffIgnore:rel.extra-opt.R_X86_64_REX_GOTPCRELX.RexCmpIndirectToAbsolute*
 //#DiffIgnore:rel.extra-opt.R_X86_64_REX_GOTPCRELX.RexMovIndirectToAbsolute*
-//#DiffIgnore:rel.missing-opt.R_X86_64_GOTTPOFF.RexMovIndirectToAbsolute*
 //#Arch: x86_64
 
 //#Config:clang-pie:default

--- a/wild/tests/sources/elf/cpp-integration/cpp-integration.cc
+++ b/wild/tests/sources/elf/cpp-integration/cpp-integration.cc
@@ -34,7 +34,7 @@
 //#DiffIgnore:section.rela.plt.link
 // Wild uses similar order as LLD, which is different from GNU ld.
 //#DiffIgnore:init_array
-// TODO: Missing `endbr64` relaxations.
+// TODO: We probably picked weak symbols from different objects than GNU ld.
 //#DiffIgnore:rel.match_failed.R_X86_64_GOTPCRELX
 //#DiffIgnore:rel.match_failed.R_X86_64_REX_GOTPCRELX
 //#DiffIgnore:literal-byte-mismatch

--- a/wild/tests/sources/elf/cpp-integration/cpp-integration.cc
+++ b/wild/tests/sources/elf/cpp-integration/cpp-integration.cc
@@ -39,7 +39,6 @@
 //#DiffIgnore:rel.match_failed.R_X86_64_REX_GOTPCRELX
 //#DiffIgnore:literal-byte-mismatch
 // TODO: Some conditions for required relaxations are wrong.
-//#DiffIgnore:rel.extra-opt.R_X86_64_GOTPCRELX.JmpIndirectToRelative*
 //#DiffIgnore:rel.extra-opt.R_X86_64_REX_GOTPCRELX.RexCmpIndirectToAbsolute*
 //#DiffIgnore:rel.extra-opt.R_X86_64_REX_GOTPCRELX.RexMovIndirectToAbsolute*
 //#Arch: x86_64

--- a/wild/tests/sources/elf/cpp-integration/cpp-integration.cc
+++ b/wild/tests/sources/elf/cpp-integration/cpp-integration.cc
@@ -29,7 +29,7 @@
 //#Config:static-no-relax:default
 //#CompArgs:-fmerge-constants
 //#LinkerDriver:g++
-//#LinkArgs:-static -Wl,-z,now,-no-relax
+//#LinkArgs:-no-pie -static -Wl,-z,now,-no-relax
 //#DiffIgnore:rel.extra-got-plt-got
 //#DiffIgnore:section.rela.plt.link
 // Wild uses similar order as LLD, which is different from GNU ld.


### PR DESCRIPTION
Found by trial and error, so they might be not entirely correct.

You might wonder why not also add static PIE test case. Well, GNU ld (version 2.47) produces broken binary, so I wouldn't trust it:
```
(gdb) disas
Dump of assembler code for function _start:
   0x00007ffff7c26460 <+0>:	endbr64
   0x00007ffff7c26464 <+4>:	xor    %ebp,%ebp
   0x00007ffff7c26466 <+6>:	mov    %rdx,%r9
   0x00007ffff7c26469 <+9>:	pop    %rsi
   0x00007ffff7c2646a <+10>:	mov    %rsp,%rdx
   0x00007ffff7c2646d <+13>:	and    $0xfffffffffffffff0,%rsp
   0x00007ffff7c26471 <+17>:	push   %rax
   0x00007ffff7c26472 <+18>:	push   %rsp
   0x00007ffff7c26473 <+19>:	xor    %r8d,%r8d
   0x00007ffff7c26476 <+22>:	xor    %ecx,%ecx
   0x00007ffff7c26478 <+24>:	mov    0x22d1a9(%rip),%rdi        # 0x7ffff7e53628
=> 0x00007ffff7c2647f <+31>:	call   *0x22e403(%rip)        # 0x7ffff7e54888
   0x00007ffff7c26485 <+37>:	hlt
End of assembler dump.
(gdb) si
0x00000000001216f0 in ?? ()
(gdb) disas
❌️ No function contains program counter for selected frame.
(gdb) si

Program received signal SIGSEGV, Segmentation fault.
0x00000000001216f0 in ?? ()
```