### PR TITLE
fix: Preserve original definitions for `--wrap` under linker-plugin LTO

### DIFF
--- a/libwild/src/linker_plugins.rs
+++ b/libwild/src/linker_plugins.rs
@@ -245,6 +245,11 @@ impl<'data> LinkerPlugin<'data> {
         let plugin_loaded =
             file_loader.load_inputs(&plugin_outputs.generated_inputs, symbol_db.args, &mut None)?;
 
+        // Temporarily restore original (pre-wrap) name mappings so that definitions of wrapped
+        // names in the LTO output are registered as alternatives of the original symbols rather
+        // than of `__wrap_*`.
+        symbol_db.restore_wrapped_symbol_names();
+
         symbol_db.add_inputs(
             per_symbol_flags,
             output_sections,
@@ -947,17 +952,17 @@ fn get_symbol_resolution<'data, C: ElfClass>(
     // plugin needs to know the pre-wrap state.
     let wrap_names = symbol_db.args.symbol_names_to_wrap();
     let is_wrapped = wrap_names.iter().any(|w| w.as_bytes() == raw_name.name);
-    if is_wrapped {
-        return if sym.is_undefined() {
-            PluginSymbolResolution::ResolvedExec
-        } else {
-            PluginSymbolResolution::PreemptedReg
-        };
-    }
 
-    let symbol_id = symbol_db
-        .get(&PreHashedSymbolName::from_raw(&raw_name), true)
-        .map(|id| symbol_db.definition(id));
+    let symbol_id = if is_wrapped {
+        let real_name = format!("__real_{}", String::from_utf8_lossy(raw_name.name));
+        symbol_db
+            .get_unversioned(&UnversionedSymbolName::prehashed(real_name.as_bytes()))
+            .map(|id| symbol_db.definition(id))
+    } else {
+        symbol_db
+            .get(&PreHashedSymbolName::from_raw(&raw_name), true)
+            .map(|id| symbol_db.definition(id))
+    };
 
     let Some(symbol_id) = symbol_id else {
         return PluginSymbolResolution::Undef;
@@ -966,6 +971,11 @@ fn get_symbol_resolution<'data, C: ElfClass>(
     if symbol_id.is_undefined() {
         PluginSymbolResolution::Undef
     } else if sym.is_undefined() {
+        // Wrapped symbols are always reported as resolved outside IR.
+        if is_wrapped {
+            return PluginSymbolResolution::ResolvedExec;
+        }
+
         let defining_file = symbol_db.file(symbol_db.file_id_for_symbol(symbol_id));
 
         match defining_file {
@@ -992,6 +1002,9 @@ fn get_symbol_resolution<'data, C: ElfClass>(
         } else {
             PluginSymbolResolution::PrevailingDefIronly
         }
+    } else if is_wrapped {
+        // Wrapped symbols use the regular (non-IR) preemption codes.
+        PluginSymbolResolution::PreemptedReg
     } else {
         let defining_file = symbol_db.file(symbol_db.file_id_for_symbol(symbol_id));
         match defining_file {

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -608,6 +608,28 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
         }
     }
 
+    /// Restores name-table entries for wrapped symbols to their original (pre-wrap) definitions.
+    #[cfg(all(feature = "plugins", unix))]
+    pub(crate) fn restore_wrapped_symbol_names(&mut self) {
+        let wrap = self.args.symbol_names_to_wrap();
+        if wrap.is_empty() {
+            return;
+        }
+
+        let allocator = self.herd.get();
+
+        for name in wrap {
+            let name_bytes = allocator.alloc_slice_copy(name.as_bytes());
+            let real_name = allocator.alloc_slice_copy(format!("__real_{name}").as_bytes());
+
+            if let Some(orig_id) =
+                self.get_unversioned(&UnversionedSymbolName::prehashed(real_name))
+            {
+                self.override_name(UnversionedSymbolName::prehashed(name_bytes), orig_id);
+            }
+        }
+    }
+
     /// Overrides `name` to point to `symbol_id`. Returns the old symbol ID for `name`.
     fn override_name(
         &mut self,

--- a/wild/tests/sources/elf/wrap-lto-real/wrap-lto-real-def.c
+++ b/wild/tests/sources/elf/wrap-lto-real/wrap-lto-real-def.c
@@ -1,0 +1,1 @@
+int foo(void) { return 10; }

--- a/wild/tests/sources/elf/wrap-lto-real/wrap-lto-real-wrap.c
+++ b/wild/tests/sources/elf/wrap-lto-real/wrap-lto-real-wrap.c
@@ -1,0 +1,3 @@
+int __real_foo(void);
+
+int __wrap_foo(void) { return __real_foo() + 32; }

--- a/wild/tests/sources/elf/wrap-lto-real/wrap-lto-real.c
+++ b/wild/tests/sources/elf/wrap-lto-real/wrap-lto-real.c
@@ -1,0 +1,29 @@
+//#AbstractConfig:default
+//#RequiresLinkerPlugin:true
+//#Object:runtime.c
+//#Object:wrap-lto-real-def.c:-flto
+//#Object:wrap-lto-real-wrap.c
+//#ReferenceLinkers:
+//#LinkArgs:-flto -nostdlib -z now -Wl,-wrap,foo
+//#DiffIgnore:rel.R_X86_64_PC32.R_X86_64_PC32
+//#DiffIgnore:rel.R_AARCH64_CALL26.R_AARCH64_CALL26
+
+//#Config:gcc:default
+//#LinkerDriver:gcc
+
+//#Config:clang:default
+//#Compiler:clang
+//#LinkerDriver:clang
+//#ReferenceLinkers:lld
+
+#include "../common/runtime.h"
+
+int foo(void);
+
+void _start(void) {
+  runtime_init();
+  if (foo() != 42) {
+    exit_syscall(100);
+  }
+  exit_syscall(42);
+}


### PR DESCRIPTION
When `--wrap` redirected name lookup to `__wrap_*`, `get_symbol_resolution()` always reported IR definitions of the wrapped name as `PreemptedReg`. The plugin then dropped the original, so `__real_*` kept pointing at a disabled LTO input and relocation failed.

Fixes #1903 