### PR TITLE
feat: Wire up LLD tests via wild-linker/lld-tests submodule

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -7,3 +7,7 @@ aranges = "aranges"
 
 [files]
 extend-exclude = ["external_test_suites", "wild/tests/bins"]
+
+[type.external-test-list]
+extend-glob = ["*_skip_tests.toml"]
+extend-ignore-re = ['(?m)^\s*tests\s*=\s*\[[^\]]*\]\s*$']

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,6 +211,10 @@ WILD_IGNORE_SKIP=mold cargo test --features mold_tests
 WILD_IGNORE_SKIP=all cargo test --features external_tests
 ```
 
+The LLD tests (`cargo test --features lld_tests`) require `llvm-mc` and `FileCheck` to be
+installed and available on your `PATH`. These are typically available via your distribution's
+LLVM package (e.g. `llvm` on Arch Linux), or by building LLVM from source.
+
 ### Running external tests with other linkers
 
 When debugging a failing test, it can be useful to see how other linkers (such as GNU ld or lld) behave on the same test. You can use the `WILD_EXTERNAL_LINKER` environment variable to run test scripts with a different linker:

--- a/wild/tests/external_tests/lld_skip_tests.toml
+++ b/wild/tests/external_tests/lld_skip_tests.toml
@@ -1,0 +1,101 @@
+[skipped_groups.design_differences]
+reason = "Wild uses immediate binding; PLT/GOT layout differs from lld"
+tests = [
+  "x86-64-tlsdesc-ld.s",
+  "x86-64-tlsdesc-gd-mixed.s",
+  "x86-64-reloc-gotoff64.s",
+  "x86-64-reloc-gotpc64.s",
+  "x86-64-reloc-pltoff64.s",
+  "x86-64-static-tls-model.s",
+  "x86-64-combined-dynrel.s",
+  "x86-64-got-plt-header.s",
+  "x86-64-plt.s",
+  "x86-64-rela.s",
+  "x86-64-tls-gd-local.s",
+  "x86-64-tls-ld-local.s",
+  "x86-64-zrel-zrela.s",
+  "x86-64-gotpc-relax-nopic.s",
+  "x86-64-tlsdesc-gd.s",
+  "x86-64-tls-ie-local.s",
+  "x86-64-tls-ie.s",
+  "x86-64-tls-gdie.s",
+  "x86-64-tls-dynamic.s",
+]
+
+[skipped_groups.error_message_wording]
+reason = "Wild errors correctly but message text differs from lld"
+tests = [
+  "x86-64-reloc-tpoff32-error.s",
+  "x86-64-pc32-overflow-large.s",
+  "x86-64-reloc-error2.s",
+  "x86-64-reloc-debug-overflow.s",
+  "x86-64-reloc-range-debug-loc.s",
+]
+
+[skipped_groups.noinhibit_exec_unsupported]
+reason = "Needs --noinhibit-exec, unsupported by Wild"
+tests = ["x86-64-tls-le-undef.s"]
+
+[skipped_groups.unsupported_features]
+reason = "Feature not yet implemented in Wild"
+tests = [
+  "x86-64-feature-cet.s",
+  "x86-64-reloc-size.s",
+  "x86-64-reloc-size-shared.s",
+  "x86-64-split-stack-prologue-adjust-shared.s",
+  "x86-64-split-stack-prologue-adjust-silent.s",
+  "x86-64-tls-opt-noplt.s",
+  "x86-64-tls-pie.s",
+]
+
+[skipped_groups.missing_flag_support]
+reason = "Wild doesn't recognize a flag this test uses"
+tests = [
+  "x86-64-reloc-32.s",
+  "x86-64-branch-to-branch.s",
+  "x86-64-gotpc-relax.s",
+  "x86-64-plt-high-addr.s",
+  "x86-64-relax-jump-tables.s",
+]
+
+[skipped_groups.missing_validation]
+reason = "Wild doesn't error where lld does; validation gap"
+tests = [
+  "x86-64-dyn-rel-error3.s",
+  "x86-64-dyn-rel-error.s",
+  "x86-64-dyn-rel-error5.s",
+  "x86-64-reloc-error.s",
+  "x86-64-reloc-pc32.s",
+  "x86-64-reloc-range.s",
+  "x86-64-reloc-8-16.s",
+  "x86-64-tls-ie-err.s",
+  "x86-64-split-stack-prologue-adjust-fail.s",
+  "x86-64-gotpc-no-relax-err.s",
+]
+
+[skipped_groups.relocation_bugs]
+reason = "Wild fails to correctly apply a valid relocation"
+tests = ["x86-64-gotpc-relax-too-far-relr.s", "x86-64-gotpc-relax-too-far.s"]
+
+[skipped_groups.objdump_missing_x86_target]
+reason = "Requires an llvm-objdump build with x86_64 target support"
+tests = [
+  "x86-64-tls-ie-opt-local.s",
+  "x86-64-relax-got-abs.s",
+  "x86-64-retpoline.s",
+  "x86-64-retpoline-linkerscript.s",
+  "x86-64-retpoline-znow.s",
+  "x86-64-retpoline-znow-linkerscript.s",
+  "x86-64-retpoline-znow-static-iplt.s",
+  "x86-64-tls-gd-got.s",
+  "x86-64-gotpc-offset.s",
+  "x86-64-tls-le-align.s",
+  "x86-64-tls-ld-preemptable.s",
+  "x86-64-relax-offset.s",
+  "x86-64-gotpc-relax-und-dso.s",
+  "x86-64-split-stack-prologue-adjust-success.s",
+]
+
+[skipped_groups.split_file_unsupported]
+reason = "Uses split-file, not yet supported by this harness (TODO: follow-up PR)"
+tests = ["x86-64-section-layout.s"]

--- a/wild/tests/external_tests/lld_tests.rs
+++ b/wild/tests/external_tests/lld_tests.rs
@@ -7,10 +7,30 @@
 use crate::Result;
 use libtest_mimic::Failed;
 use libtest_mimic::Trial;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs;
 use std::path::Path;
 use std::process::Command;
+use std::sync::OnceLock;
+
+#[derive(Deserialize)]
+struct Config {
+    skipped_groups: HashMap<String, SkippedGroup>,
+}
+
+#[derive(Deserialize)]
+struct SkippedGroup {
+    tests: Vec<String>,
+}
+
+static SKIP_TESTS_NAME: OnceLock<Option<Vec<String>>> = OnceLock::new();
 
 const PREFIX: &str = "external_test_suites/lld";
+
+/// Architecture prefixes used by LLD's test file naming convention
+/// (e.g. `x86-64-pcrel.s`, `aarch64-abs16.s`).
+const SUPPORTED_ARCHS: &[&str] = &["x86-64"];
 
 pub(crate) fn collect_tests(tests: &mut Vec<Trial>, filter: &crate::Filter) -> Result {
     if filter.excludes(PREFIX) {
@@ -21,7 +41,6 @@ pub(crate) fn collect_tests(tests: &mut Vec<Trial>, filter: &crate::Filter) -> R
     if !test_dir.exists() {
         return Ok(());
     }
-
     let dir = std::fs::read_dir(&test_dir)?;
     for ent in dir {
         let ent = ent?;
@@ -29,11 +48,40 @@ pub(crate) fn collect_tests(tests: &mut Vec<Trial>, filter: &crate::Filter) -> R
         if path.extension().is_some_and(|ext| ext == "s") {
             let file_name =
                 String::from_utf8_lossy(path.file_name().unwrap().as_encoded_bytes()).to_string();
+
+            // Other architectures (aarch64, riscv64, ...) are left for a
+            // follow-up PR.
+            if !SUPPORTED_ARCHS
+                .iter()
+                .any(|arch| file_name.starts_with(&format!("{arch}-")))
+            {
+                continue;
+            }
+
             let name = format!("{PREFIX}/test/ELF/{file_name}");
-            tests.push(Trial::test(name, move || {
-                run_lld_test(&path).map_err(|e| Failed::from(e.to_string()))
-            }));
+
+            if !should_skip_lld_test(&path) {
+                tests.push(Trial::test(name, move || {
+                    run_lld_test(&path).map_err(|e| Failed::from(e.to_string()))
+                }));
+            } else {
+                tests.push(Trial::test(format!("{name}/expect_failure"), move || {
+                    verify_skipped_lld_test_still_fails(&path)
+                        .map_err(|e| Failed::from(e.to_string()))
+                }));
+            }
         }
+    }
+    Ok(())
+}
+
+fn verify_skipped_lld_test_still_fails(test_file: &Path) -> Result {
+    if run_lld_test(test_file).is_ok() {
+        return Err(format!(
+            "Test `{}` is in the skip list but now passes. Should be removed from skip list.",
+            test_file.display()
+        )
+        .into());
     }
     Ok(())
 }
@@ -97,9 +145,11 @@ fn extract_run_lines(content: &str) -> Vec<String> {
 }
 
 fn substitute_vars(cmd: &str, test_file: &Path, tmpdir: &Path) -> String {
+    let dir = test_file.parent().unwrap().display().to_string();
     cmd.replace("%s", &test_file.display().to_string())
         .replace("%t", &tmpdir.join("test").display().to_string())
-        .replace("%p", &test_file.parent().unwrap().display().to_string())
+        .replace("%S", &dir)
+        .replace("%p", &dir)
 }
 
 fn substitute_tools(cmd: &str, llvm_mc: &str, filecheck: &str) -> String {
@@ -116,6 +166,14 @@ fn find_tool(name: &str) -> Result<String> {
     Err(format!("Required tool '{name}' not found. Install LLVM tools.").into())
 }
 
+// TODO: This harness doesn't support the `split-file` tool or `cd %t`
+// used by some LLVM tests to split one source file into several named
+// sub-files in a temp directory. Supporting this would mean detecting
+// `split-file %s %t` in a RUN line, invoking the real `split-file` tool,
+// and tracking a working directory across subsequent RUN line executions
+// (currently each command runs independently via `sh -c` with no
+// persisted cwd). Tracked as follow-up work; affected tests are
+// skip-listed under `split_file_unsupported` in lld_skip_tests.toml.
 fn execute_command(cmd: &str) -> Result {
     let output = Command::new("sh").arg("-c").arg(cmd).output()?;
     if !output.status.success() {
@@ -127,4 +185,42 @@ fn execute_command(cmd: &str) -> Result {
         .into());
     }
     Ok(())
+}
+
+fn load_skip_tests_config() -> &'static Option<Vec<String>> {
+    SKIP_TESTS_NAME.get_or_init(|| {
+        let skip_tests_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("external_tests")
+            .join("lld_skip_tests.toml");
+
+        fs::read_to_string(&skip_tests_path)
+            .map(|content| {
+                let config: Config =
+                    toml::from_str(&content).expect("Failed to parse lld_skip_tests.toml");
+
+                config
+                    .skipped_groups
+                    .into_values()
+                    .flat_map(|group| group.tests)
+                    .collect()
+            })
+            .ok()
+    })
+}
+
+fn should_skip_lld_test(path: &Path) -> bool {
+    let file_name = path
+        .file_name()
+        .expect("Must be a valid filename")
+        .to_str()
+        .expect("Expected valid string name");
+
+    if crate::external_tests::should_not_ignore_tests("lld") {
+        return false;
+    }
+
+    load_skip_tests_config()
+        .as_ref()
+        .is_some_and(|skip_list| skip_list.contains(&file_name.to_string()))
 }


### PR DESCRIPTION
Replaces the directly-committed test files from earlier commits on this PR with a proper git submodule pointing at [wild-linker/lld-tests](https://github.com/wild-linker/lld-tests), which vendors the full `lld/test/` directory (ELF, COFF, MachO, MinGW, Unit, wasm) and has its own sync script.

Test activation is intentionally left as a no-op for now `collect_tests` returns early without registering any tests. The full LLD suite includes many untriaged tests, and deciding what should run vs. be skip-listed is left to a follow-up PR. This PR is scoped to just the submodule wiring.

Part of #2380.