### PR TITLE
port(MachO): Order TLV template sections

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -4792,6 +4792,10 @@ impl<C: ElfClass> platform::SectionAttributes for SectionAttributes<C> {
         self.flags.contains(shf::TLS)
     }
 
+    fn occupies_only_tls_address_space(&self) -> bool {
+        self.is_tls() && self.is_no_bits()
+    }
+
     fn is_writable(&self) -> bool {
         self.flags.contains(shf::WRITE)
     }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1987,10 +1987,11 @@ fn compute_segment_layout<'data, P: Platform>(
                             continue;
                         };
 
-                        // No-bits TLS sections neither exist in the file nor in the normal address
-                        // space. They shouldn't affect the extent of LOAD or RELRO segments.
-                        if section_info.section_attributes.is_tls()
-                            && section_info.section_attributes.is_no_bits()
+                        // Sections that occupy only TLS address space should not contribute to the
+                        // extent of non-TLS LOAD or RELRO segments.
+                        if section_info
+                            .section_attributes
+                            .occupies_only_tls_address_space()
                             && !program_segments.is_tls_segment(rec.segment_id)
                         {
                             continue;
@@ -5468,9 +5469,10 @@ fn compute_layout_sections<'data, P: Platform>(
                 let section_info = output_sections.output_info(section_id);
                 let section_offset = pending_location.take();
 
-                let is_tls_nobits = section_info.section_attributes.is_tls()
-                    && section_info.section_attributes.is_no_bits();
-                if is_tls_nobits {
+                if section_info
+                    .section_attributes
+                    .occupies_only_tls_address_space()
+                {
                     // Save our current mem_offset as we enter our first nobits TLS section
                     if tls_memsave.is_none() {
                         tls_memsave = Some(mem_offset);

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -63,6 +63,7 @@ use object::macho::S_ATTR_LOC_RELOC;
 use object::macho::S_ATTR_PURE_INSTRUCTIONS;
 use object::macho::S_ATTR_SOME_INSTRUCTIONS;
 use object::macho::S_GB_ZEROFILL;
+use object::macho::S_THREAD_LOCAL_REGULAR;
 use object::macho::S_THREAD_LOCAL_ZEROFILL;
 use object::macho::S_ZEROFILL;
 use object::macho::SECTION_ATTRIBUTES;
@@ -812,6 +813,10 @@ impl platform::SectionAttributes for SectionAttributes {
     }
 
     fn is_tls(&self) -> bool {
+        matches!(self.ty, S_THREAD_LOCAL_REGULAR | S_THREAD_LOCAL_ZEROFILL)
+    }
+
+    fn occupies_only_tls_address_space(&self) -> bool {
         false
     }
 
@@ -1843,6 +1848,10 @@ impl platform::Platform for MachO {
             add_sections_in_segment(&mut builder, output_sections, &custom.exec, segment);
             add_sections_in_segment(&mut builder, output_sections, &custom.ro, segment);
             add_sections_in_segment(&mut builder, output_sections, &custom.data, segment);
+            if segment == SegmentName::DATA {
+                add_sections_in_segment(&mut builder, output_sections, &custom.tdata, segment);
+                add_sections_in_segment(&mut builder, output_sections, &custom.tbss, segment);
+            }
             add_sections_in_segment(&mut builder, output_sections, &custom.bss, segment);
         }
 

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -1383,6 +1383,8 @@ pub(crate) trait SectionAttributes:
 
     fn is_tls(&self) -> bool;
 
+    fn occupies_only_tls_address_space(&self) -> bool;
+
     fn is_writable(&self) -> bool;
 
     fn is_no_bits(&self) -> bool;

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1297,6 +1297,10 @@ impl platform::SectionAttributes for SectionAttributes {
         false
     }
 
+    fn occupies_only_tls_address_space(&self) -> bool {
+        false
+    }
+
     fn is_writable(&self) -> bool {
         false
     }

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -354,6 +354,8 @@ use object::ObjectSymbol as _;
 use object::macho::LC_CODE_SIGNATURE;
 use object::macho::LC_DYLD_CHAINED_FIXUPS;
 use object::macho::LC_DYLD_EXPORTS_TRIE;
+use object::macho::S_THREAD_LOCAL_REGULAR;
+use object::macho::S_THREAD_LOCAL_ZEROFILL;
 use object::macho::SEG_LINKEDIT;
 use object::macho::SEG_TEXT;
 use object::read::elf::ProgramHeader;
@@ -4933,6 +4935,7 @@ impl Assertions {
         verify_no_overlapping_sections(obj)?;
         verify_no_overlapping_segments(obj)?;
         verify_chained_fixups_segment_offsets(obj, bytes)?;
+        verify_macho_tlv_template_layout(obj)?;
 
         if linker_used.is_wild() {
             verify_uuid(obj, bytes)?;
@@ -5969,6 +5972,49 @@ fn verify_macho_exports(obj: &object::File, bytes: &[u8]) -> Result<HashMap<Vec<
     }
 
     Ok(exports)
+}
+
+fn verify_macho_tlv_template_layout(obj: &object::File) -> Result {
+    let object::File::MachO64(_) = obj else {
+        return Ok(());
+    };
+
+    let mut sections = Vec::new();
+    for section in obj.sections() {
+        let object::SectionFlags::MachO { flags, .. } = section.flags() else {
+            bail!("Expected Mach-O section flags");
+        };
+
+        sections.push((section.name()?, flags.typ()));
+    }
+
+    let is_tlv_template = |ty| matches!(ty, S_THREAD_LOCAL_REGULAR | S_THREAD_LOCAL_ZEROFILL);
+
+    let (Some(start), Some(end)) = (
+        sections.iter().position(|&(_, ty)| is_tlv_template(ty)),
+        sections.iter().rposition(|&(_, ty)| is_tlv_template(ty)),
+    ) else {
+        return Ok(());
+    };
+
+    let template = &sections[start..=end];
+    let types = template.iter().map(|&(_, ty)| ty).dedup().collect_vec();
+
+    ensure!(
+        matches!(
+            types.as_slice(),
+            [S_THREAD_LOCAL_REGULAR]
+                | [S_THREAD_LOCAL_ZEROFILL]
+                | [S_THREAD_LOCAL_REGULAR, S_THREAD_LOCAL_ZEROFILL]
+        ),
+        "Mach-O TLV template sections must be contiguous: {}",
+        template
+            .iter()
+            .map(|(name, ty)| format!("{name} ({ty:?})"))
+            .join(", ")
+    );
+
+    Ok(())
 }
 
 fn verify_chained_fixups_segment_offsets(obj: &object::File, bytes: &[u8]) -> Result {

--- a/wild/tests/sources/macho/trivial-tls/trivial-tls.c
+++ b/wild/tests/sources/macho/trivial-tls/trivial-tls.c
@@ -1,0 +1,15 @@
+//#LinkerDriver:clang
+// TODO: We don't emit fixups for `__tlv_bootstrap` yet, so we need to disable `RunEnabled` and
+// `DiffEnabled` for now.
+//#RunEnabled:false
+//#DiffEnabled:false
+//#Object:runtime.c
+//#ExpectSection:__thread_data
+//#ExpectSection:__thread_bss
+
+#include "../common/runtime.h"
+
+_Thread_local int initialized = 1;
+_Thread_local int uninitialized;
+
+void main(void) { exit_syscall(42); }


### PR DESCRIPTION
The generic layout implements ELF semantics so that NOBITS TLS sections 1) overlap non-TLS sections in the virtual address space and 2) extend `PT_TLS.p_memsz` without extending a non-TLS segment. For Mach-O, `S_THREAD_LOCAL_ZEROFILL` is treated as a zerofill section (typically `__DATA,__thread_bss`) that occupies virtual address space. This diff introduces a new `SectionAttributes::is_tls_only` so that Mach-O can then use `is_tls` to classify `S_THREAD_LOCAL_REGULAR` and `S_THREAD_LOCAL_ZEROFILL` sections, since it shouldn't follow the behavior above.

[`dyld` also constructs a TLV initialization template from the first `S_THREAD_LOCAL_REGULAR` or `S_THREAD_LOCAL_ZEROFILL` section it sees to the last](https://github.com/apple-oss-distributions/dyld/blob/fd8d0c4d52320ebf64db34f3cb280310d905c5ae/libdyld/ThreadLocalVariables.cpp#L62-L90). These sections therefore need to be laid out contiguously, with `S_THREAD_LOCAL_REGULAR` before `S_THREAD_LOCAL_ZEROFILL`. `__thread_vars` and `__thread_ptrs` (proper support coming in a future diff) don't have to be contiguous. 

I plan on adding [TLV template alignment](https://github.com/llvm/llvm-project/blob/main/lld/MachO/Writer.cpp#L987-L1008) in the following diff.

**Before**:
```
  Caused by:
    Mach-O TLV template sections must be contiguous: __thread_data (S_THREAD_LOCAL_REGULAR), __thread_vars (S_THREAD_LOCAL_VARIABLES), __thread_bss (S_THREAD_LOCAL_ZEROFILL)



failures:
    macho/aarch64/tls/default

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.93s
```

**After**:
```
running 1 test
test macho/aarch64/trivial-tls/default ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 24 filtered out; finished in 1.10s
```

Part of #2071
