### PR TITLE
chore: Remove an unused taplo config file

### DIFF
--- a/wild/tests/external_tests/taplo.toml
+++ b/wild/tests/external_tests/taplo.toml
@@ -1,4 +1,0 @@
-[formatting]
-align_entries = true
-allowed_blank_lines = 1
-reorder_arrays = true


### PR DESCRIPTION
`wild/tests/external_tests/taplo.toml` is not currently used for formatting checks in the tidy tests. It's just a leftover from the past. Since we do not have a strong reason to enforce these rules, it would be better to remove it.