### PR TITLE
test: Wire up ignore_external_tests for LLD tests

### DIFF
--- a/wild/tests/external_tests/lld_tests.rs
+++ b/wild/tests/external_tests/lld_tests.rs
@@ -6,6 +6,7 @@
 
 use crate::Result;
 use crate::TestConfig;
+use crate::external_tests::should_skip_by_local_config;
 use libtest_mimic::Failed;
 use libtest_mimic::Trial;
 use libwild::ensure;
@@ -73,8 +74,11 @@ pub(crate) fn collect_tests(
             }
 
             let name = format!("{PREFIX}/test/ELF/{file_name}");
-
             let test_config = test_config.clone();
+
+            if should_skip_by_local_config(&path, &test_config) {
+                continue;
+            }
 
             if !should_skip_lld_test(&path) {
                 tests.push(Trial::test(name, move || {

--- a/wild/tests/external_tests/mod.rs
+++ b/wild/tests/external_tests/mod.rs
@@ -29,6 +29,14 @@ pub(super) fn collect_tests(
     Ok(())
 }
 
+/// Returns whether the user's test-config.toml says to skip a particular test. If this returns
+/// true, then we skip both the positive and negative versions of the test.
+pub(super) fn should_skip_by_local_config(path: &Path, config: &TestConfig) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| config.ignore_external_tests.iter().any(|n| n == name))
+}
+
 #[derive(Clone, Debug)]
 enum ExternalLinker {
     Wild,

--- a/wild/tests/external_tests/mold_tests.rs
+++ b/wild/tests/external_tests/mold_tests.rs
@@ -4,6 +4,7 @@ use crate::TestConfig;
 use crate::external_tests::external_linker_name;
 use crate::external_tests::run_external_test;
 use crate::external_tests::should_not_ignore_tests;
+use crate::external_tests::should_skip_by_local_config;
 use crate::external_tests::using_third_party_linker;
 use crate::get_host_architecture;
 use crate::get_wild_test_cross;
@@ -195,14 +196,6 @@ fn should_skip_mold_test_by_toml(path: &Path) -> bool {
     }
 
     false
-}
-
-/// Returns whether the user's test-config.toml says to skip a particular test. If this returns
-/// true, then we skip both the positive and negative versions of the test.
-fn should_skip_by_local_config(path: &Path, config: &TestConfig) -> bool {
-    path.file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| config.ignore_external_tests.iter().any(|n| n == name))
 }
 
 // Some mold tests have names starting with `arch-`, indicating the target architecture they run on.


### PR DESCRIPTION
Moves `should_skip_by_local_config` to the shared `external_tests` module and wires it into `lld_tests`, so `ignore_external_tests` in `test-config.toml` now works for LLD tests too (previously only mold tests).

Part of #2380 