### PR TITLE
port(wasm): Add support for `--export-if-defined`

### DIFF
--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -35,6 +35,7 @@ pub struct WasmArgs {
     pub(crate) common: super::CommonArgs,
     pub(crate) lib_search_path: Vec<Box<Path>>,
     pub(crate) export_symbols: Vec<String>,
+    pub(crate) required_export_symbols: Vec<String>,
     pub(crate) export_memory: Option<String>,
     pub(crate) z_stack_size: u32,
     // Since LLVM 22, the default option is true.
@@ -70,6 +71,7 @@ impl Default for WasmArgs {
             common: CommonArgs::default(),
             lib_search_path: Vec::new(),
             export_symbols: Vec::new(),
+            required_export_symbols: Vec::new(),
             z_stack_size: DEFAULT_STACK_SIZE,
             stack_first: true,
             entry: Some(DEFAULT_ENTRY.to_owned()),
@@ -241,6 +243,17 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
         .declare_with_param()
         .long("export")
         .help("Force a symbol to be exported")
+        .execute(|args, _modifier_stack, value| {
+            let value = value.to_owned();
+            args.export_symbols.push(value.clone());
+            args.required_export_symbols.push(value);
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("export-if-defined")
+        .help("Export a symbol if it is defined")
         .execute(|args, _modifier_stack, value| {
             args.export_symbols.push(value.to_owned());
             Ok(())
@@ -444,5 +457,24 @@ mod tests {
         let args = parse_args(["--export", "__main_void", "-o", "out.wasm"]);
         assert_eq!(args.export_symbols, ["__main_void"]);
         assert_eq!(args.common.inputs, []);
+    }
+
+    #[test]
+    fn export_if_defined() {
+        let args = parse_args([
+            "--export-if-defined",
+            "foo",
+            "--export=bar",
+            "--export-if-defined=baz",
+            "-o",
+            "out.wasm",
+        ]);
+
+        assert_eq!(args.export_symbols, ["foo", "bar", "baz"]);
+        assert_eq!(args.required_export_symbols, ["bar"]);
+        assert_eq!(
+            Args::force_export_symbol_names(&args),
+            ["foo", "bar", "baz"]
+        );
     }
 }

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -5499,7 +5499,7 @@ fn ensure_entry_export<'data>(
     });
 }
 
-/// Export symbols requested via `--export`.
+/// Export symbols requested via `--export` and `--export-if-defined`.
 fn ensure_force_exports<'data>(
     exports: &mut Vec<OutputExport<'data>>,
     layout_inputs: &[WasmObjectLayoutInput<'data>],
@@ -5509,10 +5509,14 @@ fn ensure_force_exports<'data>(
     entry_wrapper_func: Option<u32>,
 ) -> Result<()> {
     for name in symbol_db.args.force_export_symbol_names() {
+        let required = symbol_db.args.required_export_symbols.contains(name);
         let Some(symbol_id) =
             symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(name.as_bytes()))
         else {
-            bail!("symbol exported via --export not found: {name}");
+            if required {
+                bail!("symbol exported via --export not found: {name}");
+            }
+            continue;
         };
         let def_id = symbol_db.definition(symbol_id);
         let def_file_id = symbol_db.file_id_for_symbol(def_id);
@@ -5521,12 +5525,18 @@ fn ensure_force_exports<'data>(
             .iter()
             .position(|input| input.file_id == def_file_id)
         else {
-            bail!("symbol exported via --export not found: {name}");
+            if required {
+                bail!("symbol exported via --export not found: {name}");
+            }
+            continue;
         };
         let def_input = &layout_inputs[def_obj_idx];
         let def_sym = &def_input.symbols[def_input.symbol_id_range.id_to_offset(def_id)];
         if def_sym.is_undefined() {
-            bail!("symbol exported via --export not found: {name}");
+            if required {
+                bail!("symbol exported via --export not found: {name}");
+            }
+            continue;
         }
 
         let index_map = object_index_maps

--- a/wild/tests/sources/wasm/export/export.c
+++ b/wild/tests/sources/wasm/export/export.c
@@ -10,6 +10,11 @@
 //#LinkArgs: --export does_not_exist
 //#ExpectError: symbol exported via --export not found: does_not_exist
 
+//#Config:export-if-defined
+//#LinkArgs: --export-if-defined=not_exported --export-if-defined=does_not_exist
+//#ExpectSym: not_exported
+//#NoSym: does_not_exist
+
 int foo(void) { return 42; }
 
 void not_exported(void) {}


### PR DESCRIPTION
Adds support for wasm-ld's `--export-if-defined` option.

Symbols passed through `--export-if-defined` are exported when defined and ignored otherwise. Existing `--export` behaviour remains unchanged and still reports missing symbols as errors.

Tested locally on NixOS with:

- `nix develop --command env RUSTFLAGS=-Dwarnings cargo test --profile ci --workspace`
- `nix develop --command env NIX_HARDENING_ENABLE= RUSTFLAGS=-Dwarnings cargo test --features wasm -- wasm`
- `cargo clippy --all-targets --workspace --target x86_64-unknown-linux-gnu`
- `cargo clippy --all-targets --workspace --target x86_64-unknown-linux-gnu --no-default-features`
- `cargo +nightly fmt --all -- --check`

Related to #2335.