### PR TITLE
chore: Add more stable test for line number debug

### DIFF
--- a/wild/tests/sources/elf/dwarf-line-add-sub/dwarf-line-add-sub.s
+++ b/wild/tests/sources/elf/dwarf-line-add-sub/dwarf-line-add-sub.s
@@ -1,0 +1,27 @@
+/*
+
+This test is similar to source-info-from-debug, but due to being asm, can more reliably pick up some
+problems that test fails to detect.
+
+//#CompArgs:-g
+//#ExpectError:the-answer:42
+*/
+
+.file 1 "the-answer"
+
+.section .text
+.globl _start
+.type _start, @function
+_start:
+        .loc 1 2
+        nop
+        .loc 1 12
+        nop
+        .loc 1 22
+        nop
+        .loc 1 32
+        nop
+        .loc 1 42
+        nop
+        .8byte undefined
+.size _start, .-_start


### PR DESCRIPTION
This test tests for the bug that was fixed by #2411, but in a way that is less toolchain-specific than the test that PR was fixing. On Ubuntu 26.04, without the fix, this test fails for risc-v and loongarch64.