### PR TITLE
feat: Add infrastructure for LLD ELF test integration

### DIFF
--- a/external_test_suites/lld/test/ELF/README.md
+++ b/external_test_suites/lld/test/ELF/README.md
@@ -2,6 +2,6 @@
 
 This directory contains tests vendored from llvm-project/lld/test/ELF/.
 
-To update these tests, run: scripts/update-lld-tests.sh
+To update these tests, run: external_test_suites/lld/update-lld-tests.sh
 
 These tests are run with Wild substituted for ld.lld to verify compatibility.

--- a/external_test_suites/lld/test/ELF/README.md
+++ b/external_test_suites/lld/test/ELF/README.md
@@ -1,0 +1,7 @@
+# LLD ELF Tests
+
+This directory contains tests vendored from llvm-project/lld/test/ELF/.
+
+To update these tests, run: scripts/update-lld-tests.sh
+
+These tests are run with Wild substituted for ld.lld to verify compatibility.

--- a/external_test_suites/lld/update-lld-tests.sh
+++ b/external_test_suites/lld/update-lld-tests.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Updates the vendored LLD ELF tests from a local llvm-project checkout.
+#
+# Usage:
+#   external_test_suites/lld/update-lld-tests.sh <path-to-llvm-project>
+#
+# Example:
+#   external_test_suites/lld/update-lld-tests.sh ~/Desktop/Deepak/llvm-project
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <path-to-llvm-project>" >&2
+    exit 1
+fi
+
+LLVM_PROJECT="$1"
+SRC="$LLVM_PROJECT/lld/test/ELF"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEST="$SCRIPT_DIR/test/ELF"
+
+if [[ ! -d "$SRC" ]]; then
+    echo "error: $SRC does not exist. Is '$LLVM_PROJECT' a valid llvm-project checkout?" >&2
+    exit 1
+fi
+
+mkdir -p "$DEST"
+
+# Mirror the upstream test directory, removing anything locally that no
+# longer exists upstream, so stale/removed tests don't linger.
+rsync -a --delete "$SRC/" "$DEST/"
+
+echo "Vendored LLD ELF tests from $SRC to $DEST"
+echo "Review the diff and update lld_skip_tests.toml as needed."

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -71,5 +71,6 @@ wasm = ["libwild/wasm"]
 macho = ["libwild/macho"]
 
 # external tests
-external_tests = ["mold_tests"]
+external_tests = ["mold_tests", "lld_tests"]
 mold_tests = []
+lld_tests = []

--- a/wild/tests/external_tests/lld_skip_tests.toml
+++ b/wild/tests/external_tests/lld_skip_tests.toml
@@ -1,0 +1,3 @@
+[skipped_groups.unsupported_features]
+reason = "These tests use features not yet supported by Wild"
+tests = []

--- a/wild/tests/external_tests/lld_skip_tests.toml
+++ b/wild/tests/external_tests/lld_skip_tests.toml
@@ -1,3 +1,0 @@
-[skipped_groups.unsupported_features]
-reason = "These tests use features not yet supported by Wild"
-tests = []

--- a/wild/tests/external_tests/lld_tests.rs
+++ b/wild/tests/external_tests/lld_tests.rs
@@ -1,0 +1,106 @@
+//! Integration tests that run LLD's ELF test suite with Wild as the linker.
+//! Tests are vendored from llvm-project/lld/test/ELF/.
+//!
+//! Requires system LLVM tools: llvm-mc, FileCheck, split-file.
+//! These are available on distributions like Arch Linux.
+
+use crate::Result;
+use libtest_mimic::Failed;
+use libtest_mimic::Trial;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+
+const PREFIX: &str = "external_test_suites/lld";
+
+pub(crate) fn collect_tests(tests: &mut Vec<Trial>, filter: &crate::Filter) -> Result {
+    if filter.excludes(PREFIX) {
+        return Ok(());
+    }
+
+    let test_dir = crate::base_dir().join("../external_test_suites/lld/test/ELF");
+    if !test_dir.exists() {
+        return Ok(());
+    }
+
+    let dir = std::fs::read_dir(&test_dir)?;
+    for ent in dir {
+        let ent = ent?;
+        let path = ent.path();
+        if path.extension().is_some_and(|ext| ext == "s") {
+            let file_name =
+                String::from_utf8_lossy(path.file_name().unwrap().as_encoded_bytes()).to_string();
+            let name = format!("{PREFIX}/test/ELF/{file_name}");
+            tests.push(Trial::test(name, move || {
+                run_lld_test(&path).map_err(|e| Failed::from(e.to_string()))
+            }));
+        }
+    }
+    Ok(())
+}
+
+fn run_lld_test(test_file: &Path) -> Result {
+    // Check if required LLVM tools are available
+    let llvm_mc = find_tool("llvm-mc")?;
+    let filecheck = find_tool("FileCheck")?;
+
+    let content = std::fs::read_to_string(test_file)?;
+    let tmpdir = tempfile::tempdir()?;
+
+    // Extract and execute RUN: lines
+    for line in content.lines() {
+        let Some(cmd) = line
+            .trim()
+            .strip_prefix("// RUN:")
+            .or_else(|| line.trim().strip_prefix("# RUN:"))
+        else {
+            continue;
+        };
+
+        let cmd = substitute_vars(cmd.trim(), test_file, tmpdir.path());
+        let cmd = substitute_tools(&cmd, &llvm_mc, &filecheck);
+
+        execute_command(&cmd)?;
+    }
+    Ok(())
+}
+
+fn substitute_vars(cmd: &str, test_file: &Path, tmpdir: &Path) -> String {
+    cmd.replace("%s", &test_file.display().to_string())
+        .replace("%t", &tmpdir.join("test").display().to_string())
+        .replace("%p", &test_file.parent().unwrap().display().to_string())
+}
+
+fn substitute_tools(cmd: &str, llvm_mc: &str, filecheck: &str) -> String {
+    let wild = std::env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("wild");
+
+    cmd.replace("llvm-mc", llvm_mc)
+        .replace("FileCheck", filecheck)
+        .replace("ld.lld", &format!("{} -m elf_x86_64", wild.display()))
+}
+
+fn find_tool(name: &str) -> Result<String> {
+    if let Ok(path) = which::which(name) {
+        return Ok(path.display().to_string());
+    }
+    Err(format!("Required tool '{name}' not found. Install LLVM tools.").into())
+}
+
+fn execute_command(cmd: &str) -> Result {
+    let output = Command::new("sh").arg("-c").arg(cmd).output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "Command failed: {cmd}\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        )
+        .into());
+    }
+    Ok(())
+}

--- a/wild/tests/external_tests/lld_tests.rs
+++ b/wild/tests/external_tests/lld_tests.rs
@@ -8,7 +8,6 @@ use crate::Result;
 use libtest_mimic::Failed;
 use libtest_mimic::Trial;
 use std::path::Path;
-use std::path::PathBuf;
 use std::process::Command;
 
 const PREFIX: &str = "external_test_suites/lld";
@@ -40,29 +39,61 @@ pub(crate) fn collect_tests(tests: &mut Vec<Trial>, filter: &crate::Filter) -> R
 }
 
 fn run_lld_test(test_file: &Path) -> Result {
-    // Check if required LLVM tools are available
     let llvm_mc = find_tool("llvm-mc")?;
     let filecheck = find_tool("FileCheck")?;
-
     let content = std::fs::read_to_string(test_file)?;
     let tmpdir = tempfile::tempdir()?;
 
-    // Extract and execute RUN: lines
+    for cmd in extract_run_lines(&content) {
+        let cmd = substitute_vars(&cmd, test_file, tmpdir.path());
+        let cmd = substitute_tools(&cmd, &llvm_mc, &filecheck);
+        execute_command(&cmd)?;
+    }
+    Ok(())
+}
+
+/// Extracts RUN: lines from the test file, joining lines that end in a
+/// trailing `\` continuation character into a single logical command, per
+/// the LLVM lit RUN line syntax:
+/// https://llvm.org/docs/TestingGuide.html#run-lines
+fn extract_run_lines(content: &str) -> Vec<String> {
+    let mut commands = Vec::new();
+    let mut current: Option<String> = None;
+
     for line in content.lines() {
-        let Some(cmd) = line
+        let Some(rest) = line
             .trim()
             .strip_prefix("// RUN:")
             .or_else(|| line.trim().strip_prefix("# RUN:"))
         else {
             continue;
         };
+        let rest = rest.trim();
 
-        let cmd = substitute_vars(cmd.trim(), test_file, tmpdir.path());
-        let cmd = substitute_tools(&cmd, &llvm_mc, &filecheck);
+        let (piece, continues) = match rest.strip_suffix('\\') {
+            Some(stripped) => (stripped.trim_end(), true),
+            None => (rest, false),
+        };
 
-        execute_command(&cmd)?;
+        current = Some(match current.take() {
+            Some(mut buf) => {
+                buf.push(' ');
+                buf.push_str(piece);
+                buf
+            }
+            None => piece.to_string(),
+        });
+
+        if !continues {
+            commands.push(current.take().unwrap());
+        }
     }
-    Ok(())
+
+    if let Some(buf) = current {
+        commands.push(buf);
+    }
+
+    commands
 }
 
 fn substitute_vars(cmd: &str, test_file: &Path, tmpdir: &Path) -> String {
@@ -72,17 +103,10 @@ fn substitute_vars(cmd: &str, test_file: &Path, tmpdir: &Path) -> String {
 }
 
 fn substitute_tools(cmd: &str, llvm_mc: &str, filecheck: &str) -> String {
-    let wild = std::env::current_exe()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .join("wild");
-
+    const WILD: &str = env!("CARGO_BIN_EXE_wild");
     cmd.replace("llvm-mc", llvm_mc)
         .replace("FileCheck", filecheck)
-        .replace("ld.lld", &format!("{} -m elf_x86_64", wild.display()))
+        .replace("ld.lld", &format!("{WILD} -m elf_x86_64"))
 }
 
 fn find_tool(name: &str) -> Result<String> {

--- a/wild/tests/external_tests/mod.rs
+++ b/wild/tests/external_tests/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "lld_tests")]
 mod lld_tests;
 mod mold_tests;
 
@@ -18,7 +17,9 @@ pub(super) fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
         mold_tests::collect_tests(tests, filter)?;
     }
 
-    let _ = (tests, filter);
+    if cfg!(feature = "lld_tests") {
+        lld_tests::collect_tests(tests, filter)?;
+    }
 
     Ok(())
 }

--- a/wild/tests/external_tests/mod.rs
+++ b/wild/tests/external_tests/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "lld_tests")]
+mod lld_tests;
 mod mold_tests;
 
 use crate::Filter;


### PR DESCRIPTION
Adds basic infrastructure to run LLD's ELF test suite with Wild as the linker, similar to the existing Mold test integration.
Tests are vendored (not submoduled) to avoid pulling in the full LLVM repository. A script is provided to sync tests from llvm-project.

Part of   #2380 