### PR TITLE
feat: parse ASSERT in linker script expressions

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -5065,6 +5065,9 @@ fn write_internal_symbols<C: ElfClass>(
     symbol_writer: &mut SymbolTableWriter<'_, '_, C>,
 ) -> Result {
     for (local_index, def_info) in internal_symbols.symbol_definitions.iter().enumerate() {
+        if def_info.name.is_empty() {
+            continue;
+        }
         let symbol_id = internal_symbols.start_symbol_id.add_usize(local_index);
         if !layout.symbol_db.is_canonical(symbol_id) {
             continue;

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -4,12 +4,10 @@
 /// features. Symbol resolution and full location counter semantics (e.g. ALIGN with a non-zero
 /// current address) will be implemented in future work.
 use crate::bail;
-use crate::error::Context;
 use crate::error::Result;
-use crate::grouping::Group;
+use crate::input_data::InputRef;
 use crate::layout;
 use crate::layout::OutputRecordLayout;
-use crate::layout::Resolution;
 use crate::linker_script::Expression;
 use crate::output_section_id::OutputSections;
 use crate::output_section_id::SectionName;
@@ -26,62 +24,6 @@ fn line_number(file_bytes: &[u8], remainder: &[u8]) -> u32 {
     let parsed_len = file_bytes.len().saturating_sub(remainder.len());
     let consumed = &file_bytes[..parsed_len];
     consumed.iter().filter(|&&b| b == b'\n').count() as u32 + 1
-}
-
-/// Evaluate all ASSERT commands from all processed linker scripts.
-/// Must be called after layout is complete so section sizes/addresses are known.
-pub(crate) fn evaluate_assertions<'data, P: Platform>(
-    symbol_db: &SymbolDb<'data, P>,
-    section_layouts: &OutputSectionMap<OutputRecordLayout>,
-    output_sections: &OutputSections<'data, P>,
-    resolutions: &[Option<Resolution<P>>],
-    sizeof_headers: u64,
-    memory_regions: &HashMap<&[u8], layout::MemoryRegion>,
-    resolved_location_counters: &[ResolvedLocationCounter],
-) -> Result {
-    for group in &symbol_db.groups {
-        let Group::LinkerScripts(scripts) = group else {
-            continue;
-        };
-        for script in scripts {
-            let parsed = &script.parsed;
-            for assertion in &parsed.assertions {
-                let line = line_number(parsed.file_bytes, assertion.remainder);
-                let result = evaluate_expression(
-                    &assertion.expression,
-                    &SymbolLoc::None,
-                    section_layouts,
-                    output_sections,
-                    memory_regions,
-                    symbol_db,
-                    sizeof_headers,
-                    resolved_location_counters,
-                    &|name| {
-                        let Some(target_symbol_id) =
-                            symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(name))
-                        else {
-                            bail!(
-                                "Undefined symbol '{}' referenced in expression",
-                                String::from_utf8_lossy(name)
-                            );
-                        };
-
-                        let canonical_target_id = symbol_db.definition(target_symbol_id);
-                        Ok(resolutions[canonical_target_id.as_usize()]
-                            .as_ref()
-                            .map_or(0, |r| r.raw_value))
-                    },
-                )
-                .with_context(|| format!("{}:{}: Failed to evaluate ASSERT", parsed.input, line))?;
-
-                if result == 0 {
-                    let msg = String::from_utf8_lossy(assertion.message);
-                    bail!("{}:{}: {msg}", parsed.input, line);
-                }
-            }
-        }
-    }
-    Ok(())
 }
 
 #[derive(Clone, Default)]
@@ -129,6 +71,7 @@ fn evaluate_location<'data, P: Platform>(
 pub(crate) fn evaluate_expression<'data, P: Platform>(
     expr: &Expression<'data>,
     expr_loc: &SymbolLoc,
+    input_ref: Option<&InputRef<'data>>,
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
     output_sections: &OutputSections<'data, P>,
     memory_regions: &HashMap<&[u8], layout::MemoryRegion>,
@@ -141,6 +84,7 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
     let value = evaluate_expression_value(
         expr,
         expr_loc,
+        input_ref,
         section_layouts,
         output_sections,
         memory_regions,
@@ -175,6 +119,7 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
 fn evaluate_expression_value<'data, P: Platform>(
     expr: &Expression<'data>,
     expr_loc: &SymbolLoc,
+    input_ref: Option<&InputRef<'data>>,
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
     output_sections: &OutputSections<'data, P>,
     memory_regions: &HashMap<&[u8], layout::MemoryRegion>,
@@ -189,6 +134,7 @@ fn evaluate_expression_value<'data, P: Platform>(
             evaluate_expression_value(
                 $e,
                 expr_loc,
+                input_ref,
                 section_layouts,
                 output_sections,
                 memory_regions,
@@ -312,6 +258,18 @@ fn evaluate_expression_value<'data, P: Platform>(
         Expression::Defined(name) => Ok(symbol_db
             .get_unversioned(&UnversionedSymbolName::prehashed(name))
             .map_or(0, |_| 1)),
+        Expression::Assert(assert_command) => {
+            let result = eval!(&assert_command.expression)?;
+            if result == 0 {
+                let msg = String::from_utf8_lossy(assert_command.message);
+                let Some(input_ref) = input_ref else {
+                    bail!("{msg}");
+                };
+                let line = line_number(input_ref.data(), assert_command.remainder);
+                bail!("{}:{}: {msg}", input_ref, line);
+            }
+            Ok(result)
+        }
     }
 }
 
@@ -437,12 +395,15 @@ mod tests {
     use super::*;
     use crate::OsFileSystem;
     use crate::elf::Elf64;
-    use crate::grouping::Group;
     use crate::grouping::SequencedLinkerScript;
     use crate::input_data::FileId;
     use crate::layout::MemoryRegion;
     use crate::linker_script::AssertCommand;
+    use crate::parsing::InternalSymDefInfo;
     use crate::parsing::ProcessedLinkerScript;
+    use crate::parsing::Redirect;
+    use crate::parsing::RedirectKind;
+    use crate::parsing::SymbolPlacement;
     use crate::symbol_db::SymbolDb;
     use crate::symbol_db::SymbolIdRange;
     use colosseum::sync::Arena;
@@ -471,6 +432,7 @@ mod tests {
             evaluate_expression::<Elf64>(
                 expr,
                 &SymbolLoc::None,
+                None,
                 layouts,
                 sections,
                 &HashMap::new(),
@@ -791,17 +753,29 @@ mod tests {
         );
     }
 
-    fn make_group<'data>(assertions: Vec<AssertCommand<'static>>) -> Group<'data, Elf64> {
-        let script = SequencedLinkerScript {
+    fn make_script<'data>(
+        assertions: &[AssertCommand<'static>],
+    ) -> SequencedLinkerScript<'data, Elf64> {
+        SequencedLinkerScript {
             parsed: ProcessedLinkerScript {
                 input: crate::input_data::InputRef {
                     file: crate::input_data::InputFileRef::for_testing(),
                     data: &[],
                     entry: None,
                 },
-                symbol_defs: Vec::new(),
-                assertions,
-                file_bytes: b"",
+                symbol_defs: assertions
+                    .iter()
+                    .map(|assertion| {
+                        InternalSymDefInfo::new(
+                            SymbolPlacement::Redirect(Redirect {
+                                kind: RedirectKind::Script,
+                                expression: Expression::Assert(assertion.clone()),
+                                loc: SymbolLoc::None,
+                            }),
+                            b"",
+                        )
+                    })
+                    .collect(),
                 memory_regions: Vec::new(),
                 program_headers: Vec::new(),
                 location_counters: Vec::new(),
@@ -809,28 +783,55 @@ mod tests {
             },
             symbol_id_range: SymbolIdRange::empty(),
             file_id: FileId::new(0, 0),
-        };
-        Group::LinkerScripts(vec![script])
+        }
+    }
+
+    fn evaluate_assertions<'data>(
+        script: &SequencedLinkerScript<'data, Elf64>,
+        symbol_db: &SymbolDb<'data, Elf64>,
+        section_layouts: &OutputSectionMap<OutputRecordLayout>,
+        output_sections: &OutputSections<'data, Elf64>,
+        sizeof_headers: u64,
+        memory_regions: &HashMap<&[u8], layout::MemoryRegion>,
+        resolved_location_counters: &[ResolvedLocationCounter],
+    ) -> Result {
+        for assertion in &script.parsed.symbol_defs {
+            let SymbolPlacement::Redirect(redirect) = &assertion.placement else {
+                continue;
+            };
+            evaluate_expression(
+                &redirect.expression,
+                &SymbolLoc::None,
+                None,
+                section_layouts,
+                output_sections,
+                memory_regions,
+                symbol_db,
+                sizeof_headers,
+                resolved_location_counters,
+                &|_| unreachable!(),
+            )?;
+        }
+        Ok(())
     }
 
     #[test]
     fn test_evaluate_assertions_passes() {
         with_dummy_context(|layouts, sections, symbol_db| {
-            let group = make_group(vec![AssertCommand {
-                expression: Expression::Equal(
+            let script = make_script(&[AssertCommand {
+                expression: Box::new(Expression::Equal(
                     Box::new(Expression::Number(1)),
                     Box::new(Expression::Number(1)),
-                ),
+                )),
                 message: b"should pass",
                 remainder: b"",
             }]);
-            symbol_db.add_group(group);
             assert!(
-                evaluate_assertions::<Elf64>(
+                evaluate_assertions(
+                    &script,
                     symbol_db,
                     layouts,
                     sections,
-                    &[],
                     0,
                     &HashMap::new(),
                     &[]
@@ -843,17 +844,16 @@ mod tests {
     #[test]
     fn test_evaluate_assertions_fails() {
         with_dummy_context(|layouts, sections, symbol_db| {
-            let group = make_group(vec![AssertCommand {
-                expression: Expression::Number(0),
+            let script = make_script(&[AssertCommand {
+                expression: Box::new(Expression::Number(0)),
                 message: b"intentional failure",
                 remainder: b"",
             }]);
-            symbol_db.add_group(group);
-            let err = evaluate_assertions::<Elf64>(
+            let err = evaluate_assertions(
+                &script,
                 symbol_db,
                 layouts,
                 sections,
-                &[],
                 0,
                 &HashMap::new(),
                 &[],
@@ -888,6 +888,7 @@ mod tests {
                 evaluate_expression::<Elf64>(
                     expr,
                     &SymbolLoc::None,
+                    None,
                     layouts,
                     sections,
                     &regions,

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -431,22 +431,12 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>, F: FileSystem>(
         &mut symbol_resolutions.resolutions,
         &output_sections,
         &section_layouts,
+        &merged_section_layouts,
         sizeof_headers,
         &memory_regions,
         &resolved_location_counters,
     )?;
     crate::gc_stats::maybe_write_gc_stats(&group_layouts, &symbol_db)?;
-
-    // Evaluate ASSERT commands from all linker scripts now that layout is complete.
-    crate::expression_eval::evaluate_assertions(
-        &symbol_db,
-        &merged_section_layouts,
-        &output_sections,
-        &symbol_resolutions.resolutions,
-        sizeof_headers,
-        &memory_regions,
-        &resolved_location_counters,
-    )?;
 
     let thunk_block_addresses = thunk_block_addresses_out
         .into_iter()
@@ -507,6 +497,7 @@ fn update_redirect_resolutions<'data, P: Platform>(
     resolutions: &mut [Option<Resolution<P>>],
     output_sections: &OutputSections<'data, P>,
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
+    merged_section_layouts: &OutputSectionMap<OutputRecordLayout>,
     sizeof_headers: u64,
     memory_regions: &HashMap<&[u8], MemoryRegion>,
     resolved_location_counters: &[ResolvedLocationCounter],
@@ -518,11 +509,12 @@ fn update_redirect_resolutions<'data, P: Platform>(
             Group::Prelude(prelude) => {
                 for def_info in &prelude.symbol_definitions {
                     update_defsym_symbol_resolution(
+                        None,
                         def_info,
                         symbol_db,
                         resolutions,
                         output_sections,
-                        section_layouts,
+                        merged_section_layouts,
                         memory_regions,
                         sizeof_headers,
                         &[],
@@ -532,7 +524,21 @@ fn update_redirect_resolutions<'data, P: Platform>(
             Group::LinkerScripts(scripts) => {
                 for script in scripts {
                     for def_info in &script.parsed.symbol_defs {
+                        let SymbolPlacement::Redirect(redirect) = &def_info.placement else {
+                            continue;
+                        };
+                        let section_layouts = if matches!(
+                            redirect.loc,
+                            SymbolLoc::SectionStartRelative(_)
+                                | SymbolLoc::SectionEndRelative(_)
+                                | SymbolLoc::LocationCounter(..)
+                        ) {
+                            section_layouts
+                        } else {
+                            merged_section_layouts
+                        };
                         update_defsym_symbol_resolution(
+                            Some(&script.parsed.input),
                             def_info,
                             symbol_db,
                             resolutions,
@@ -555,6 +561,7 @@ fn update_redirect_resolutions<'data, P: Platform>(
 }
 
 fn update_defsym_symbol_resolution<'data, P: Platform>(
+    input_ref: Option<&InputRef<'data>>,
     def_info: &InternalSymDefInfo<'data, P>,
     symbol_db: &SymbolDb<'data, P>,
     resolutions: &mut [Option<Resolution<P>>],
@@ -565,9 +572,20 @@ fn update_defsym_symbol_resolution<'data, P: Platform>(
     resolved_location_counters: &[ResolvedLocationCounter],
 ) -> Result {
     if let SymbolPlacement::Redirect(redirect) = &def_info.placement {
+        let current_section_base = match redirect.loc {
+            SymbolLoc::SectionStartRelative(id)
+            | SymbolLoc::SectionEndRelative(id)
+            | SymbolLoc::LocationCounter(_, Some(id)) => {
+                let primary_id = output_sections.primary_output_section(id);
+                Some(section_layouts.get(primary_id).mem_offset)
+            }
+            _ => None,
+        };
+
         let value = crate::expression_eval::evaluate_expression(
             &redirect.expression,
             &redirect.loc,
+            input_ref,
             section_layouts,
             output_sections,
             memory_regions,
@@ -587,9 +605,19 @@ fn update_defsym_symbol_resolution<'data, P: Platform>(
                     .as_ref()
                     .ok_or_else(|| redirect.missing_resolution(name))?;
 
+                if let Some(section_base) = current_section_base
+                    && resolution.raw_value >= section_base
+                {
+                    return Ok(resolution.raw_value - section_base);
+                }
+
                 Ok(resolution.raw_value)
             },
         )?;
+
+        if def_info.name.is_empty() {
+            return Ok(());
+        }
 
         let canonical_symbol_id = symbol_db
             .get_unversioned(&UnversionedSymbolName::prehashed(def_info.name))
@@ -3301,6 +3329,10 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
             extra_sizes,
             symbol_db,
             |symbol_id, def_info| {
+                if def_info.name.is_empty() {
+                    return false;
+                }
+
                 let flags = per_symbol_flags.flags_for_symbol(symbol_id);
 
                 // If the symbol is referenced, then we keep it.
@@ -3644,6 +3676,10 @@ impl<'data, P: Platform> InternalSymbols<'data, P> {
                 _ => {}
             }
 
+            if def_info.name.is_empty() {
+                continue;
+            }
+
             resources
                 .per_symbol_flags
                 .get_atomic(symbol_id)
@@ -3665,6 +3701,9 @@ impl<'data, P: Platform> InternalSymbols<'data, P> {
     ) -> Result {
         // Allocate space in the symbol table for the symbols that we define.
         for (index, def_info) in self.symbol_definitions.iter().enumerate() {
+            if def_info.name.is_empty() {
+                continue;
+            }
             let symbol_id = self.start_symbol_id.add_usize(index);
             if !symbol_db.is_canonical(symbol_id) || symbol_id.is_undefined() {
                 continue;
@@ -3708,7 +3747,7 @@ fn create_internal_symbol_resolution<'data, P: Platform>(
     def_info: &InternalSymDefInfo<P>,
     symbol_id: SymbolId,
 ) -> Option<Resolution<P>> {
-    if !resources.symbol_db.is_canonical(symbol_id) {
+    if def_info.name.is_empty() || !resources.symbol_db.is_canonical(symbol_id) {
         return None;
     }
 
@@ -5288,6 +5327,7 @@ fn compute_layout_sections<'data, P: Platform>(
         crate::expression_eval::evaluate_expression(
             expr,
             loc,
+            None,
             section_layouts,
             output_sections,
             memory_regions,

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -388,6 +388,14 @@ impl<'data> LayoutRulesBuilder<'data> {
                                     // On ELF it is a nop.
                                     // (https://sourceware.org/binutils/docs/ld/Output-Section-Keywords.html#index-CONSTRUCTORS)
                                     ContentsCommand::Constructors => (),
+                                    ContentsCommand::Assert(assert_cmd) => {
+                                        let placement = SymbolPlacement::Redirect(Redirect {
+                                            kind: RedirectKind::Script,
+                                            expression: Expression::Assert(assert_cmd.clone()),
+                                            loc: last_symbol_loc.clone(),
+                                        });
+                                        symbol_defs.push(InternalSymDefInfo::new(placement, b""));
+                                    }
                                 }
                             }
                             if inner_lc_idx > inner_lc_start_idx {

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -15,6 +15,7 @@ use crate::input_data::InputLinkerScript;
 use crate::input_data::InputRef;
 use crate::linker_script;
 use crate::linker_script::ContentsCommand;
+use crate::linker_script::Expression;
 use crate::linker_script::SectionCommand;
 use crate::output_section_id::OutputSectionId;
 use crate::output_section_id::SectionIdentity;
@@ -188,7 +189,6 @@ impl<'data> LayoutRulesBuilder<'data> {
         args: &P::Args,
     ) -> Result<ProcessedLinkerScript<'data, P>> {
         let mut symbol_defs = Vec::new();
-        let mut assertions = Vec::new();
         let mut memory_regions = Vec::new();
         let mut program_headers = Vec::new();
         let mut location_counters = Vec::new();
@@ -216,6 +216,13 @@ impl<'data> LayoutRulesBuilder<'data> {
                     loc: loc_for_global_expr(value, current_section_id),
                 });
                 symbol_defs.push(crate::parsing::InternalSymDefInfo::new(placement, name));
+            } else if let linker_script::Command::SetLocation(loc) = cmd {
+                let placement = SymbolPlacement::Redirect(Redirect {
+                    kind: RedirectKind::Script,
+                    expression: loc.address.clone(),
+                    loc: loc_for_global_expr(&loc.address, current_section_id),
+                });
+                symbol_defs.push(crate::parsing::InternalSymDefInfo::new(placement, b""));
             } else if let linker_script::Command::Sections(sections) = cmd {
                 let mut section_start_lc_idx = last_lc_idx;
                 let mut prev_phdrs = Vec::new();
@@ -411,7 +418,12 @@ impl<'data> LayoutRulesBuilder<'data> {
                             last_lc_idx += 1;
                         }
                         SectionCommand::Assert(assert_cmd) => {
-                            assertions.push(assert_cmd.clone());
+                            let placement = SymbolPlacement::Redirect(Redirect {
+                                kind: RedirectKind::Script,
+                                expression: Expression::Assert(assert_cmd.clone()),
+                                loc: loc.clone(),
+                            });
+                            symbol_defs.push(InternalSymDefInfo::new(placement, b""));
                         }
                         SectionCommand::Provide(provide) => {
                             let placement = SymbolPlacement::Redirect(Redirect {
@@ -435,7 +447,12 @@ impl<'data> LayoutRulesBuilder<'data> {
                     }
                 }
             } else if let linker_script::Command::Assert(assert_cmd) = cmd {
-                assertions.push(assert_cmd.clone());
+                let placement = SymbolPlacement::Redirect(Redirect {
+                    kind: RedirectKind::Script,
+                    expression: Expression::Assert(assert_cmd.clone()),
+                    loc: loc_for_global_expr(&assert_cmd.expression, None),
+                });
+                symbol_defs.push(InternalSymDefInfo::new(placement, b""));
             } else if let linker_script::Command::Memory(regions) = cmd {
                 memory_regions = regions.clone();
             } else if let linker_script::Command::Phdrs(phdrs) = cmd {
@@ -469,13 +486,11 @@ impl<'data> LayoutRulesBuilder<'data> {
 
         Ok(ProcessedLinkerScript {
             symbol_defs,
-            assertions,
             input: InputRef {
                 file: input.input_file,
                 data: input.script_bytes,
                 entry: None,
             },
-            file_bytes: input.script_bytes,
             memory_regions,
             program_headers,
             location_counters,

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -72,6 +72,7 @@ pub(crate) enum Command<'a> {
         name: &'a [u8],
         value: Expression<'a>,
     },
+    SetLocation(Location<'a>),
     Provide(ProvideSymbolDefinition<'a>),
     Assert(AssertCommand<'a>),
     Memory(Vec<MemoryRegion<'a>>),
@@ -157,7 +158,7 @@ pub(crate) struct ProvideSymbolDefinition<'a> {
 
 #[derive(Debug, Clone)]
 pub(crate) struct AssertCommand<'a> {
-    pub(crate) expression: Expression<'a>,
+    pub(crate) expression: Box<Expression<'a>>,
     pub(crate) message: &'a [u8],
     /// Remaining input at the point this ASSERT was parsed. Used to lazily compute
     /// the line number only when an error occurs.
@@ -258,6 +259,7 @@ pub(crate) enum Expression<'a> {
         Box<Expression<'a>>,
     ),
     Defined(&'a [u8]),
+    Assert(AssertCommand<'a>),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -318,7 +320,8 @@ impl<'a> Expression<'a> {
             Expression::Align(e)
             | Expression::LogicalNot(e)
             | Expression::BitwiseNot(e)
-            | Expression::Negate(e) => e.visit_expressions(cb),
+            | Expression::Negate(e)
+            | Expression::Assert(AssertCommand { expression: e, .. }) => e.visit_expressions(cb),
             Expression::SegmentStart(_, default_expr) => default_expr.visit_expressions(cb),
             Expression::Ternary(expression, expression1, expression2) => {
                 expression.visit_expressions(cb);
@@ -414,7 +417,12 @@ fn parse_command<'input>(input: &mut &'input BStr) -> winnow::Result<Command<'in
         b"VERSION" => Command::Version(parse_version(input)?),
         b"PROVIDE" => Command::Provide(parse_provide(input, false)?),
         b"PROVIDE_HIDDEN" => Command::Provide(parse_provide(input, true)?),
-        b"ASSERT" => Command::Assert(parse_assert(input)?),
+        b"ASSERT" => {
+            let assert = parse_assert(input)?;
+            opt(';').parse_next(input)?;
+            skip_comments_and_whitespace(input)?;
+            Command::Assert(assert)
+        }
         b"MEMORY" => Command::Memory(parse_memory(input)?),
         b"PHDRS" => Command::Phdrs(parse_phdrs(input)?),
         other => {
@@ -424,9 +432,14 @@ fn parse_command<'input>(input: &mut &'input BStr) -> winnow::Result<Command<'in
                 let value = parse_expression.parse_next(input)?;
                 skip_comments_and_whitespace(input)?;
                 opt(';').parse_next(input)?;
-                Command::SymbolDefinition {
-                    name: other,
-                    value: op.expand(other, value),
+                let expanded = op.expand(other, value);
+                if other == b"." {
+                    Command::SetLocation(Location { address: expanded })
+                } else {
+                    Command::SymbolDefinition {
+                        name: other,
+                        value: expanded,
+                    }
                 }
             } else {
                 Command::Arg(other)
@@ -481,11 +494,9 @@ fn parse_assert<'input>(input: &mut &'input BStr) -> winnow::Result<AssertComman
     skip_comments_and_whitespace(input)?;
     ')'.parse_next(input)?;
     skip_comments_and_whitespace(input)?;
-    opt(';').parse_next(input)?;
-    skip_comments_and_whitespace(input)?;
 
     Ok(AssertCommand {
-        expression,
+        expression: Box::new(expression),
         message,
         remainder,
     })
@@ -926,7 +937,7 @@ fn parse_identifier_or_function<'a>(input: &mut &'a BStr) -> winnow::Result<Expr
     multispace0.parse_next(input)?;
 
     // Check if it's a function call
-    if opt('(').parse_next(input)?.is_some() {
+    if input.starts_with(b"(") {
         multispace0.parse_next(input)?;
 
         match ident {
@@ -955,6 +966,7 @@ fn parse_identifier_or_function<'a>(input: &mut &'a BStr) -> winnow::Result<Expr
                 Ok(Expression::Loadaddr(arg))
             }
             b"ALIGN" => {
+                '('.parse_next(input)?;
                 let arg_expr = parse_expression.parse_next(input)?;
                 multispace0.parse_next(input)?;
                 ')'.parse_next(input)?;
@@ -962,6 +974,7 @@ fn parse_identifier_or_function<'a>(input: &mut &'a BStr) -> winnow::Result<Expr
             }
             b"MIN" => {
                 // MIN takes two expressions separated by comma
+                '('.parse_next(input)?;
                 let first = parse_expression.parse_next(input)?;
                 multispace0.parse_next(input)?;
                 ','.parse_next(input)?;
@@ -973,6 +986,7 @@ fn parse_identifier_or_function<'a>(input: &mut &'a BStr) -> winnow::Result<Expr
             }
             b"MAX" => {
                 // MAX takes two expressions separated by comma
+                '('.parse_next(input)?;
                 let first = parse_expression.parse_next(input)?;
                 multispace0.parse_next(input)?;
                 ','.parse_next(input)?;
@@ -983,6 +997,7 @@ fn parse_identifier_or_function<'a>(input: &mut &'a BStr) -> winnow::Result<Expr
                 Ok(Expression::Max(Box::new(first), Box::new(second)))
             }
             b"SEGMENT_START" => {
+                '('.parse_next(input)?;
                 multispace0.parse_next(input)?;
                 '"'.parse_next(input)?;
                 let name = take_while(1.., |b: u8| b != b'"')
@@ -1005,6 +1020,10 @@ fn parse_identifier_or_function<'a>(input: &mut &'a BStr) -> winnow::Result<Expr
                 let symbol = parse_function_arg.parse_next(input)?;
                 Ok(Expression::Defined(symbol))
             }
+            b"ASSERT" => {
+                let assert = parse_assert.parse_next(input)?;
+                Ok(Expression::Assert(assert))
+            }
             _ => Err(ContextError::default()),
         }
     } else if ident == b"SIZEOF_HEADERS" {
@@ -1017,6 +1036,7 @@ fn parse_identifier_or_function<'a>(input: &mut &'a BStr) -> winnow::Result<Expr
 
 /// Parse a function argument (section name for SIZEOF/ADDR)
 fn parse_function_arg<'a>(input: &mut &'a BStr) -> winnow::Result<&'a [u8]> {
+    '('.parse_next(input)?;
     multispace0.parse_next(input)?;
 
     // Section names: start with '.', letter, or underscore
@@ -1182,7 +1202,10 @@ fn parse_section_command<'input>(
     // Handle ASSERT command
     match name {
         b"ASSERT" => {
-            return Ok(SectionCommand::Assert(parse_assert(input)?));
+            let assert = parse_assert(input)?;
+            opt(';').parse_next(input)?;
+            skip_comments_and_whitespace(input)?;
+            return Ok(SectionCommand::Assert(assert));
         }
         b"PROVIDE" => {
             return Ok(SectionCommand::Provide(parse_provide(input, false)?));
@@ -2024,10 +2047,10 @@ mod tests {
                         })],
                     }),
                     Command::Assert(AssertCommand {
-                        expression: Expression::LessThan(
+                        expression: Box::new(Expression::LessThan(
                             Box::new(Expression::LocationCounter),
                             Box::new(Expression::Number(0x10000)),
-                        ),
+                        )),
                         message: b"Output too large",
                         remainder: b"",
                     }),
@@ -2067,10 +2090,10 @@ mod tests {
                             attributes: None,
                         }),
                         SectionCommand::Assert(AssertCommand {
-                            expression: Expression::LessThan(
+                            expression: Box::new(Expression::LessThan(
                                 Box::new(Expression::Sizeof(b".text")),
                                 Box::new(Expression::Number(0x1000)),
-                            ),
+                            )),
                             message: b"Text section too large",
                             remainder: b"",
                         }),
@@ -2089,7 +2112,7 @@ mod tests {
         match &script.commands[0] {
             Command::Assert(assert_cmd) => {
                 assert_eq!(
-                    assert_cmd.expression,
+                    *assert_cmd.expression,
                     Expression::LessEqual(
                         Box::new(Expression::Subtract(
                             Box::new(Expression::Symbol(b"__bss_end")),
@@ -2112,7 +2135,7 @@ mod tests {
         match &script.commands[0] {
             Command::Assert(assert_cmd) => {
                 assert_eq!(
-                    assert_cmd.expression,
+                    *assert_cmd.expression,
                     Expression::Equal(
                         Box::new(Expression::Add(
                             Box::new(Expression::Number(1)),
@@ -2142,8 +2165,8 @@ mod tests {
         match &script.commands[0] {
             Command::Assert(assert_cmd) => {
                 // Verify it parsed as LessThan with MIN function
-                assert_matches!(assert_cmd.expression, Expression::LessThan(_, _));
-                if let Expression::LessThan(left, _) = &assert_cmd.expression {
+                assert_matches!(*assert_cmd.expression, Expression::LessThan(_, _));
+                if let Expression::LessThan(left, _) = &*assert_cmd.expression {
                     // The left side should be a MIN expression with two SIZEOF calls
                     assert_matches!(**left, Expression::Min(_, _));
                 }
@@ -2160,7 +2183,7 @@ mod tests {
         match &script.commands[0] {
             Command::Assert(assert_cmd) => {
                 assert_eq!(
-                    assert_cmd.expression,
+                    *assert_cmd.expression,
                     Expression::Equal(
                         Box::new(Expression::BitwiseAnd(
                             Box::new(Expression::Number(0xFF)),
@@ -2179,8 +2202,8 @@ mod tests {
         match &script.commands[0] {
             Command::Assert(assert_cmd) => {
                 // The == binds loosest, so the top level is Equal
-                assert_matches!(assert_cmd.expression, Expression::Equal(_, _));
-                if let Expression::Equal(left, _) = &assert_cmd.expression {
+                assert_matches!(*assert_cmd.expression, Expression::Equal(_, _));
+                if let Expression::Equal(left, _) = &*assert_cmd.expression {
                     // Left side should be BitwiseOr(1, BitwiseXor(2, 3))
                     assert_matches!(**left, Expression::BitwiseOr(_, _));
                     if let Expression::BitwiseOr(or_left, or_right) = &**left {
@@ -2201,7 +2224,7 @@ mod tests {
         match &script.commands[0] {
             Command::Assert(assert_cmd) => {
                 assert_eq!(
-                    assert_cmd.expression,
+                    *assert_cmd.expression,
                     Expression::Equal(
                         Box::new(Expression::LeftShift(
                             Box::new(Expression::Number(1)),
@@ -2224,7 +2247,7 @@ mod tests {
         match &script.commands[0] {
             Command::Assert(assert_cmd) => {
                 assert_eq!(
-                    assert_cmd.expression,
+                    *assert_cmd.expression,
                     Expression::LogicalOr(
                         Box::new(Expression::LogicalAnd(
                             Box::new(Expression::Number(1)),
@@ -2245,7 +2268,7 @@ mod tests {
         match &script.commands[0] {
             Command::Assert(assert_cmd) => {
                 assert_eq!(
-                    assert_cmd.expression,
+                    *assert_cmd.expression,
                     Expression::LogicalNot(Box::new(Expression::Number(0)))
                 );
             }
@@ -2257,7 +2280,7 @@ mod tests {
         match &script.commands[0] {
             Command::Assert(assert_cmd) => {
                 assert_eq!(
-                    assert_cmd.expression,
+                    *assert_cmd.expression,
                     Expression::Equal(
                         Box::new(Expression::BitwiseNot(Box::new(Expression::Number(0xFF)))),
                         Box::new(Expression::Number(0)),
@@ -2272,7 +2295,7 @@ mod tests {
         match &script.commands[0] {
             Command::Assert(assert_cmd) => {
                 assert_eq!(
-                    assert_cmd.expression,
+                    *assert_cmd.expression,
                     Expression::Equal(
                         Box::new(Expression::Negate(Box::new(Expression::Number(1)))),
                         Box::new(Expression::Number(0)),
@@ -2290,7 +2313,7 @@ mod tests {
         let script = parse_script(r#"ASSERT(~0xFF & 0xFF == 0, "unary precedence");"#).unwrap();
         match &script.commands[0] {
             Command::Assert(assert_cmd) => {
-                if let Expression::Equal(left, _) = &assert_cmd.expression {
+                if let Expression::Equal(left, _) = &*assert_cmd.expression {
                     assert_eq!(
                         **left,
                         Expression::BitwiseAnd(
@@ -2312,7 +2335,7 @@ mod tests {
         match &script.commands[0] {
             Command::Assert(assert_cmd) => {
                 assert_eq!(
-                    assert_cmd.expression,
+                    *assert_cmd.expression,
                     Expression::Equal(
                         Box::new(Expression::Alignof(b".text")),
                         Box::new(Expression::Number(8)),
@@ -2329,7 +2352,7 @@ mod tests {
         match &script.commands[0] {
             Command::Assert(assert_cmd) => {
                 assert_eq!(
-                    assert_cmd.expression,
+                    *assert_cmd.expression,
                     Expression::Equal(
                         Box::new(Expression::Loadaddr(b".text")),
                         Box::new(Expression::Number(8)),
@@ -2392,7 +2415,7 @@ mod tests {
                 panic!()
             };
             assert_eq!(
-                cmd.expression,
+                *cmd.expression,
                 Expression::Equal(
                     Box::new(expected_fn),
                     Box::new(Expression::Number(expected_val))

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -141,6 +141,7 @@ pub(crate) enum ContentsCommand<'a> {
     Provide(ProvideSymbolDefinition<'a>),
     SetLocation(Location<'a>),
     Constructors,
+    Assert(AssertCommand<'a>),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -1202,10 +1203,7 @@ fn parse_section_command<'input>(
     // Handle ASSERT command
     match name {
         b"ASSERT" => {
-            let assert = parse_assert(input)?;
-            opt(';').parse_next(input)?;
-            skip_comments_and_whitespace(input)?;
-            return Ok(SectionCommand::Assert(assert));
+            return Ok(SectionCommand::Assert(parse_assert(input)?));
         }
         b"PROVIDE" => {
             return Ok(SectionCommand::Provide(parse_provide(input, false)?));
@@ -1354,6 +1352,7 @@ fn parse_contents_command<'input>(
 ) -> winnow::Result<ContentsCommand<'input>> {
     alt((
         parse_contents_provide,
+        parse_contents_assert,
         parse_matcher,
         parse_assignment,
         parse_constructors,
@@ -1476,6 +1475,17 @@ fn parse_pattern<'input>(input: &mut &'input BStr) -> winnow::Result<SectionPatt
     }
 
     Ok(SectionPattern { name, sorted })
+}
+
+fn parse_contents_assert<'input>(
+    input: &mut &'input BStr,
+) -> winnow::Result<ContentsCommand<'input>> {
+    "ASSERT".parse_next(input)?;
+    skip_comments_and_whitespace(input)?;
+    let assert = parse_assert(input)?;
+    opt(';').parse_next(input)?;
+    skip_comments_and_whitespace(input)?;
+    Ok(ContentsCommand::Assert(assert))
 }
 
 /// Call `cb` for each input file requested by `commands`.
@@ -2065,7 +2075,7 @@ mod tests {
             r#"
             SECTIONS {
                 .text : { *(.text) }
-                ASSERT(SIZEOF(.text) < 0x1000, "Text section too large");
+                ASSERT(SIZEOF(.text) < 0x1000, "Text section too large")
             }
             "#,
             &LinkerScript {

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -52,10 +52,6 @@ pub(crate) struct ParsedInputObject<'data, P: Platform> {
 pub(crate) struct ProcessedLinkerScript<'data, P: Platform> {
     pub(crate) input: InputRef<'data>,
     pub(crate) symbol_defs: Vec<InternalSymDefInfo<'data, P>>,
-    pub(crate) assertions: Vec<crate::linker_script::AssertCommand<'data>>,
-    /// Raw bytes of the linker script file. Used to compute line numbers from
-    /// `AssertCommand::remainder` when reporting errors.
-    pub(crate) file_bytes: &'data [u8],
     pub(crate) memory_regions: Vec<crate::linker_script::MemoryRegion<'data>>,
     pub(crate) program_headers: Vec<crate::linker_script::Phdr<'data>>,
     pub(crate) location_counters: Vec<LocationCounter<'data>>,

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -1661,13 +1661,15 @@ fn load_linker_script_symbols<'data, P: Platform>(
     for (offset, definition) in script.parsed.symbol_defs.iter().enumerate() {
         let symbol_id = script.symbol_id_range.offset_to_id(offset);
 
-        outputs.add_non_versioned(PendingSymbol::from_prehashed(
-            symbol_id,
-            PreHashed::new(
-                UnversionedSymbolName::new(definition.name),
-                hash_bytes(definition.name),
-            ),
-        ));
+        if !definition.name.is_empty() {
+            outputs.add_non_versioned(PendingSymbol::from_prehashed(
+                symbol_id,
+                PreHashed::new(
+                    UnversionedSymbolName::new(definition.name),
+                    hash_bytes(definition.name),
+                ),
+            ));
+        }
 
         let mut flags = ValueFlags::NON_INTERPOSABLE;
         // PROVIDE_HIDDEN symbols have hidden visibility, which means they should be

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.c
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.c
@@ -4,7 +4,9 @@
 //#Object:runtime.c
 // RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
 //#SkipArch:riscv64
+//#ExpectSym:symbol10 section=".data",offset-in-section=0x10040
 //#ExpectSym:symbol11 address=0x80
+//#ExpectSym:symbol10_assert section=".data",offset-in-section=1
 //#ExpectSym:symbol11_assert address=0x1
 
 #include "../common/runtime.h"

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.c
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.c
@@ -5,6 +5,7 @@
 // RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
 //#SkipArch:riscv64
 //#ExpectSym:symbol11 address=0x80
+//#ExpectSym:symbol11_assert address=0x1
 
 #include "../common/runtime.h"
 

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
@@ -9,7 +9,7 @@ SECTIONS {
     symbol11_assert = ASSERT(symbol11 == 0x100, "symbol11 must be 0x100");
     symbol11 -= 0x20;
     symbol11 &= 0x80;
-    symbol11_assert = ASSERT(symbol11 == 0x80, "symbol11 must be 0x80");
+    ASSERT(symbol11 == 0x80, "symbol11 must be 0x80")
     .data : {
         *(.data*)
         symbol10 = 0x100;

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
@@ -6,11 +6,14 @@ SECTIONS {
         symbol3 = 0x3000;
     }
     symbol11 = 0x100;
+    symbol11_assert = ASSERT(symbol11 == 0x100, "symbol11 must be 0x100");
     symbol11 -= 0x20;
     symbol11 &= 0x80;
+    symbol11_assert = ASSERT(symbol11 == 0x80, "symbol11 must be 0x80");
     .data : {
         *(.data*)
         symbol10 = 0x100;
+        symbol10_assert = ASSERT(symbol10 == 0x100, "symbol10 must be 0x100");
         symbol10 *= 0x100;
         symbol10 ^= 0x40;
         ASSERT(symbol10 == 0x10040, "symbol10 must be 0x10040");
@@ -57,7 +60,11 @@ ASSERT(!DEFINED(symbol8), "symbol8 should not be defined");
 
 symbol9 = 0x8;
 symbol9 += 0x10;
+ASSERT(symbol9 == 0x18, "symbol9 must be 0x18");
 symbol9 /= 0x2;
 symbol9 <<= 0x3;
 symbol9 |= 0x100;
 ASSERT(symbol9 == 0x160, "symbol9 must be 0x160");
+
+symbol12 = ASSERT(ASSERT(0x5000 < 0x10000, "0x5000 < 0x10000 must be true") == 1, "ASSERT must return 1");
+. = ASSERT(symbol12 == 1, "must be 1");


### PR DESCRIPTION
Treat `ASSERT` as a symbol definition without a symbol name. This lets us do the following:
- An `ASSERT` statement can be used within a symbol definition/location counter
- Multiple asserts on the same symbol, with different values now work, example:
```ld
foo = 1;
ASSERT(foo == 1, "foo should be 1");
foo = 10;
ASSERT(foo == 10, "foo should be 10");
```