### PR TITLE
fix: Apply ADD/SUB relocations correctly when reading debug sections for source info

### DIFF
--- a/libwild/src/dwarf_address_info.rs
+++ b/libwild/src/dwarf_address_info.rs
@@ -167,11 +167,7 @@ fn apply_section_relocations<
             continue;
         };
 
-        let rel_out = section_data
-            .get_mut(data_offset..data_offset + num_bytes)
-            .context("Invalid relocation offset")?;
-
-        match r_type.kind {
+        let new_value = match r_type.kind {
             RelocationKind::Absolute => {
                 let in_section_of_interest = symbol_section.sh_offset(LittleEndian).into()
                     == section_of_interest.sh_offset(LittleEndian).into();
@@ -180,13 +176,18 @@ fn apply_section_relocations<
                     value += SECTION_LOAD_ADDRESS;
                 }
 
-                r_type.write_to_buffer(value, rel_out)?;
+                value
             }
             RelocationKind::AbsoluteAddition | RelocationKind::AbsoluteSubtraction => {
-                r_type.write_to_buffer(value, rel_out)?;
+                r_type.adjust_value_based_on_content(value, section_data, data_offset)?
             }
-            _ => {}
-        }
+            _ => continue,
+        };
+
+        let rel_out = section_data
+            .get_mut(data_offset..data_offset + num_bytes)
+            .context("Invalid relocation offset")?;
+        r_type.write_to_buffer(new_value, rel_out)?;
     }
     Ok(())
 }

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2940,46 +2940,6 @@ fn write_got_plt_syms<C: ElfClass>(
     Ok(())
 }
 
-/// Adjust relocation value based on the actual value at the place of a relocation.
-fn adjust_relocation_based_on_value(
-    value: u64,
-    rel_info: &RelocationKindInfo,
-    out: &[u8],
-    offset_in_section: usize,
-) -> Result<u64> {
-    const LOW6_MASK: u64 = 0b0011_1111;
-
-    let mut read_data = [0u8; 8];
-    let RelocationSize::ByteSize(rel_size) = rel_info.size else {
-        bail!("Unexpected size for the addition/subtraction relocation");
-    };
-    // Read only N bytes from the current value based on the size of the relocation.
-    read_data[..rel_size].copy_from_slice(&out[offset_in_section..offset_in_section + rel_size]);
-    let current_value = u64::from_le_bytes(read_data);
-
-    // Handle addition and subtraction relocation kinds.
-    match rel_info.kind {
-        RelocationKind::AbsoluteSetWord6 => {
-            // Preserve the 2 most significant bits of u8.
-            let value = value & LOW6_MASK;
-            Ok(value | (current_value & !LOW6_MASK))
-        }
-        RelocationKind::AbsoluteAddition => Ok(current_value.wrapping_add(value)),
-        RelocationKind::AbsoluteAdditionWord6 => {
-            // Preserve the 2 most significant bits of u8.
-            let value = (current_value & LOW6_MASK).wrapping_add(value & LOW6_MASK) & LOW6_MASK;
-            Ok(value | (current_value & !LOW6_MASK))
-        }
-        RelocationKind::AbsoluteSubtraction => Ok(current_value.wrapping_sub(value)),
-        RelocationKind::AbsoluteSubtractionWord6 => {
-            // Preserve the 2 most significant bits of u8.
-            let value = (current_value & LOW6_MASK).wrapping_sub(value & LOW6_MASK) & LOW6_MASK;
-            Ok(value | (current_value & !LOW6_MASK))
-        }
-        _ => Err(error!("Unexpected relocation: {:?}", rel_info)),
-    }
-}
-
 #[inline(always)]
 fn get_pair_subtraction_relocation_value<
     'data,
@@ -3510,7 +3470,7 @@ fn apply_relocation<
             | RelocationKind::AbsoluteSetWord6
             | RelocationKind::AbsoluteSubtractionWord6
     ) {
-        value = adjust_relocation_based_on_value(value, &rel_info, out, offset_in_section)?;
+        value = rel_info.adjust_value_based_on_content(value, out, offset_in_section)?;
     }
 
     if let Some(relaxation) = relaxation {
@@ -3713,9 +3673,8 @@ fn apply_debug_relocation<
                         | RelocationKind::AbsoluteSetWord6
                         | RelocationKind::AbsoluteSubtractionWord6
                 ) {
-                    value = adjust_relocation_based_on_value(
+                    value = rel_info.adjust_value_based_on_content(
                         value,
-                        &rel_info,
                         out,
                         offset_in_section as usize,
                     )?;

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -1130,6 +1130,41 @@ impl RelocationKindInfo {
 
         Ok(())
     }
+
+    pub fn adjust_value_based_on_content(
+        self,
+        value: u64,
+        content: &[u8],
+        offset_in_section: usize,
+    ) -> Result<u64> {
+        const LOW6_MASK: u64 = 0b0011_1111;
+
+        let mut read_data = [0u8; 8];
+        let RelocationSize::ByteSize(rel_size) = self.size else {
+            anyhow::bail!("Unexpected size for the addition/subtraction relocation");
+        };
+        read_data[..rel_size]
+            .copy_from_slice(&content[offset_in_section..offset_in_section + rel_size]);
+        let current_value = u64::from_le_bytes(read_data);
+
+        match self.kind {
+            RelocationKind::AbsoluteSetWord6 => {
+                let value = value & LOW6_MASK;
+                Ok(value | (current_value & !LOW6_MASK))
+            }
+            RelocationKind::AbsoluteAddition => Ok(current_value.wrapping_add(value)),
+            RelocationKind::AbsoluteAdditionWord6 => {
+                let value = (current_value & LOW6_MASK).wrapping_add(value & LOW6_MASK) & LOW6_MASK;
+                Ok(value | (current_value & !LOW6_MASK))
+            }
+            RelocationKind::AbsoluteSubtraction => Ok(current_value.wrapping_sub(value)),
+            RelocationKind::AbsoluteSubtractionWord6 => {
+                let value = (current_value & LOW6_MASK).wrapping_sub(value & LOW6_MASK) & LOW6_MASK;
+                Ok(value | (current_value & !LOW6_MASK))
+            }
+            _ => anyhow::bail!("Unexpected relocation: {self:?}"),
+        }
+    }
 }
 
 impl BitMask {


### PR DESCRIPTION
## Bug

These 2 tests failed on Arch Linux for Loong64:

```
     test elf/loongarch64/source-info-from-debug/non-lto ... FAILED
     test elf/loongarch64/source-info-from-debug/lto     ... FAILED
```

The test assertion in stderr requires an error with `source-info-from-debug...:27`, but wild actually reports line number `:26`.

LoongArch's `.debug_line` uses `DW_LNS_fixed_advance_pc` to encode the address advance, and its 2 byte operand is filled with a pair of R_LARCH_ADD16/R_LARCH_SUB16 relocations. The correct value should be 0x18 - 0x10 = 8.

However, wild's diagnostic code treats this as an absolute overwrite. The advance changes from 8 to 16, causing line 27 to be incorrectly mapped to address 0x20 instead of 0x18.

Therefore, when querying the `foo` call point, the range of the previous line is hit, resulting in line 26 being reported.

## Fix

Just apply the correct read-modify-write semantics. Read the current N bytes from the buffer first, then perform wrapping_add/wrapping_sub, and finally write them back.

Tested on Arch Linux for Loong64.