### PR TITLE
chore: Add test config option llvm_tools_dir

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,9 +211,13 @@ WILD_IGNORE_SKIP=mold cargo test --features mold_tests
 WILD_IGNORE_SKIP=all cargo test --features external_tests
 ```
 
-The LLD tests (`cargo test --features lld_tests`) require `llvm-mc` and `FileCheck` to be
-installed and available on your `PATH`. These are typically available via your distribution's
-LLVM package (e.g. `llvm` on Arch Linux), or by building LLVM from source.
+The LLD tests (`cargo test --features lld_tests`) require llvm-tools. e.g. `llvm-21-tools` and
+`llvm-21` on Ubuntu or `llvm` on Arch Linux. The location of these tools must be specified by
+`llvm_tools_dir` in your `test-config.toml`. e.g.:
+
+```toml
+llvm_tools_dir = "/usr/lib/llvm-21/bin"
+```
 
 ### Running external tests with other linkers
 

--- a/docker/arch-basic.Dockerfile
+++ b/docker/arch-basic.Dockerfile
@@ -12,6 +12,7 @@ RUN pacman --noconfirm -Syu \
     gcc \
     clang \
     lld \
+    llvm \
     rust
 
 RUN wget -qO- https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.71/cargo-chef-x86_64-unknown-linux-musl.tar.gz | tar -xzf- && \

--- a/docker/arch.Dockerfile
+++ b/docker/arch.Dockerfile
@@ -26,7 +26,8 @@ RUN pacman --noconfirm -Syu \
     capnproto \
     cmake \
     gdb \
-    ninja
+    ninja \
+    llvm
 
 # Install rr
 RUN useradd --no-create-home --shell=/bin/false build && usermod -L build && \

--- a/test-config.toml.sample
+++ b/test-config.toml.sample
@@ -4,3 +4,4 @@ qemu_arch = []                 # `["X86_64"]`, `["AArch64"]`, `["RiscV64"]`, `["
 allow_rust_musl_target = false # `true` or `false`
 diff_ignore = []               # ["rule1, "rule2"]
 run_all_diffs = true           # Enables diffing binaries against other linkers. Disabled by default.
+llvm_tools_dir = "/usr/bin"    # e.g. "/usr/lib/llvm-21/bin"

--- a/wild/tests/external_tests/lld_skip_tests.toml
+++ b/wild/tests/external_tests/lld_skip_tests.toml
@@ -87,7 +87,6 @@ tests = [
   "x86-64-retpoline-znow.s",
   "x86-64-retpoline-znow-linkerscript.s",
   "x86-64-retpoline-znow-static-iplt.s",
-  "x86-64-tls-gd-got.s",
   "x86-64-gotpc-offset.s",
   "x86-64-tls-le-align.s",
   "x86-64-tls-ld-preemptable.s",

--- a/wild/tests/external_tests/lld_tests.rs
+++ b/wild/tests/external_tests/lld_tests.rs
@@ -5,13 +5,17 @@
 //! These are available on distributions like Arch Linux.
 
 use crate::Result;
+use crate::TestConfig;
 use libtest_mimic::Failed;
 use libtest_mimic::Trial;
+use libwild::ensure;
+use libwild::error::Context as _;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
+use std::sync::Arc;
 use std::sync::OnceLock;
 
 #[derive(Deserialize)]
@@ -32,7 +36,11 @@ const PREFIX: &str = "external_test_suites/lld";
 /// (e.g. `x86-64-pcrel.s`, `aarch64-abs16.s`).
 const SUPPORTED_ARCHS: &[&str] = &["x86-64"];
 
-pub(crate) fn collect_tests(tests: &mut Vec<Trial>, filter: &crate::Filter) -> Result {
+pub(crate) fn collect_tests(
+    tests: &mut Vec<Trial>,
+    filter: &crate::Filter,
+    test_config: &TestConfig,
+) -> Result {
     if filter.excludes(PREFIX) {
         return Ok(());
     }
@@ -41,7 +49,13 @@ pub(crate) fn collect_tests(tests: &mut Vec<Trial>, filter: &crate::Filter) -> R
     if !test_dir.exists() {
         return Ok(());
     }
+
+    verify_system_requirements(test_config)?;
+
+    let test_config = Arc::new(test_config.clone());
+
     let dir = std::fs::read_dir(&test_dir)?;
+
     for ent in dir {
         let ent = ent?;
         let path = ent.path();
@@ -60,13 +74,15 @@ pub(crate) fn collect_tests(tests: &mut Vec<Trial>, filter: &crate::Filter) -> R
 
             let name = format!("{PREFIX}/test/ELF/{file_name}");
 
+            let test_config = test_config.clone();
+
             if !should_skip_lld_test(&path) {
                 tests.push(Trial::test(name, move || {
-                    run_lld_test(&path).map_err(|e| Failed::from(e.to_string()))
+                    run_lld_test(&path, &test_config).map_err(|e| Failed::from(e.to_string()))
                 }));
             } else {
                 tests.push(Trial::test(format!("{name}/expect_failure"), move || {
-                    verify_skipped_lld_test_still_fails(&path)
+                    verify_skipped_lld_test_still_fails(&path, &test_config)
                         .map_err(|e| Failed::from(e.to_string()))
                 }));
             }
@@ -75,8 +91,24 @@ pub(crate) fn collect_tests(tests: &mut Vec<Trial>, filter: &crate::Filter) -> R
     Ok(())
 }
 
-fn verify_skipped_lld_test_still_fails(test_file: &Path) -> Result {
-    if run_lld_test(test_file).is_ok() {
+fn verify_system_requirements(test_config: &TestConfig) -> Result {
+    // We don't check for all tools that the tests require, just ones that are known to sometimes be
+    // in different distro packages.
+    for tool in ["llvm-mc", "FileCheck"] {
+        let path = test_config.llvm_tools_dir.join(tool);
+        ensure!(
+            path.exists(),
+            "`{}` doesn't exist. Please install appropriate package or \
+            update llvm_tools_dir in test-config.toml",
+            path.display()
+        );
+    }
+
+    Ok(())
+}
+
+fn verify_skipped_lld_test_still_fails(test_file: &Path, test_config: &TestConfig) -> Result {
+    if run_lld_test(test_file, test_config).is_ok() {
         return Err(format!(
             "Test `{}` is in the skip list but now passes. Should be removed from skip list.",
             test_file.display()
@@ -86,16 +118,14 @@ fn verify_skipped_lld_test_still_fails(test_file: &Path) -> Result {
     Ok(())
 }
 
-fn run_lld_test(test_file: &Path) -> Result {
-    let llvm_mc = find_tool("llvm-mc")?;
-    let filecheck = find_tool("FileCheck")?;
+fn run_lld_test(test_file: &Path, test_config: &TestConfig) -> Result {
     let content = std::fs::read_to_string(test_file)?;
     let tmpdir = tempfile::tempdir()?;
 
     for cmd in extract_run_lines(&content) {
         let cmd = substitute_vars(&cmd, test_file, tmpdir.path());
-        let cmd = substitute_tools(&cmd, &llvm_mc, &filecheck);
-        execute_command(&cmd)?;
+        let cmd = substitute_tools(&cmd);
+        execute_command(&cmd, test_config)?;
     }
     Ok(())
 }
@@ -144,26 +174,23 @@ fn extract_run_lines(content: &str) -> Vec<String> {
     commands
 }
 
+fn path_to_str(path: &Path) -> &str {
+    path.to_str()
+        .with_context(|| format!("Non-UTF-8 path `{}`", path.display()))
+        .unwrap()
+}
+
 fn substitute_vars(cmd: &str, test_file: &Path, tmpdir: &Path) -> String {
-    let dir = test_file.parent().unwrap().display().to_string();
-    cmd.replace("%s", &test_file.display().to_string())
-        .replace("%t", &tmpdir.join("test").display().to_string())
-        .replace("%S", &dir)
-        .replace("%p", &dir)
+    let dir = test_file.parent().unwrap();
+    cmd.replace("%s", path_to_str(test_file))
+        .replace("%t", path_to_str(&tmpdir.join("test")))
+        .replace("%S", path_to_str(dir))
+        .replace("%p", path_to_str(dir))
 }
 
-fn substitute_tools(cmd: &str, llvm_mc: &str, filecheck: &str) -> String {
+fn substitute_tools(cmd: &str) -> String {
     const WILD: &str = env!("CARGO_BIN_EXE_wild");
-    cmd.replace("llvm-mc", llvm_mc)
-        .replace("FileCheck", filecheck)
-        .replace("ld.lld", &format!("{WILD} -m elf_x86_64"))
-}
-
-fn find_tool(name: &str) -> Result<String> {
-    if let Ok(path) = which::which(name) {
-        return Ok(path.display().to_string());
-    }
-    Err(format!("Required tool '{name}' not found. Install LLVM tools.").into())
+    cmd.replace("ld.lld", &format!("{WILD} -m elf_x86_64"))
 }
 
 // TODO: This harness doesn't support the `split-file` tool or `cd %t`
@@ -174,8 +201,19 @@ fn find_tool(name: &str) -> Result<String> {
 // (currently each command runs independently via `sh -c` with no
 // persisted cwd). Tracked as follow-up work; affected tests are
 // skip-listed under `split_file_unsupported` in lld_skip_tests.toml.
-fn execute_command(cmd: &str) -> Result {
-    let output = Command::new("sh").arg("-c").arg(cmd).output()?;
+fn execute_command(cmd: &str, test_config: &TestConfig) -> Result {
+    let mut command = Command::new("sh");
+
+    command.env(
+        "PATH",
+        format!(
+            "{}:{}",
+            path_to_str(&test_config.llvm_tools_dir),
+            std::env::var("PATH").expect("PATH required")
+        ),
+    );
+
+    let output = command.arg("-c").arg(cmd).output()?;
     if !output.status.success() {
         return Err(format!(
             "Command failed: {cmd}\nstdout: {}\nstderr: {}",

--- a/wild/tests/external_tests/mod.rs
+++ b/wild/tests/external_tests/mod.rs
@@ -3,6 +3,7 @@ mod mold_tests;
 
 use crate::Filter;
 use crate::Result;
+use crate::TestConfig;
 use libtest_mimic::Trial;
 use std::env;
 use std::io::Write;
@@ -12,13 +13,17 @@ use std::process::Command;
 use std::process::Output;
 use std::sync::OnceLock;
 
-pub(super) fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
+pub(super) fn collect_tests(
+    tests: &mut Vec<Trial>,
+    filter: &Filter,
+    test_config: &TestConfig,
+) -> Result {
     if cfg!(feature = "mold_tests") {
-        mold_tests::collect_tests(tests, filter)?;
+        mold_tests::collect_tests(tests, filter, test_config)?;
     }
 
     if cfg!(feature = "lld_tests") {
-        lld_tests::collect_tests(tests, filter)?;
+        lld_tests::collect_tests(tests, filter, test_config)?;
     }
 
     Ok(())

--- a/wild/tests/external_tests/mold_tests.rs
+++ b/wild/tests/external_tests/mold_tests.rs
@@ -1,5 +1,6 @@
 use crate::Architecture;
 use crate::Result;
+use crate::TestConfig;
 use crate::external_tests::external_linker_name;
 use crate::external_tests::run_external_test;
 use crate::external_tests::should_not_ignore_tests;
@@ -58,7 +59,11 @@ fn run_mold_test(mold_test: &Path) -> Result<Output> {
     run_external_test(mold_test, &env_vars)
 }
 
-pub(crate) fn collect_tests(tests: &mut Vec<Trial>, filter: &crate::Filter) -> Result {
+pub(crate) fn collect_tests(
+    tests: &mut Vec<Trial>,
+    filter: &crate::Filter,
+    test_config: &TestConfig,
+) -> Result {
     if filter.excludes(PREFIX) {
         return Ok(());
     }
@@ -83,13 +88,13 @@ pub(crate) fn collect_tests(tests: &mut Vec<Trial>, filter: &crate::Filter) -> R
                 format!("{PREFIX}/test/{file_name}")
             };
 
-            if !should_skip_mold_test(&path) && !should_skip_by_local_config(&path) {
+            if !should_skip_mold_test(&path) && !should_skip_by_local_config(&path, test_config) {
                 tests.push(Trial::test(name, move || {
                     check_mold_tests_regression(path).map_err(|e| Failed::from(e.to_string()))
                 }));
             } else if should_skip_mold_test_by_toml(&path)
                 && !should_skip_mold_test_by_arch(&path)
-                && !should_skip_by_local_config(&path)
+                && !should_skip_by_local_config(&path, test_config)
             {
                 tests.push(Trial::test(format!("{name}/expect_failure"), move || {
                     verify_skipped_mold_tests_still_fail(path)
@@ -194,15 +199,10 @@ fn should_skip_mold_test_by_toml(path: &Path) -> bool {
 
 /// Returns whether the user's test-config.toml says to skip a particular test. If this returns
 /// true, then we skip both the positive and negative versions of the test.
-fn should_skip_by_local_config(path: &Path) -> bool {
-    if let Ok(config) = crate::read_test_config()
-        && let Some(name) = path.file_name().and_then(|name| name.to_str())
-        && config.ignore_external_tests.iter().any(|n| n == name)
-    {
-        true
-    } else {
-        false
-    }
+fn should_skip_by_local_config(path: &Path, config: &TestConfig) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| config.ignore_external_tests.iter().any(|n| n == name))
 }
 
 // Some mold tests have names starting with `arch-`, indicating the target architecture they run on.

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -404,15 +404,14 @@ fn main() -> Result<std::process::ExitCode> {
         args.color = Some(libtest_mimic::ColorSetting::Always);
     }
     let filter = Filter::new(&args);
+    let test_config = read_test_config()?;
     let mut tests = Vec::new();
-    collect_tests(&mut tests, &filter)?;
-    external_tests::collect_tests(&mut tests, &filter)?;
+    collect_tests(&mut tests, &filter, &test_config)?;
+    external_tests::collect_tests(&mut tests, &filter, &test_config)?;
     Ok(libtest_mimic::run(&args, tests).exit_code())
 }
 
-fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
-    let test_config = read_test_config()?;
-
+fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter, test_config: &TestConfig) -> Result {
     let host_arch = get_host_architecture();
 
     for platform in [PlatformKind::Elf, PlatformKind::MachO, PlatformKind::Wasm] {
@@ -459,7 +458,7 @@ fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
                         platform,
                         arch,
                         path.clone(),
-                        &test_config,
+                        test_config,
                         &linker_catalog,
                     ),
                 )?;
@@ -1372,6 +1371,9 @@ struct TestConfig {
     /// A list of external tests to ignore. Expected values are filenames not full paths.
     #[serde(default)]
     ignore_external_tests: Vec<String>,
+
+    #[serde(default = "default_llvm_tools_dir")]
+    llvm_tools_dir: PathBuf,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, serde::Deserialize, Debug, Default)]
@@ -7794,4 +7796,8 @@ impl FatArch for object::read::macho::FatArch64 {
 
         Ok(())
     }
+}
+
+fn default_llvm_tools_dir() -> PathBuf {
+    PathBuf::from("/usr/bin")
 }


### PR DESCRIPTION
On Ubuntu, the package llvm-21-tools installs e.g. `/usr/bin/FileCheck-21` and `/usr/lib/llvm-21/bin/FileCheck`. Just adding `/usr/lib/llvm-21/bin` globally to my path doesn't seem appealing, especially since it contains a binary called "not", which seems a bit special-purpose. Instead, we now require that for running lld tests, `lld_tools_dir` in `test-config.toml` needs to point to the directory containing these tools.

I also got rid of some code that was using `.display().to_string()` to produce a string that would be executed. If the path had contained non-UTF-8 characters, then this would have given a confusing error. Given that this is a test, it's better to panic with a reasonable error message.

I also removed code that was substituting `FileCheck` and `llvm-mc` for absolute paths to these tools. I couldn't figure out a reason why we'd need to do this given that they'll be found on the path which was where we were getting the absolute paths from. But maybe I'm missing some reason why this was necessary.

`x86-64-tls-gd-got.s` was passing, so I removed it from the exclusion list.

Tested on Ubuntu 26.04 and on Arch Linux.