### PR TITLE
fix: Don't consume the next argument for `--trace` / `-t`

### DIFF
--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -1603,11 +1603,11 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
         });
 
     parser
-        .declare_with_param()
+        .declare()
         .short("t")
         .long("trace")
         .help("Print opened input files")
-        .execute(|args, _modifier_stack, _value| {
+        .execute(|args, _modifier_stack| {
             args.trace = true;
             Ok(())
         });

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -41,9 +41,7 @@ tests = [
   "sort-debug-info-merged.sh",             # `-Map`
   "sort-debug-info.sh",                    # `-Map`
   "spare-program-headers.sh",
-  "static-archive.sh",                     # error: Undefined symbol main, passes with GNU ld
   "synthetic-symbols.sh",                  # `--image-base`
-  "thin-archive.sh",                       # error: Undefined symbol main, passes with GNU ld
   "trace-symbol-symver.sh",
   "trace-symbol.sh",
   "undefined-glob-gc-sections.sh",
@@ -198,6 +196,8 @@ tests = [
   "warn-unresolved-symbols.sh",     # Different message formats
   "whole-archive.sh",               # Passes when `--no-gc-sections` is passed.
   "z-defs.sh",                      # Different message formats
+  "thin-archive.sh",                # Different `--trace` output formats
+  "static-archive.sh",              # Different `--trace` output formats
 ]
 
 [skipped_groups.lto]


### PR DESCRIPTION
These options take no value, but declaring them with `declare_with_param()` causes them to consume the next argument.