### PR TITLE
feat: lookup object symbol values in linker script location counters

### DIFF
--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -32,6 +32,23 @@ pub(crate) struct ResolvedLocationCounter {
     pub(crate) section_offset: Option<u64>,
 }
 
+pub(crate) enum ResolvedSymbolValue {
+    Absolute(u64),
+    SectionRelative(u64),
+}
+
+#[derive(Default)]
+struct ExpressionValueKind {
+    contains_absolute: bool,
+    contains_section_relative: bool,
+}
+
+impl ExpressionValueKind {
+    fn needs_section_base(&self) -> bool {
+        self.contains_section_relative || !self.contains_absolute
+    }
+}
+
 fn evaluate_location<'data, P: Platform>(
     expr_loc: &SymbolLoc,
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
@@ -78,9 +95,9 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
     symbol_db: &SymbolDb<'data, P>,
     sizeof_headers: u64,
     resolved_location_counters: &[ResolvedLocationCounter],
-    symbol_resolution_callback: &dyn Fn(&[u8]) -> Result<u64>,
+    symbol_resolution_callback: &dyn Fn(&[u8]) -> Result<ResolvedSymbolValue>,
 ) -> Result<u64> {
-    let mut has_section_relative_offset = true;
+    let mut value_kind = ExpressionValueKind::default();
     let value = evaluate_expression_value(
         expr,
         expr_loc,
@@ -91,11 +108,11 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
         symbol_db,
         sizeof_headers,
         resolved_location_counters,
-        &mut has_section_relative_offset,
+        &mut value_kind,
         symbol_resolution_callback,
     )?;
 
-    let offset = if has_section_relative_offset {
+    let offset = if value_kind.needs_section_base() {
         match expr_loc {
             SymbolLoc::SectionStartRelative(id) | SymbolLoc::SectionEndRelative(id) => {
                 let primary_id = output_sections.primary_output_section(*id);
@@ -126,8 +143,8 @@ fn evaluate_expression_value<'data, P: Platform>(
     symbol_db: &SymbolDb<'data, P>,
     sizeof_headers: u64,
     resolved_location_counters: &[ResolvedLocationCounter],
-    has_section_relative_offset: &mut bool,
-    symbol_resolution_callback: &dyn Fn(&[u8]) -> Result<u64>,
+    value_kind: &mut ExpressionValueKind,
+    symbol_resolution_callback: &dyn Fn(&[u8]) -> Result<ResolvedSymbolValue>,
 ) -> Result<u64> {
     macro_rules! eval {
         ($e:expr) => {
@@ -141,7 +158,7 @@ fn evaluate_expression_value<'data, P: Platform>(
                 symbol_db,
                 sizeof_headers,
                 resolved_location_counters,
-                has_section_relative_offset,
+                value_kind,
                 symbol_resolution_callback,
             )
         };
@@ -174,7 +191,16 @@ fn evaluate_expression_value<'data, P: Platform>(
             resolved_location_counters,
         ),
 
-        Expression::Symbol(name) => symbol_resolution_callback(name),
+        Expression::Symbol(name) => match symbol_resolution_callback(name)? {
+            ResolvedSymbolValue::Absolute(value) => {
+                value_kind.contains_absolute = true;
+                Ok(value)
+            }
+            ResolvedSymbolValue::SectionRelative(value) => {
+                value_kind.contains_section_relative = true;
+                Ok(value)
+            }
+        },
 
         Expression::Add(l, r) => Ok(eval!(l)?.wrapping_add(eval!(r)?)),
         Expression::Subtract(l, r) => Ok(eval!(l)?.wrapping_sub(eval!(r)?)),
@@ -205,12 +231,12 @@ fn evaluate_expression_value<'data, P: Platform>(
         Expression::Sizeof(name) => Ok(section_size(name, section_layouts, output_sections)),
         Expression::Alignof(name) => Ok(section_align(name, section_layouts, output_sections)),
         Expression::Addr(name) => {
-            *has_section_relative_offset = false;
+            value_kind.contains_absolute = true;
             section_address(name, section_layouts, output_sections)
         }
 
         Expression::Loadaddr(name) => {
-            *has_section_relative_offset = false;
+            value_kind.contains_absolute = true;
             section_load_address(name, section_layouts, output_sections)
         }
 
@@ -247,7 +273,7 @@ fn evaluate_expression_value<'data, P: Platform>(
         Expression::Negate(e) => Ok(eval!(e)?.wrapping_neg()),
 
         Expression::Origin(name) => {
-            *has_section_relative_offset = false;
+            value_kind.contains_absolute = true;
             let region = memory_regions.get(name).ok_or_else(|| {
                 crate::error!(
                     "ORIGIN: memory region '{}' not found",
@@ -266,7 +292,7 @@ fn evaluate_expression_value<'data, P: Platform>(
             Ok(region.length)
         }
         Expression::SegmentStart(name, default_expr) => {
-            *has_section_relative_offset = false;
+            value_kind.contains_absolute = true;
             if let Some(val) = symbol_db.args.segment_start_override(*name) {
                 Ok(val)
             } else {
@@ -466,7 +492,7 @@ mod tests {
                 symbol_db,
                 0,
                 &[],
-                &|_| Ok(1),
+                &|_| Ok(ResolvedSymbolValue::Absolute(1)),
             )
         })
     }
@@ -922,7 +948,7 @@ mod tests {
                     symbol_db,
                     0,
                     &[],
-                    &|_| Ok(0),
+                    &|_| Ok(ResolvedSymbolValue::Absolute(0)),
                 )
             };
             assert_eq!(eval(&Expression::Origin(b"rom")).unwrap(), 0x08000000);

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -295,6 +295,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>, F: FileSystem>(
 
     let (mut section_part_layouts, mut section_layouts, mut resolved_location_counters) =
         compute_layout_sections::<A::Platform>(
+            &group_states,
             &section_part_sizes,
             &output_sections,
             &program_segments,
@@ -4970,13 +4971,44 @@ impl SymbolOutputInfos {
     }
 }
 
+fn compute_object_section_addresses<'data, P: Platform>(
+    obj: &ObjectLayoutState<'data, P>,
+    offsets: &mut OutputSectionPartMap<u64>,
+    symbol_db: &SymbolDb<'data, P>,
+    output_sections: &OutputSections<'data, P>,
+) -> Vec<u64> {
+    let mut addresses = vec![0u64; obj.sections.len()];
+    for (sec_idx, slot) in obj.sections.iter().enumerate() {
+        match slot {
+            SectionSlot::Loaded(sec) => {
+                let part_id =
+                    obj.section_part_id(object::SectionIndex(sec_idx), &symbol_db.section_part_ids);
+                addresses[sec_idx] = offsets.get(part_id);
+                *offsets.get_mut(part_id) += sec.capacity(part_id, output_sections);
+            }
+            SectionSlot::LoadedDebugInfo(sec) => {
+                // Advance offsets so subsequent sections are placed correctly, but we don't need
+                // the address for relaxation.
+                let part_id =
+                    obj.section_part_id(object::SectionIndex(sec_idx), &symbol_db.section_part_ids);
+                *offsets.get_mut(part_id) += sec.capacity(part_id, output_sections);
+            }
+            _ => {}
+        }
+    }
+
+    P::compute_object_addresses(obj, offsets);
+
+    addresses
+}
+
 /// Compute the output address of every loaded input section and every symbol in a single parallel
 /// pass over groups.
 fn compute_section_and_symbol_addresses<'data, P: Platform>(
     group_states: &[GroupState<'data, P>],
     section_part_layouts: &OutputSectionPartMap<OutputRecordLayout>,
     symbol_db: &SymbolDb<'data, P>,
-    output_sections: &OutputSections<P>,
+    output_sections: &OutputSections<'data, P>,
 ) -> (Vec<Vec<Vec<u64>>>, SymbolOutputInfos) {
     timing_phase!("Compute section and symbol addresses");
     let mem_offsets: OutputSectionPartMap<u64> = starting_memory_offsets(section_part_layouts);
@@ -4997,33 +5029,12 @@ fn compute_section_and_symbol_addresses<'data, P: Platform>(
                 .iter()
                 .map(|file| match file {
                     FileLayoutState::Object(obj) => {
-                        let mut addresses = vec![0u64; obj.sections.len()];
-                        for (sec_idx, slot) in obj.sections.iter().enumerate() {
-                            match slot {
-                                SectionSlot::Loaded(sec) => {
-                                    let part_id = obj.section_part_id(
-                                        object::SectionIndex(sec_idx),
-                                        &symbol_db.section_part_ids,
-                                    );
-                                    addresses[sec_idx] = offsets.get(part_id);
-                                    *offsets.get_mut(part_id) +=
-                                        sec.capacity(part_id, output_sections);
-                                }
-                                SectionSlot::LoadedDebugInfo(sec) => {
-                                    // Advance offsets so subsequent sections are placed
-                                    // correctly, but we don't need the address for relaxation.
-                                    let part_id = obj.section_part_id(
-                                        object::SectionIndex(sec_idx),
-                                        &symbol_db.section_part_ids,
-                                    );
-                                    *offsets.get_mut(part_id) +=
-                                        sec.capacity(part_id, output_sections);
-                                }
-                                _ => {}
-                            }
-                        }
-
-                        P::compute_object_addresses(obj, &mut offsets);
+                        let addresses = compute_object_section_addresses(
+                            obj,
+                            &mut offsets,
+                            symbol_db,
+                            output_sections,
+                        );
 
                         // While we have the section addresses, also resolve symbol
                         // output addresses for this file's canonical definitions.
@@ -5071,6 +5082,77 @@ fn compute_section_and_symbol_addresses<'data, P: Platform>(
     (section_addresses, SymbolOutputInfos { addresses })
 }
 
+/// Looks up the memory address of a symbol during pre-layout location counter evaluation in linker
+/// scripts. This function is used before final symbol resolutions are computed.
+pub(crate) fn compute_object_symbol_address<'data, P: Platform>(
+    group_states: &[GroupState<'data, P>],
+    mem_offsets: &OutputSectionPartMap<u64>,
+    symbol_db: &SymbolDb<'data, P>,
+    output_sections: &OutputSections<'data, P>,
+    symbol_id: SymbolId,
+) -> Result<(u64, Option<OutputSectionId>)> {
+    let canonical_id = symbol_db.definition(symbol_id);
+
+    let mut offsets = compute_start_offsets_by_group(group_states, mem_offsets.clone());
+
+    let source_file = group_states
+        .iter()
+        .enumerate()
+        .find_map(|(group_idx, group)| {
+            group.files.iter().find_map(|file| {
+                if let FileLayoutState::Object(obj) = file
+                    && obj
+                        .symbol_id_range
+                        .as_usize()
+                        .contains(&canonical_id.as_usize())
+                {
+                    Some((group_idx, obj))
+                } else {
+                    None
+                }
+            })
+        });
+
+    let Some((group_idx, obj)) = source_file else {
+        bail!(
+            "symbol '{}' is not defined by an input object",
+            symbol_db.symbol_name_for_display(canonical_id)
+        );
+    };
+
+    let sym_local_idx = canonical_id.as_usize() - obj.symbol_id_range.start().as_usize();
+    let sym_input_idx = object::SymbolIndex(sym_local_idx);
+
+    let Some(sym) = obj.object.symbol(sym_input_idx).ok() else {
+        bail!(
+            "cannot resolve address of symbol '{}'",
+            symbol_db.symbol_name_for_display(canonical_id)
+        );
+    };
+
+    let addresses =
+        compute_object_section_addresses(obj, &mut offsets[group_idx], symbol_db, output_sections);
+
+    match obj.object.symbol_section(sym, sym_input_idx)? {
+        Some(section_index) => {
+            let Some(sec_addr) = addresses.get(section_index.0).copied() else {
+                bail!(
+                    "cannot resolve address of symbol '{}' because its section hasn't been laid out yet",
+                    symbol_db.symbol_name_for_display(canonical_id)
+                );
+            };
+            let part_id = obj.section_part_id(section_index, &symbol_db.section_part_ids);
+            let output_section_id = part_id.output_section_id::<P>();
+            Ok((sec_addr + sym.value(), Some(output_section_id)))
+        }
+        None if sym.is_absolute() => Ok((sym.value(), None)),
+        _ => bail!(
+            "cannot resolve address of symbol '{}'",
+            symbol_db.symbol_name_for_display(canonical_id)
+        ),
+    }
+}
+
 /// Per-file list of section indices to rescan on subsequent relaxation iterations. Indexed as
 /// `[group_idx][file_idx]`.  Files that are not objects get an empty entry.
 type RescanSections = Vec<Vec<SmallVec<[usize; 16]>>>;
@@ -5090,7 +5172,7 @@ fn relaxation_scan_pass<'data, A: Arch>(
     per_symbol_flags: &PerSymbolFlags,
     section_part_sizes: &mut OutputSectionPartMap<u64>,
     prev_rescan: Option<&RescanSections>,
-    output_sections: &OutputSections<A::Platform>,
+    output_sections: &OutputSections<'data, A::Platform>,
 ) -> (u64, RescanCandidates) {
     timing_phase!("Relaxation scan pass");
 
@@ -5305,6 +5387,7 @@ fn perform_iterative_relaxation<'data, A: Arch>(
             *section_layouts,
             *resolved_location_counters,
         ) = compute_layout_sections::<A::Platform>(
+            group_states,
             section_part_sizes,
             output_sections,
             program_segments,
@@ -5318,6 +5401,7 @@ fn perform_iterative_relaxation<'data, A: Arch>(
 }
 
 fn compute_layout_sections<'data, P: Platform>(
+    group_states: &[GroupState<'data, P>],
     sizes: &OutputSectionPartMap<u64>,
     output_sections: &OutputSections<'data, P>,
     program_segments: &ProgramSegments<P::ProgramSegmentDef>,
@@ -5343,27 +5427,60 @@ fn compute_layout_sections<'data, P: Platform>(
 
     let mut section_layouts = OutputSectionMap::with_size(output_sections.num_sections());
 
-    let expression_eval = |expr: &Expression<'data>,
-                           loc: &SymbolLoc,
-                           memory_regions: &HashMap<&[u8], MemoryRegion>,
-                           section_layouts: &OutputSectionMap<OutputRecordLayout>,
-                           resolved_lc: &[ResolvedLocationCounter]| {
-        crate::expression_eval::evaluate_expression(
-            expr,
-            loc,
-            None,
-            section_layouts,
-            output_sections,
-            memory_regions,
-            symbol_db,
-            sizeof_headers,
-            resolved_lc,
-            &|_| {
-                bail!("Symbols with the set location operation are not yet supported.");
-            },
-        )
-    };
+    let expression_eval =
+        |expr: &Expression<'data>,
+         loc: &SymbolLoc,
+         memory_regions: &HashMap<&[u8], MemoryRegion>,
+         section_layouts: &OutputSectionMap<OutputRecordLayout>,
+         resolved_lc: &[ResolvedLocationCounter],
+         laid_out_mem_offsets: &OutputSectionPartMap<u64>| {
+            crate::expression_eval::evaluate_expression(
+                expr,
+                loc,
+                None,
+                section_layouts,
+                output_sections,
+                memory_regions,
+                symbol_db,
+                sizeof_headers,
+                resolved_lc,
+                &|name| {
+                    let Some(symbol_id) =
+                        symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(name))
+                    else {
+                        bail!(
+                            "undefined symbol '{}' in linker script expression",
+                            String::from_utf8_lossy(name)
+                        );
+                    };
+                    let (address, definition_section) = compute_object_symbol_address(
+                        group_states,
+                        laid_out_mem_offsets,
+                        symbol_db,
+                        output_sections,
+                        symbol_id,
+                    )?;
+                    let current_section = match loc {
+                        SymbolLoc::LocationCounter(_, Some(id))
+                        | SymbolLoc::SectionEndRelative(id)
+                        | SymbolLoc::SectionStartRelative(id) => Some(*id),
+                        _ => None,
+                    };
+                    match (current_section, definition_section) {
+                        (Some(current_section), Some(def_section))
+                            if current_section == def_section =>
+                        {
+                            let primary_id =
+                                output_sections.primary_output_section(current_section);
+                            Ok(address - section_layouts.get(primary_id).mem_offset)
+                        }
+                        _ => Ok(address),
+                    }
+                },
+            )
+        };
 
+    let empty_mem_offsets = output_sections.new_part_map::<u64>();
     let mut file_offset = 0;
     let mut mem_offset = expression_eval(
         &output_sections.base_address,
@@ -5371,6 +5488,7 @@ fn compute_layout_sections<'data, P: Platform>(
         memory_regions,
         &section_layouts,
         &[],
+        &empty_mem_offsets,
     )?;
     let mut lma_offset = mem_offset;
     let mut nonalloc_mem_offsets: OutputSectionMap<u64> =
@@ -5389,6 +5507,10 @@ fn compute_layout_sections<'data, P: Platform>(
 
     let mut records_out = output_sections.new_part_map();
 
+    // Memory offsets of the output-section parts that have been laid out so far. Used to resolve
+    // object symbols referenced from location-counter expressions.
+    let mut laid_out_mem_offsets = output_sections.new_part_map::<u64>();
+
     // TLS sections without data (like .tbss) overlap normal sections in memory.
     // This is possible because every thread copies the TLS segments (see TLS PHDR)
     // to construct thread local data. However, uninitialized TLS data is assumed to be zero
@@ -5406,8 +5528,14 @@ fn compute_layout_sections<'data, P: Platform>(
                     };
                     loc = SymbolLoc::LocationCounter(idx, None);
                 }
-                let value =
-                    expression_eval(&expr, &loc, memory_regions, &section_layouts, &resolved_lc)?;
+                let value = expression_eval(
+                    &expr,
+                    &loc,
+                    memory_regions,
+                    &section_layouts,
+                    &resolved_lc,
+                    &laid_out_mem_offsets,
+                )?;
                 pending_location = Some(value);
                 resolved_lc[idx] = ResolvedLocationCounter {
                     value,
@@ -5417,8 +5545,14 @@ fn compute_layout_sections<'data, P: Platform>(
             OrderEvent::SetLocationRelative(expr, section_id, loc, idx) => {
                 let primary_id = output_sections.primary_output_section(section_id);
                 let section_base = section_layouts.get(primary_id).mem_offset;
-                let value =
-                    expression_eval(&expr, &loc, memory_regions, &section_layouts, &resolved_lc)?;
+                let value = expression_eval(
+                    &expr,
+                    &loc,
+                    memory_regions,
+                    &section_layouts,
+                    &resolved_lc,
+                    &laid_out_mem_offsets,
+                )?;
                 let offset = value - section_base;
                 pending_location = Some(value);
                 resolved_lc[idx] = ResolvedLocationCounter {
@@ -5433,6 +5567,7 @@ fn compute_layout_sections<'data, P: Platform>(
                     memory_regions,
                     &section_layouts,
                     &resolved_lc,
+                    &laid_out_mem_offsets,
                 )?;
                 pending_location = Some(value);
             }
@@ -5632,6 +5767,8 @@ fn compute_layout_sections<'data, P: Platform>(
                         file_offset += mem_size as usize;
                     }
 
+                    *laid_out_mem_offsets.get_mut(part_id) = part_layout.mem_offset;
+
                     layout_section_from_part_layouts(
                         part_layout,
                         section_layouts.get_mut(section_id),
@@ -5650,6 +5787,7 @@ fn compute_layout_sections<'data, P: Platform>(
                             memory_regions,
                             &section_layouts,
                             &resolved_lc,
+                            &laid_out_mem_offsets,
                         )?;
                         part_layout.lma_offset = lma_offset;
                         let section_layout = section_layouts.get_mut(section_id);
@@ -6042,6 +6180,7 @@ fn test_no_disallowed_overlaps() {
         crate::symbol_db::SymbolDb::<Elf64>::new(&args, output_kind, &auxiliary, &herd).unwrap();
 
     let (_, section_layouts, _) = compute_layout_sections::<Elf64>(
+        &[],
         &section_part_sizes,
         &output_sections,
         &program_segments,

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -926,7 +926,6 @@ pub(crate) struct LinkerScriptLayoutState<'data, P: Platform> {
     input: InputRef<'data>,
     pub(crate) symbol_id_range: SymbolIdRange,
     pub(crate) internal_symbols: InternalSymbols<'data, P>,
-    relative_location_counter_expressions: Vec<Expression<'data>>,
 }
 
 #[derive(Debug)]
@@ -6134,7 +6133,6 @@ impl<'data, P: Platform> LinkerScriptLayoutState<'data, P> {
                 symbol_definitions: input.symbol_definitions,
                 start_symbol_id: input.symbol_id_range.start(),
             },
-            relative_location_counter_expressions: input.relative_location_counter_expressions,
         }
     }
 
@@ -6145,8 +6143,22 @@ impl<'data, P: Platform> LinkerScriptLayoutState<'data, P> {
         queue: &mut LocalWorkQueue<P>,
         scope: &Scope<'scope>,
     ) -> Result {
-        for expression in &self.relative_location_counter_expressions {
-            load_expression_referenced_symbols::<A>(resources, queue, scope, expression);
+        for group in &resources.symbol_db.groups {
+            match group {
+                Group::LinkerScripts(linker_scripts) => {
+                    for script in linker_scripts {
+                        for lc in &script.parsed.location_counters {
+                            load_expression_referenced_symbols::<A>(
+                                resources,
+                                queue,
+                                scope,
+                                &lc.get_expression(),
+                            );
+                        }
+                    }
+                }
+                _ => {}
+            }
         }
         self.internal_symbols
             .activate_symbols::<A>(common, resources, queue, scope)

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -4976,22 +4976,32 @@ fn compute_object_section_addresses<'data, P: Platform>(
     offsets: &mut OutputSectionPartMap<u64>,
     symbol_db: &SymbolDb<'data, P>,
     output_sections: &OutputSections<'data, P>,
-) -> Vec<u64> {
+    skip_sorted_sections: bool,
+) -> Result<Vec<u64>> {
     let mut addresses = vec![0u64; obj.sections.len()];
-    for (sec_idx, slot) in obj.sections.iter().enumerate() {
+    for (sec_idx, slot) in obj
+        .sections
+        .iter()
+        .enumerate()
+        .map(|(idx, slot)| (object::SectionIndex(idx), slot))
+    {
         match slot {
             SectionSlot::Loaded(sec) => {
-                let part_id =
-                    obj.section_part_id(object::SectionIndex(sec_idx), &symbol_db.section_part_ids);
-                addresses[sec_idx] = offsets.get(part_id);
+                let part_id = obj.section_part_id(sec_idx, &symbol_db.section_part_ids);
+                addresses[sec_idx.0] = offsets.get(part_id);
                 *offsets.get_mut(part_id) += sec.capacity(part_id, output_sections);
             }
             SectionSlot::LoadedDebugInfo(sec) => {
                 // Advance offsets so subsequent sections are placed correctly, but we don't need
                 // the address for relaxation.
-                let part_id =
-                    obj.section_part_id(object::SectionIndex(sec_idx), &symbol_db.section_part_ids);
+                let part_id = obj.section_part_id(sec_idx, &symbol_db.section_part_ids);
                 *offsets.get_mut(part_id) += sec.capacity(part_id, output_sections);
+            }
+            SectionSlot::Sorted(sec) if !skip_sorted_sections => {
+                bail!(
+                    "Early evaluation of sorted section {} is not supported",
+                    obj.object.section_display_name(sec_idx)
+                );
             }
             _ => {}
         }
@@ -4999,7 +5009,7 @@ fn compute_object_section_addresses<'data, P: Platform>(
 
     P::compute_object_addresses(obj, offsets);
 
-    addresses
+    Ok(addresses)
 }
 
 /// Compute the output address of every loaded input section and every symbol in a single parallel
@@ -5034,7 +5044,9 @@ fn compute_section_and_symbol_addresses<'data, P: Platform>(
                             &mut offsets,
                             symbol_db,
                             output_sections,
-                        );
+                            true,
+                        )
+                        .unwrap();
 
                         // While we have the section addresses, also resolve symbol
                         // output addresses for this file's canonical definitions.
@@ -5130,8 +5142,13 @@ pub(crate) fn compute_object_symbol_address<'data, P: Platform>(
         );
     };
 
-    let addresses =
-        compute_object_section_addresses(obj, &mut offsets[group_idx], symbol_db, output_sections);
+    let addresses = compute_object_section_addresses(
+        obj,
+        &mut offsets[group_idx],
+        symbol_db,
+        output_sections,
+        false,
+    )?;
 
     match obj.object.symbol_section(sym, sym_input_idx)? {
         Some(section_index) => {
@@ -5472,7 +5489,15 @@ fn compute_layout_sections<'data, P: Platform>(
                         {
                             let primary_id =
                                 output_sections.primary_output_section(current_section);
-                            Ok(address - section_layouts.get(primary_id).mem_offset)
+                            address
+                                .checked_sub(section_layouts.get(primary_id).mem_offset)
+                                .ok_or_else(|| {
+                                    error!(
+                                        "Address {} is not within section {}",
+                                        address,
+                                        output_sections.display_name(current_section)
+                                    )
+                                })
                         }
                         _ => Ok(address),
                     }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -16,6 +16,7 @@ use crate::error::Context;
 use crate::error::Error;
 use crate::error::Result;
 use crate::expression_eval::ResolvedLocationCounter;
+use crate::expression_eval::ResolvedSymbolValue;
 use crate::expression_eval::evaluate_const;
 use crate::file_writer;
 use crate::grouping::Group;
@@ -92,6 +93,7 @@ use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::IntoParallelRefMutIterator;
 use rayon::iter::ParallelIterator;
 use smallvec::SmallVec;
+use std::cell::OnceCell;
 use std::collections::BTreeMap;
 use std::ffi::CString;
 use std::fmt::Display;
@@ -611,10 +613,12 @@ fn update_defsym_symbol_resolution<'data, P: Platform>(
                 if let Some(section_base) = current_section_base
                     && resolution.raw_value >= section_base
                 {
-                    return Ok(resolution.raw_value - section_base);
+                    return Ok(ResolvedSymbolValue::SectionRelative(
+                        resolution.raw_value - section_base,
+                    ));
                 }
 
-                Ok(resolution.raw_value)
+                Ok(ResolvedSymbolValue::Absolute(resolution.raw_value))
             },
         )?;
 
@@ -922,6 +926,7 @@ pub(crate) struct LinkerScriptLayoutState<'data, P: Platform> {
     input: InputRef<'data>,
     pub(crate) symbol_id_range: SymbolIdRange,
     pub(crate) internal_symbols: InternalSymbols<'data, P>,
+    relative_location_counter_expressions: Vec<Expression<'data>>,
 }
 
 #[derive(Debug)]
@@ -3591,16 +3596,25 @@ fn load_redirect_referenced_symbols<'data, 'scope, A: Arch>(
     queue: &mut LocalWorkQueue<A::Platform>,
     scope: &Scope<'scope>,
     symbol_id: SymbolId,
-    redirect: &crate::parsing::Redirect<'_>,
+    redirect: &crate::parsing::Redirect<'data>,
 ) {
     resources
         .per_symbol_flags
         .get_atomic(symbol_id)
         .or_assign(ValueFlags::DIRECT);
 
+    load_expression_referenced_symbols::<A>(resources, queue, scope, &redirect.expression);
+}
+
+fn load_expression_referenced_symbols<'data, 'scope, A: Arch>(
+    resources: &'scope GraphResources<'data, '_, <A as Arch>::Platform>,
+    queue: &mut LocalWorkQueue<A::Platform>,
+    scope: &Scope<'scope>,
+    expression: &Expression<'data>,
+) {
     // Also mark any symbols in the expression as used and queue it for loading to
     // prevent it from being GC'd.
-    redirect.expression.visit_expressions(&mut |e| {
+    expression.visit_expressions(&mut |e| {
         if let crate::linker_script::Expression::Symbol(target_name) = e
             && let Some(target_symbol_id) = resources
                 .symbol_db
@@ -4947,6 +4961,17 @@ const MAX_RELAXATION_ITERATIONS: usize = 5;
 /// unknown.
 const SYMBOL_ADDRESS_UNRESOLVED: u64 = u64::MAX;
 
+#[derive(Debug, Clone, Copy)]
+struct InputSectionPosition {
+    part_id: PartId,
+    address: u64,
+}
+
+/// Input-section positions in the coordinate system supplied by the initial part offsets.
+/// Zero initial offsets produce part-relative positions, while final part offsets produce output
+/// addresses.
+type InputSectionPositions = Vec<Vec<Vec<Option<InputSectionPosition>>>>;
+
 /// Stores precomputed output-address information for every symbol.
 struct SymbolOutputInfos {
     addresses: Vec<u64>,
@@ -4971,14 +4996,13 @@ impl SymbolOutputInfos {
     }
 }
 
-fn compute_object_section_addresses<'data, P: Platform>(
+fn compute_object_section_positions<'data, P: Platform>(
     obj: &ObjectLayoutState<'data, P>,
     offsets: &mut OutputSectionPartMap<u64>,
     symbol_db: &SymbolDb<'data, P>,
-    output_sections: &OutputSections<'data, P>,
-    skip_sorted_sections: bool,
-) -> Result<Vec<u64>> {
-    let mut addresses = vec![0u64; obj.sections.len()];
+    output_sections: &OutputSections<P>,
+) -> Vec<Option<InputSectionPosition>> {
+    let mut positions = vec![None; obj.sections.len()];
     for (sec_idx, slot) in obj
         .sections
         .iter()
@@ -4988,7 +5012,10 @@ fn compute_object_section_addresses<'data, P: Platform>(
         match slot {
             SectionSlot::Loaded(sec) => {
                 let part_id = obj.section_part_id(sec_idx, &symbol_db.section_part_ids);
-                addresses[sec_idx.0] = offsets.get(part_id);
+                positions[sec_idx.0] = Some(InputSectionPosition {
+                    part_id,
+                    address: offsets.get(part_id),
+                });
                 *offsets.get_mut(part_id) += sec.capacity(part_id, output_sections);
             }
             SectionSlot::LoadedDebugInfo(sec) => {
@@ -4997,19 +5024,44 @@ fn compute_object_section_addresses<'data, P: Platform>(
                 let part_id = obj.section_part_id(sec_idx, &symbol_db.section_part_ids);
                 *offsets.get_mut(part_id) += sec.capacity(part_id, output_sections);
             }
-            SectionSlot::Sorted(sec) if !skip_sorted_sections => {
-                bail!(
-                    "Early evaluation of sorted section {} is not supported",
-                    obj.object.section_display_name(sec_idx)
-                );
-            }
             _ => {}
         }
     }
 
     P::compute_object_addresses(obj, offsets);
 
-    Ok(addresses)
+    positions
+}
+
+fn compute_input_section_positions<'data, P: Platform>(
+    group_states: &[GroupState<'data, P>],
+    mem_offsets: OutputSectionPartMap<u64>,
+    symbol_db: &SymbolDb<'data, P>,
+    output_sections: &OutputSections<P>,
+) -> InputSectionPositions {
+    let starting_offsets = compute_start_offsets_by_group(group_states, mem_offsets);
+
+    group_states
+        .par_iter()
+        .enumerate()
+        .map(|(group_idx, group)| {
+            let mut offsets = starting_offsets[group_idx].clone();
+
+            group
+                .files
+                .iter()
+                .map(|file| match file {
+                    FileLayoutState::Object(obj) => compute_object_section_positions(
+                        obj,
+                        &mut offsets,
+                        symbol_db,
+                        output_sections,
+                    ),
+                    _ => vec![],
+                })
+                .collect()
+        })
+        .collect()
 }
 
 /// Compute the output address of every loaded input section and every symbol in a single parallel
@@ -5019,7 +5071,7 @@ fn compute_section_and_symbol_addresses<'data, P: Platform>(
     section_part_layouts: &OutputSectionPartMap<OutputRecordLayout>,
     symbol_db: &SymbolDb<'data, P>,
     output_sections: &OutputSections<'data, P>,
-) -> (Vec<Vec<Vec<u64>>>, SymbolOutputInfos) {
+) -> (InputSectionPositions, SymbolOutputInfos) {
     timing_phase!("Compute section and symbol addresses");
     let mem_offsets: OutputSectionPartMap<u64> = starting_memory_offsets(section_part_layouts);
     let starting_offsets = compute_start_offsets_by_group(group_states, mem_offsets);
@@ -5028,7 +5080,7 @@ fn compute_section_and_symbol_addresses<'data, P: Platform>(
         .map(|_| AtomicU64::new(SYMBOL_ADDRESS_UNRESOLVED))
         .collect();
 
-    let section_addresses: Vec<Vec<Vec<u64>>> = group_states
+    let section_positions = group_states
         .par_iter()
         .enumerate()
         .map(|(group_idx, group)| {
@@ -5039,14 +5091,12 @@ fn compute_section_and_symbol_addresses<'data, P: Platform>(
                 .iter()
                 .map(|file| match file {
                     FileLayoutState::Object(obj) => {
-                        let addresses = compute_object_section_addresses(
+                        let positions = compute_object_section_positions(
                             obj,
                             &mut offsets,
                             symbol_db,
                             output_sections,
-                            true,
-                        )
-                        .unwrap();
+                        );
 
                         // While we have the section addresses, also resolve symbol
                         // output addresses for this file's canonical definitions.
@@ -5064,12 +5114,22 @@ fn compute_section_and_symbol_addresses<'data, P: Platform>(
 
                             match obj.object.symbol_section(sym, sym_input_idx) {
                                 Ok(Some(section)) => {
-                                    let sec_addr = addresses.get(section.0).copied().unwrap_or(0);
-                                    if sec_addr == 0 {
+                                    let Some(sec_addr) =
+                                        positions.get(section.0).copied().flatten()
+                                    else {
                                         continue;
-                                    }
+                                    };
+                                    let Ok(input_offset) =
+                                        obj.object.symbol_offset_in_section(sym, section)
+                                    else {
+                                        continue;
+                                    };
+                                    let output_offset = opt_input_to_output(
+                                        obj.section_relax_deltas.get(section.0),
+                                        input_offset,
+                                    );
                                     symbol_addresses[sym_id.as_usize()]
-                                        .store(sec_addr + sym.value(), Relaxed);
+                                        .store(sec_addr.address + output_offset, Relaxed);
                                 }
                                 Ok(None) if sym.is_absolute() => {
                                     symbol_addresses[sym_id.as_usize()].store(sym.value(), Relaxed);
@@ -5078,7 +5138,7 @@ fn compute_section_and_symbol_addresses<'data, P: Platform>(
                             }
                         }
 
-                        addresses
+                        positions
                     }
                     _ => vec![],
                 })
@@ -5091,83 +5151,74 @@ fn compute_section_and_symbol_addresses<'data, P: Platform>(
         .map(|a| a.into_inner())
         .collect();
 
-    (section_addresses, SymbolOutputInfos { addresses })
+    (section_positions, SymbolOutputInfos { addresses })
 }
 
-/// Looks up the memory address of a symbol during pre-layout location counter evaluation in linker
-/// scripts. This function is used before final symbol resolutions are computed.
-pub(crate) fn compute_object_symbol_address<'data, P: Platform>(
-    group_states: &[GroupState<'data, P>],
-    mem_offsets: &OutputSectionPartMap<u64>,
-    symbol_db: &SymbolDb<'data, P>,
-    output_sections: &OutputSections<'data, P>,
+enum EarlyObjectSymbolValue {
+    Absolute(u64),
+    PartRelative { part_id: PartId, offset: u64 },
+}
+
+fn resolve_early_object_symbol<'data, P: Platform>(
     symbol_id: SymbolId,
-) -> Result<(u64, Option<OutputSectionId>)> {
+    group_states: &[GroupState<'data, P>],
+    section_positions: &InputSectionPositions,
+    symbol_db: &SymbolDb<'data, P>,
+) -> Result<EarlyObjectSymbolValue> {
     let canonical_id = symbol_db.definition(symbol_id);
-
-    let mut offsets = compute_start_offsets_by_group(group_states, mem_offsets.clone());
-
-    let source_file = group_states
-        .iter()
-        .enumerate()
-        .find_map(|(group_idx, group)| {
-            group.files.iter().find_map(|file| {
-                if let FileLayoutState::Object(obj) = file
-                    && obj
-                        .symbol_id_range
-                        .as_usize()
-                        .contains(&canonical_id.as_usize())
-                {
-                    Some((group_idx, obj))
-                } else {
-                    None
-                }
-            })
-        });
-
-    let Some((group_idx, obj)) = source_file else {
+    let file_id = symbol_db.file_id_for_symbol(canonical_id);
+    let Some(FileLayoutState::Object(obj)) = group_states
+        .get(file_id.group())
+        .and_then(|group| group.files.get(file_id.file()))
+    else {
         bail!(
             "symbol '{}' is not defined by an input object",
             symbol_db.symbol_name_for_display(canonical_id)
         );
     };
 
-    let sym_local_idx = canonical_id.as_usize() - obj.symbol_id_range.start().as_usize();
-    let sym_input_idx = object::SymbolIndex(sym_local_idx);
-
-    let Some(sym) = obj.object.symbol(sym_input_idx).ok() else {
+    let local_index = canonical_id.to_input(obj.symbol_id_range);
+    let symbol = obj.object.symbol(local_index)?;
+    let Some(section_index) = obj.object.symbol_section(symbol, local_index)? else {
+        if symbol.is_absolute() {
+            return Ok(EarlyObjectSymbolValue::Absolute(symbol.value()));
+        }
         bail!(
             "cannot resolve address of symbol '{}'",
             symbol_db.symbol_name_for_display(canonical_id)
         );
     };
 
-    let addresses = compute_object_section_addresses(
-        obj,
-        &mut offsets[group_idx],
-        symbol_db,
-        output_sections,
-        false,
-    )?;
+    let section_position = section_positions
+        .get(file_id.group())
+        .and_then(|group| group.get(file_id.file()))
+        .and_then(|file| file.get(section_index.0))
+        .copied()
+        .flatten();
 
-    match obj.object.symbol_section(sym, sym_input_idx)? {
-        Some(section_index) => {
-            let Some(sec_addr) = addresses.get(section_index.0).copied() else {
-                bail!(
-                    "cannot resolve address of symbol '{}' because its section hasn't been laid out yet",
-                    symbol_db.symbol_name_for_display(canonical_id)
-                );
-            };
-            let part_id = obj.section_part_id(section_index, &symbol_db.section_part_ids);
-            let output_section_id = part_id.output_section_id::<P>();
-            Ok((sec_addr + sym.value(), Some(output_section_id)))
+    let Some(section_position) = section_position else {
+        if matches!(
+            obj.sections.get(section_index.0),
+            Some(SectionSlot::Sorted(_))
+        ) {
+            bail!(
+                "Early evaluation of sorted section {} is not supported",
+                obj.object.section_display_name(section_index)
+            );
         }
-        None if sym.is_absolute() => Ok((sym.value(), None)),
-        _ => bail!(
-            "cannot resolve address of symbol '{}'",
+        bail!(
+            "cannot resolve address of symbol '{}' because its section does not have an early layout",
             symbol_db.symbol_name_for_display(canonical_id)
-        ),
-    }
+        );
+    };
+
+    let input_offset = obj.object.symbol_offset_in_section(symbol, section_index)?;
+    let output_offset =
+        opt_input_to_output(obj.section_relax_deltas.get(section_index.0), input_offset);
+    Ok(EarlyObjectSymbolValue::PartRelative {
+        part_id: section_position.part_id,
+        offset: section_position.address + output_offset,
+    })
 }
 
 /// Per-file list of section indices to rescan on subsequent relaxation iterations. Indexed as
@@ -5248,10 +5299,14 @@ fn relaxation_scan_pass<'data, A: Arch>(
                             continue;
                         };
 
-                        let sec_output_addr = file_section_addrs.get(sec_idx).copied().unwrap_or(0);
-                        if sec_output_addr == 0 {
+                        let Some(sec_output_addr) = file_section_addrs
+                            .get(sec_idx)
+                            .copied()
+                            .flatten()
+                            .map(|section| section.address)
+                        else {
                             continue;
-                        }
+                        };
 
                         let existing_deltas = obj.section_relax_deltas.get(sec_idx);
 
@@ -5443,6 +5498,7 @@ fn compute_layout_sections<'data, P: Platform>(
     timing_phase!("Layout sections");
 
     let mut section_layouts = OutputSectionMap::with_size(output_sections.num_sections());
+    let section_positions = OnceCell::new();
 
     let expression_eval =
         |expr: &Expression<'data>,
@@ -5450,7 +5506,7 @@ fn compute_layout_sections<'data, P: Platform>(
          memory_regions: &HashMap<&[u8], MemoryRegion>,
          section_layouts: &OutputSectionMap<OutputRecordLayout>,
          resolved_lc: &[ResolvedLocationCounter],
-         laid_out_mem_offsets: &OutputSectionPartMap<u64>| {
+         laid_out_mem_offsets: &OutputSectionPartMap<Option<u64>>| {
             crate::expression_eval::evaluate_expression(
                 expr,
                 loc,
@@ -5470,42 +5526,64 @@ fn compute_layout_sections<'data, P: Platform>(
                             String::from_utf8_lossy(name)
                         );
                     };
-                    let (address, definition_section) = compute_object_symbol_address(
-                        group_states,
-                        laid_out_mem_offsets,
-                        symbol_db,
-                        output_sections,
+
+                    let symbol_value = match resolve_early_object_symbol(
                         symbol_id,
-                    )?;
-                    let current_section = match loc {
-                        SymbolLoc::LocationCounter(_, Some(id))
-                        | SymbolLoc::SectionEndRelative(id)
-                        | SymbolLoc::SectionStartRelative(id) => Some(*id),
-                        _ => None,
-                    };
-                    match (current_section, definition_section) {
-                        (Some(current_section), Some(def_section))
-                            if current_section == def_section =>
-                        {
-                            let primary_id =
-                                output_sections.primary_output_section(current_section);
-                            address
-                                .checked_sub(section_layouts.get(primary_id).mem_offset)
-                                .ok_or_else(|| {
-                                    error!(
-                                        "Address {} is not within section {}",
-                                        address,
-                                        output_sections.display_name(current_section)
-                                    )
-                                })
+                        group_states,
+                        section_positions.get_or_init(|| {
+                            compute_input_section_positions(
+                                group_states,
+                                sizes.new_empty_like(),
+                                symbol_db,
+                                output_sections,
+                            )
+                        }),
+                        symbol_db,
+                    )? {
+                        EarlyObjectSymbolValue::Absolute(value) => {
+                            ResolvedSymbolValue::Absolute(value)
                         }
-                        _ => Ok(address),
-                    }
+                        EarlyObjectSymbolValue::PartRelative { part_id, offset } => {
+                            let Some(part_address) = laid_out_mem_offsets.get(part_id) else {
+                                bail!(
+                                    "cannot resolve address of symbol '{}' because its output section part has not been laid out yet",
+                                    String::from_utf8_lossy(name)
+                                );
+                            };
+                            let address = part_address + offset;
+                            let symbol_section = output_sections
+                                .primary_output_section(part_id.output_section_id::<P>());
+                            let current_section = match loc {
+                                SymbolLoc::SectionStartRelative(id)
+                                | SymbolLoc::SectionEndRelative(id)
+                                | SymbolLoc::LocationCounter(_, Some(id)) => {
+                                    Some(output_sections.primary_output_section(*id))
+                                }
+                                _ => None,
+                            };
+                            if current_section == Some(symbol_section) {
+                                let section_base = section_layouts.get(symbol_section).mem_offset;
+                                ResolvedSymbolValue::SectionRelative(
+                                    address.checked_sub(section_base).with_context(|| {
+                                        format!(
+                                            "address of symbol '{}' is before its output section",
+                                            String::from_utf8_lossy(name)
+                                        )
+                                    })?,
+                                )
+                            } else {
+                                ResolvedSymbolValue::Absolute(address)
+                            }
+                        }
+                    };
+                    Ok(symbol_value)
                 },
             )
         };
 
-    let empty_mem_offsets = output_sections.new_part_map::<u64>();
+    // Memory offsets of the output-section parts that have been laid out so far. Used to resolve
+    // object symbols referenced from location-counter expressions.
+    let mut laid_out_mem_offsets = output_sections.new_part_map::<Option<u64>>();
     let mut file_offset = 0;
     let mut mem_offset = expression_eval(
         &output_sections.base_address,
@@ -5513,7 +5591,7 @@ fn compute_layout_sections<'data, P: Platform>(
         memory_regions,
         &section_layouts,
         &[],
-        &empty_mem_offsets,
+        &laid_out_mem_offsets,
     )?;
     let mut lma_offset = mem_offset;
     let mut nonalloc_mem_offsets: OutputSectionMap<u64> =
@@ -5531,10 +5609,6 @@ fn compute_layout_sections<'data, P: Platform>(
     }
 
     let mut records_out = output_sections.new_part_map();
-
-    // Memory offsets of the output-section parts that have been laid out so far. Used to resolve
-    // object symbols referenced from location-counter expressions.
-    let mut laid_out_mem_offsets = output_sections.new_part_map::<u64>();
 
     // TLS sections without data (like .tbss) overlap normal sections in memory.
     // This is possible because every thread copies the TLS segments (see TLS PHDR)
@@ -5792,7 +5866,7 @@ fn compute_layout_sections<'data, P: Platform>(
                         file_offset += mem_size as usize;
                     }
 
-                    *laid_out_mem_offsets.get_mut(part_id) = part_layout.mem_offset;
+                    *laid_out_mem_offsets.get_mut(part_id) = Some(part_layout.mem_offset);
 
                     layout_section_from_part_layouts(
                         part_layout,
@@ -6060,6 +6134,7 @@ impl<'data, P: Platform> LinkerScriptLayoutState<'data, P> {
                 symbol_definitions: input.symbol_definitions,
                 start_symbol_id: input.symbol_id_range.start(),
             },
+            relative_location_counter_expressions: input.relative_location_counter_expressions,
         }
     }
 
@@ -6070,6 +6145,9 @@ impl<'data, P: Platform> LinkerScriptLayoutState<'data, P> {
         queue: &mut LocalWorkQueue<P>,
         scope: &Scope<'scope>,
     ) -> Result {
+        for expression in &self.relative_location_counter_expressions {
+            load_expression_referenced_symbols::<A>(resources, queue, scope, expression);
+        }
         self.internal_symbols
             .activate_symbols::<A>(common, resources, queue, scope)
     }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -6152,7 +6152,7 @@ impl<'data, P: Platform> LinkerScriptLayoutState<'data, P> {
                                 resources,
                                 queue,
                                 scope,
-                                &lc.get_expression(),
+                                lc.get_expression(),
                             );
                         }
                     }

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -161,6 +161,15 @@ pub(crate) enum LocationCounter<'data> {
     Relative(linker_script::Expression<'data>, SymbolLoc, OutputSectionId),
 }
 
+impl<'data> LocationCounter<'data> {
+    pub(crate) fn get_expression(&self) -> &linker_script::Expression<'data> {
+        match self {
+            LocationCounter::Absolute(expr, ..) => expr,
+            LocationCounter::Relative(expr, ..) => expr,
+        }
+    }
+}
+
 fn loc_for_global_expr<'data>(
     expr: &crate::linker_script::Expression<'data>,
     section_id: Option<OutputSectionId>,

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -17,7 +17,6 @@ use crate::input_data::FileId;
 use crate::input_data::InputRef;
 use crate::input_data::PRELUDE_FILE_ID;
 use crate::input_section_id::SectionIdRange;
-use crate::layout_rules::LocationCounter;
 use crate::layout_rules::SectionRuleOutcome;
 use crate::layout_rules::SectionRules;
 use crate::linker_script::Expression;
@@ -361,17 +360,6 @@ fn resolve_group<'data, 'definitions, P: Platform>(
                         symbol_id_range: s.symbol_id_range,
                         // TODO: Consider alternative to cloning this.
                         symbol_definitions: s.parsed.symbol_defs.clone(),
-                        relative_location_counter_expressions: s
-                            .parsed
-                            .location_counters
-                            .iter()
-                            .filter_map(|location_counter| match location_counter {
-                                LocationCounter::Relative(expression, ..) => {
-                                    Some(expression.clone())
-                                }
-                                LocationCounter::Absolute(..) => None,
-                            })
-                            .collect(),
                     })
                 })
                 .collect();
@@ -817,7 +805,6 @@ pub(crate) struct ResolvedLinkerScript<'data, P: Platform> {
     pub(crate) file_id: FileId,
     pub(crate) symbol_id_range: SymbolIdRange,
     pub(crate) symbol_definitions: Vec<InternalSymDefInfo<'data, P>>,
-    pub(crate) relative_location_counter_expressions: Vec<Expression<'data>>,
 }
 
 #[derive(Debug, Clone)]

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -17,6 +17,7 @@ use crate::input_data::FileId;
 use crate::input_data::InputRef;
 use crate::input_data::PRELUDE_FILE_ID;
 use crate::input_section_id::SectionIdRange;
+use crate::layout_rules::LocationCounter;
 use crate::layout_rules::SectionRuleOutcome;
 use crate::layout_rules::SectionRules;
 use crate::linker_script::Expression;
@@ -360,6 +361,17 @@ fn resolve_group<'data, 'definitions, P: Platform>(
                         symbol_id_range: s.symbol_id_range,
                         // TODO: Consider alternative to cloning this.
                         symbol_definitions: s.parsed.symbol_defs.clone(),
+                        relative_location_counter_expressions: s
+                            .parsed
+                            .location_counters
+                            .iter()
+                            .filter_map(|location_counter| match location_counter {
+                                LocationCounter::Relative(expression, ..) => {
+                                    Some(expression.clone())
+                                }
+                                LocationCounter::Absolute(..) => None,
+                            })
+                            .collect(),
                     })
                 })
                 .collect();
@@ -805,6 +817,7 @@ pub(crate) struct ResolvedLinkerScript<'data, P: Platform> {
     pub(crate) file_id: FileId,
     pub(crate) symbol_id_range: SymbolIdRange,
     pub(crate) symbol_definitions: Vec<InternalSymDefInfo<'data, P>>,
+    pub(crate) relative_location_counter_expressions: Vec<Expression<'data>>,
 }
 
 #[derive(Debug, Clone)]

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-earlier-section-symbol.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-earlier-section-symbol.ld
@@ -1,0 +1,27 @@
+ENTRY(begin_here)
+
+SECTIONS
+{
+    . = 0x10000;
+
+    .text : {
+        *(.text)
+        *(.text.*)
+    }
+
+    . = 0x20000;
+
+    .data : {
+        . = foo + 0x20000;
+        data_from_earlier_section = .;
+        *(.data)
+        *(.data.*)
+    }
+
+    .bss : {
+        *(.bss)
+        *(.bss.*)
+    }
+}
+
+ASSERT(data_from_earlier_section == foo + 0x20000, "incorrect address from earlier section symbol");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-symbols.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-symbols.ld
@@ -1,0 +1,51 @@
+ENTRY(begin_here)
+
+SECTIONS
+{
+    . = 0x600000;
+
+    .inputs : {
+        *(.text.1)
+        *(.text.2)
+        . = text_two + 0x100;
+        *(.text.3)
+        . = 0x1000;
+    }
+
+    .text : {
+        *(.text)
+        *(.text.*)
+    }
+
+    first_lc = .;
+
+    . = . + 0x100;
+
+    second_lc = .;
+
+    . = foo + 0x100000;
+
+    after_foo = .;
+
+    . = abs_between + 0x100;
+
+    after_abs_between = .;
+
+    . = abs_symbol;
+
+    after_abs = .;
+
+    .data : {
+        *(.data)
+        *(.data.*)
+    }
+}
+
+ASSERT(text_three > text_two, ".text.3 must be placed after .text.2");
+ASSERT(first_lc == ADDR(.text) + SIZEOF(.text), "first_lc is incorrect");
+ASSERT(second_lc > first_lc, "second_lc must be after first_lc");
+ASSERT(ADDR(.inputs) <= text_two && text_three < ADDR(.text), ".text.3 must be placed after .text.2");
+ASSERT(after_foo == foo + 0x100000, "after_foo is incorrect");
+ASSERT(after_abs_between == abs_between + 0x100, "after_abs_between is incorrect");
+ASSERT(after_abs == abs_symbol, "after_abs is incorrect");
+ASSERT(ADDR(.data) == after_abs, ".data must start at after_abs");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-symbols.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-symbols.ld
@@ -4,11 +4,11 @@ SECTIONS
 {
     . = 0x600000;
 
-    .inputs : {
-        *(.text.1)
-        *(.text.2)
-        . = text_two + 0x100;
-        *(.text.3)
+    .custom : {
+        *(.custom.1)
+        *(.custom.2)
+        . = custom_two + 0x100;
+        *(.custom.3)
         . = 0x1000;
     }
 
@@ -41,10 +41,10 @@ SECTIONS
     }
 }
 
-ASSERT(text_three > text_two, ".text.3 must be placed after .text.2");
+ASSERT(custom_three > custom_two, ".text.3 must be placed after .text.2");
 ASSERT(first_lc == ADDR(.text) + SIZEOF(.text), "first_lc is incorrect");
 ASSERT(second_lc > first_lc, "second_lc must be after first_lc");
-ASSERT(ADDR(.inputs) <= text_two && text_three < ADDR(.text), ".text.3 must be placed after .text.2");
+ASSERT(ADDR(.custom) <= custom_two && custom_three < ADDR(.text), ".text.3 must be placed after .text.2");
 ASSERT(after_foo == foo + 0x100000, "after_foo is incorrect");
 ASSERT(after_abs_between == abs_between + 0x100, "after_abs_between is incorrect");
 ASSERT(after_abs == abs_symbol, "after_abs is incorrect");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
@@ -48,6 +48,12 @@
 //#DiffIgnore:segment.LOAD.RX.alignment
 //#DiffIgnore:segment.LOAD.RWX.alignment
 
+//#Config:earlier_section_symbol
+//#Arch:x86_64
+//#LinkerScript:linker-script-earlier-section-symbol.ld
+//#Object:runtime.c
+//#RunEnabled:false
+
 //#Config:object_symbol_offset
 //#LinkerScript:linker-script-object-symbol-offset.ld
 //#Object:runtime.c
@@ -58,13 +64,34 @@
 //#DiffIgnore:segment.LOAD.RX.alignment
 //#DiffIgnore:segment.LOAD.RWX.alignment
 
-//#Config:symbol_in_sort
-//#ReferenceLinkers:
+//#Config:mixed_symbol_kinds
+//#Arch:x86_64
+//#ReferenceLinkers:bfd,lld
+//#LinkerScript:linker-script-mixed-symbol-kinds.ld
+//#Object:runtime.c
+//#RunEnabled:false
+//#DiffIgnore:segment.LOAD.RX.alignment
+//#DiffIgnore:segment.LOAD.RWX.alignment
+
+//#Config:symbol_with_unrelated_sort
+//#ReferenceLinkers:bfd,lld
 //#LinkerScript:linker-script-symbol-sort.ld
 //#Object:runtime.c
+//#RunEnabled:false
 // RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
 //#SkipArch:riscv64,ppc64le
-//#ExpectError:Early evaluation of sorted section .sort.b is not supported
+//#DiffIgnore:segment.LOAD.RX.alignment
+//#DiffIgnore:segment.LOAD.RWX.alignment
+
+//#Config:symbol_only_reference
+//#Arch:x86_64
+//#ReferenceLinkers:bfd,lld
+//#LinkerScript:linker-script-symbol-only-reference.ld
+//#Object:runtime.c
+//#Object:location-counter-only-symbol.c
+//#RunEnabled:false
+//#DiffIgnore:segment.LOAD.RX.alignment
+//#DiffIgnore:segment.LOAD.RWX.alignment
 
 #include <stddef.h>
 
@@ -87,6 +114,7 @@ __attribute__((section(".sort.c"), used)) void sort_c(void) {}
 
 __asm__(".global abs_symbol\n.set abs_symbol, 0x1000000\n");
 __asm__(".global abs_between\n.set abs_between, 0x650000\n");
+__asm__(".global abs_small\n.set abs_small, 5\n");
 
 void begin_here(void) {
   foo();

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
@@ -40,6 +40,24 @@
 //#DiffIgnore:segment.LOAD.RX.alignment
 //#DiffIgnore:segment.LOAD.RWX.alignment
 
+//#Config:symbols
+//#LinkerScript:linker-script-location-counter-symbols.ld
+//#Object:runtime.c
+// RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
+//#SkipArch:riscv64,ppc64le
+//#DiffIgnore:segment.LOAD.RX.alignment
+//#DiffIgnore:segment.LOAD.RWX.alignment
+
+//#Config:object_symbol_offset
+//#LinkerScript:linker-script-object-symbol-offset.ld
+//#Object:runtime.c
+//#Object:object-symbol-prefix.c
+//#Object:object-symbol-target.c
+// RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
+//#SkipArch:riscv64,ppc64le
+//#DiffIgnore:segment.LOAD.RX.alignment
+//#DiffIgnore:segment.LOAD.RWX.alignment
+
 #include <stddef.h>
 
 #include "../common/runtime.h"
@@ -51,7 +69,17 @@ __attribute__((section(".foo.second"), aligned(8))) int data_second = 2;
 
 __attribute__((section(".text.foo"))) void foo(void) {}
 
+__attribute__((section(".text.1"))) void text_one(void) {}
+__attribute__((section(".text.2"))) void text_two(void) {}
+__attribute__((section(".text.3"))) void text_three(void) {}
+
+__asm__(".global abs_symbol\n.set abs_symbol, 0x1000000\n");
+__asm__(".global abs_between\n.set abs_between, 0x650000\n");
+
 void begin_here(void) {
   foo();
+  text_one();
+  text_two();
+  text_three();
   exit_syscall(ret);
 }

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
@@ -85,7 +85,7 @@
 
 //#Config:symbol_only_reference
 //#Arch:x86_64
-//#ReferenceLinkers:bfd,lld
+//#ReferenceLinkers:lld
 //#LinkerScript:linker-script-symbol-only-reference.ld
 //#Object:runtime.c
 //#Object:location-counter-only-symbol.c

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
@@ -58,6 +58,14 @@
 //#DiffIgnore:segment.LOAD.RX.alignment
 //#DiffIgnore:segment.LOAD.RWX.alignment
 
+//#Config:symbol_in_sort
+//#ReferenceLinkers:
+//#LinkerScript:linker-script-symbol-sort.ld
+//#Object:runtime.c
+// RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
+//#SkipArch:riscv64,ppc64le
+//#ExpectError:Early evaluation of sorted section .sort.b is not supported
+
 #include <stddef.h>
 
 #include "../common/runtime.h"
@@ -69,17 +77,21 @@ __attribute__((section(".foo.second"), aligned(8))) int data_second = 2;
 
 __attribute__((section(".text.foo"))) void foo(void) {}
 
-__attribute__((section(".text.1"))) void text_one(void) {}
-__attribute__((section(".text.2"))) void text_two(void) {}
-__attribute__((section(".text.3"))) void text_three(void) {}
+__attribute__((section(".custom.1"))) void custom_one(void) {}
+__attribute__((section(".custom.2"))) void custom_two(void) {}
+__attribute__((section(".custom.3"))) void custom_three(void) {}
+
+__attribute__((section(".sort.b"), used)) void sort_b(void) {}
+__attribute__((section(".sort.a"), used)) void sort_a(void) {}
+__attribute__((section(".sort.c"), used)) void sort_c(void) {}
 
 __asm__(".global abs_symbol\n.set abs_symbol, 0x1000000\n");
 __asm__(".global abs_between\n.set abs_between, 0x650000\n");
 
 void begin_here(void) {
   foo();
-  text_one();
-  text_two();
-  text_three();
+  custom_one();
+  custom_two();
+  custom_three();
   exit_syscall(ret);
 }

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-mixed-symbol-kinds.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-mixed-symbol-kinds.ld
@@ -1,0 +1,32 @@
+ENTRY(begin_here)
+
+SECTIONS
+{
+    . = 0x600000;
+
+    .custom : {
+        *(.custom.1)
+        *(.custom.2)
+        . = custom_two + abs_small + 0x100;
+        mixed_symbol_location = .;
+        *(.custom.3)
+    }
+
+    .text : {
+        *(.text)
+        *(.text.*)
+    }
+
+    .data : {
+        *(.data)
+        *(.data.*)
+    }
+
+    .bss : {
+        *(.bss)
+        *(.bss.*)
+    }
+}
+
+ASSERT(mixed_symbol_location == custom_two + abs_small + 0x100,
+       "mixed symbol expression produced the wrong address");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-object-symbol-offset.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-object-symbol-offset.ld
@@ -1,0 +1,21 @@
+ENTRY(begin_here)
+
+SECTIONS
+{
+    . = 0x600000;
+    .text : {
+        *(.text)
+    }
+    .symbol_lookup : {
+        KEEP(*(.symbol_lookup))
+    }
+	. += ASSERT(displaced_symbol == ADDR(.symbol_lookup) + 32, "wrong address");
+    .data : {
+        *(.data)
+    }
+    .bss : {
+        KEEP(*(.bss))
+    }
+}
+
+ASSERT(displaced_symbol == ADDR(.symbol_lookup) + 32, "wrong address");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-symbol-only-reference.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-symbol-only-reference.ld
@@ -1,0 +1,30 @@
+ENTRY(begin_here)
+
+SECTIONS
+{
+    . = 0x600000;
+
+    .text : {
+        *(.text)
+        *(.text.*)
+    }
+
+    .location_counter_target : {
+        *(.location_counter_target)
+        . = location_counter_only_symbol + 0x100;
+        location_after_only_reference = .;
+    }
+
+    .data : {
+        *(.data)
+        *(.data.*)
+    }
+
+    .bss : {
+        *(.bss)
+        *(.bss.*)
+    }
+}
+
+ASSERT(location_after_only_reference == ADDR(.location_counter_target) + 0x100,
+       "location counter target was not positioned correctly");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-symbol-only-reference.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-symbol-only-reference.ld
@@ -15,6 +15,13 @@ SECTIONS
         location_after_only_reference = .;
     }
 
+    .location_counter_target_abs : {
+        *(.location_counter_target_abs)
+    }
+
+    . = location_counter_only_symbol_abs + 0x200;
+    location_after_abs_reference = .;
+
     .data : {
         *(.data)
         *(.data.*)
@@ -27,4 +34,6 @@ SECTIONS
 }
 
 ASSERT(location_after_only_reference == ADDR(.location_counter_target) + 0x100,
-       "location counter target was not positioned correctly");
+       "relative location counter target was not positioned correctly");
+ASSERT(location_after_abs_reference == ADDR(.location_counter_target_abs) + 0x200,
+       "absolute location counter target was not positioned correctly");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-symbol-sort.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-symbol-sort.ld
@@ -9,12 +9,11 @@ SECTIONS
         *(.custom.2)
         . = custom_two + 0x100;
         *(.custom.3)
-        . = 0x1000;
     }
 
     .sort : {
         KEEP(*(SORT_BY_NAME(.sort.*)))
-		ASSERT(sort_a < sort_b && sort_b < sort_c, "sort order is incorrect");
-		. += ASSERT(sort_a < sort_b && sort_b < sort_c, "sort order is incorrect");
     }
 }
+
+ASSERT(sort_a < sort_b && sort_b < sort_c, "sort order is incorrect");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-symbol-sort.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-symbol-sort.ld
@@ -1,0 +1,20 @@
+ENTRY(begin_here)
+
+SECTIONS
+{
+    . = 0x600000;
+
+    .custom : {
+        *(.custom.1)
+        *(.custom.2)
+        . = custom_two + 0x100;
+        *(.custom.3)
+        . = 0x1000;
+    }
+
+    .sort : {
+        KEEP(*(SORT_BY_NAME(.sort.*)))
+		ASSERT(sort_a < sort_b && sort_b < sort_c, "sort order is incorrect");
+		. += ASSERT(sort_a < sort_b && sort_b < sort_c, "sort order is incorrect");
+    }
+}

--- a/wild/tests/sources/elf/linker-script-location-counter/location-counter-only-symbol.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/location-counter-only-symbol.c
@@ -1,0 +1,2 @@
+__attribute__((section(".location_counter_target"),
+               aligned(1))) unsigned char location_counter_only_symbol;

--- a/wild/tests/sources/elf/linker-script-location-counter/location-counter-only-symbol.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/location-counter-only-symbol.c
@@ -1,2 +1,5 @@
 __attribute__((section(".location_counter_target"),
                aligned(1))) unsigned char location_counter_only_symbol;
+
+__attribute__((section(".location_counter_target_abs"),
+               aligned(1))) unsigned char location_counter_only_symbol_abs;

--- a/wild/tests/sources/elf/linker-script-location-counter/object-symbol-prefix.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/object-symbol-prefix.c
@@ -1,0 +1,1 @@
+__attribute__((section(".symbol_lookup"), aligned(1))) unsigned char symbol_prefix[32];

--- a/wild/tests/sources/elf/linker-script-location-counter/object-symbol-target.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/object-symbol-target.c
@@ -1,0 +1,1 @@
+__attribute__((section(".symbol_lookup"), aligned(1))) unsigned char displaced_symbol;

--- a/wild/tests/sources/elf/linker-script-relaxed-symbol/linker-script-relaxed-symbol.c
+++ b/wild/tests/sources/elf/linker-script-relaxed-symbol/linker-script-relaxed-symbol.c
@@ -1,0 +1,7 @@
+//#Arch:riscv64
+//#LinkerScript:linker-script-relaxed-symbol.ld
+//#ReferenceLinkers:bfd,lld
+//#Object:linker-script-relaxed-symbol.s
+//#RunEnabled:false
+//#DiffIgnore:file-header.entry
+//#DiffIgnore:section.text.alignment

--- a/wild/tests/sources/elf/linker-script-relaxed-symbol/linker-script-relaxed-symbol.ld
+++ b/wild/tests/sources/elf/linker-script-relaxed-symbol/linker-script-relaxed-symbol.ld
@@ -1,0 +1,14 @@
+ENTRY(relax_entry)
+
+SECTIONS
+{
+    . = 0x10000;
+    .text : {
+        *(.text.relax)
+        . = after_relaxed_call + 0x100;
+        data_address = .;
+        *(.data)
+    }
+}
+
+ASSERT(data_address == after_relaxed_call + 0x100, "relaxed symbol address is incorrect");

--- a/wild/tests/sources/elf/linker-script-relaxed-symbol/linker-script-relaxed-symbol.s
+++ b/wild/tests/sources/elf/linker-script-relaxed-symbol/linker-script-relaxed-symbol.s
@@ -1,0 +1,19 @@
+.option relax
+
+.section .text.relax,"ax",@progbits
+.global relax_entry
+.type relax_entry, @function
+relax_entry:
+    call relax_target
+
+.global after_relaxed_call
+.type after_relaxed_call, @function
+after_relaxed_call:
+    ret
+
+.type relax_target, @function
+relax_target:
+    ret
+
+.section .data,"aw",@progbits
+.byte 1


### PR DESCRIPTION
This PR adds support for symbol lookup within location counters in linker scripts. For now we only fetch the first definition of the symbol, if it was defined in a linker script.