### PR TITLE
fix: correctly resolve linker script functions that return addresses

### DIFF
--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -147,6 +147,23 @@ fn evaluate_expression_value<'data, P: Platform>(
         };
     }
 
+    macro_rules! eval_abs {
+        ($e:expr) => {
+            evaluate_expression(
+                $e,
+                expr_loc,
+                input_ref,
+                section_layouts,
+                output_sections,
+                memory_regions,
+                symbol_db,
+                sizeof_headers,
+                resolved_location_counters,
+                symbol_resolution_callback,
+            )
+        };
+    }
+
     match expr {
         Expression::Number(n) => Ok(*n),
 
@@ -178,20 +195,24 @@ fn evaluate_expression_value<'data, P: Platform>(
         }
 
         // Comparisons return 1 (true) or 0 (false)
-        Expression::LessThan(l, r) => Ok(u64::from(eval!(l)? < eval!(r)?)),
-        Expression::GreaterThan(l, r) => Ok(u64::from(eval!(l)? > eval!(r)?)),
-        Expression::LessEqual(l, r) => Ok(u64::from(eval!(l)? <= eval!(r)?)),
-        Expression::GreaterEqual(l, r) => Ok(u64::from(eval!(l)? >= eval!(r)?)),
-        Expression::Equal(l, r) => Ok(u64::from(eval!(l)? == eval!(r)?)),
-        Expression::NotEqual(l, r) => Ok(u64::from(eval!(l)? != eval!(r)?)),
+        Expression::LessThan(l, r) => Ok(u64::from(eval_abs!(l)? < eval_abs!(r)?)),
+        Expression::GreaterThan(l, r) => Ok(u64::from(eval_abs!(l)? > eval_abs!(r)?)),
+        Expression::LessEqual(l, r) => Ok(u64::from(eval_abs!(l)? <= eval_abs!(r)?)),
+        Expression::GreaterEqual(l, r) => Ok(u64::from(eval_abs!(l)? >= eval_abs!(r)?)),
+        Expression::Equal(l, r) => Ok(u64::from(eval_abs!(l)? == eval_abs!(r)?)),
+        Expression::NotEqual(l, r) => Ok(u64::from(eval_abs!(l)? != eval_abs!(r)?)),
 
         Expression::Sizeof(name) => Ok(section_size(name, section_layouts, output_sections)),
         Expression::Alignof(name) => Ok(section_align(name, section_layouts, output_sections)),
-        Expression::Addr(name) => section_address(name, section_layouts, output_sections),
+        Expression::Addr(name) => {
+            *has_section_relative_offset = false;
+            section_address(name, section_layouts, output_sections)
+        }
 
-        // TODO: This is a temporary alias for ADDR.
-        // Needs to be updated when AT(expr) and disjoint LMA/VMA tracking are implemented.
-        Expression::Loadaddr(name) => section_load_address(name, section_layouts, output_sections),
+        Expression::Loadaddr(name) => {
+            *has_section_relative_offset = false;
+            section_load_address(name, section_layouts, output_sections)
+        }
 
         Expression::Align(expr) => {
             let align = eval!(expr)?;
@@ -221,6 +242,7 @@ fn evaluate_expression_value<'data, P: Platform>(
         Expression::Negate(e) => Ok(eval!(e)?.wrapping_neg()),
 
         Expression::Origin(name) => {
+            *has_section_relative_offset = false;
             let region = memory_regions.get(name).ok_or_else(|| {
                 crate::error!(
                     "ORIGIN: memory region '{}' not found",

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
@@ -10,13 +10,16 @@ SECTIONS {
     symbol11 -= 0x20;
     symbol11 &= 0x80;
     ASSERT(symbol11 == 0x80, "symbol11 must be 0x80")
-    .data : {
+    .data : AT(ADDR(.data) + 0x10000) {
+		data_start = .;
         *(.data*)
         symbol10 = 0x100;
         symbol10_assert = ASSERT(symbol10 == 0x100, "symbol10 must be 0x100");
         symbol10 *= 0x100;
         symbol10 ^= 0x40;
         ASSERT(symbol10 == 0x10040, "symbol10 must be 0x10040");
+		ASSERT(data_start == ADDR(.data), "data_start must be ADDR(.data)");
+		ASSERT(data_start + 0x10000 == LOADADDR(.data), "data_start + 0x10000 must be LOADADDR(.data)");
     }
     .bss  : { *(.bss*)  }
 }

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
@@ -11,15 +11,15 @@ SECTIONS {
     symbol11 &= 0x80;
     ASSERT(symbol11 == 0x80, "symbol11 must be 0x80")
     .data : AT(ADDR(.data) + 0x10000) {
-		data_start = .;
+        data_start = .;
         *(.data*)
         symbol10 = 0x100;
         symbol10_assert = ASSERT(symbol10 == 0x100, "symbol10 must be 0x100");
         symbol10 *= 0x100;
         symbol10 ^= 0x40;
         ASSERT(symbol10 == 0x10040, "symbol10 must be 0x10040");
-		ASSERT(data_start == ADDR(.data), "data_start must be ADDR(.data)");
-		ASSERT(data_start + 0x10000 == LOADADDR(.data), "data_start + 0x10000 must be LOADADDR(.data)");
+        ASSERT(data_start == ADDR(.data), "data_start must be ADDR(.data)");
+        ASSERT(data_start + 0x10000 == LOADADDR(.data), "data_start + 0x10000 must be LOADADDR(.data)");
     }
     .bss  : { *(.bss*)  }
 }

--- a/wild/tests/sources/elf/linker-script-region/linker-script-region.ld
+++ b/wild/tests/sources/elf/linker-script-region/linker-script-region.ld
@@ -8,7 +8,7 @@ SECTIONS {
     .data.flash : {
         KEEP(*(.data.flash))
     } > FLASH
-	ASSERT(ORIGIN(FLASH) == 0x40000000, "ROM region must start at 0x20000000")
+	ASSERT(ORIGIN(FLASH) == 0x40000000, "ORIGIN(FLASH) is incorrect")
 
     .data.ram1 : {
         KEEP(*(.data.ram1))

--- a/wild/tests/sources/elf/linker-script-region/linker-script-region.ld
+++ b/wild/tests/sources/elf/linker-script-region/linker-script-region.ld
@@ -8,6 +8,7 @@ SECTIONS {
     .data.flash : {
         KEEP(*(.data.flash))
     } > FLASH
+	ASSERT(ORIGIN(FLASH) == 0x40000000, "ROM region must start at 0x20000000")
 
     .data.ram1 : {
         KEEP(*(.data.ram1))


### PR DESCRIPTION
Functions such as `ADDR`, `LOADADDR`, `SEGMENT_START` and `ORIGIN` return an address instead of a number. Addresses must be treated as an absolute value, instead of being relative to an output section.

Additionally, comparison operators like `==`, etc must resolve any relative values to their absolute value before performing a comparison.