### PR TITLE
feat: support aligning a given expression in linker scripts

### DIFF
--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -214,18 +214,23 @@ fn evaluate_expression_value<'data, P: Platform>(
             section_load_address(name, section_layouts, output_sections)
         }
 
-        Expression::Align(expr) => {
-            let align = eval!(expr)?;
+        Expression::Align(exponent, expr) => {
+            let align = eval!(exponent)?;
             if align == 0 {
                 bail!("ALIGN(0) is invalid");
             }
-            let location = evaluate_location(
-                expr_loc,
-                section_layouts,
-                output_sections,
-                resolved_location_counters,
+            let expr = expr.as_ref().map_or_else(
+                || {
+                    evaluate_location(
+                        expr_loc,
+                        section_layouts,
+                        output_sections,
+                        resolved_location_counters,
+                    )
+                },
+                |e| eval!(e),
             )?;
-            Ok(location.wrapping_add(align - 1) & !(align - 1))
+            Ok(expr.wrapping_add(align - 1) & !(align - 1))
         }
 
         Expression::Min(l, r) => Ok(eval!(l)?.min(eval!(r)?)),
@@ -727,19 +732,19 @@ mod tests {
     fn test_align() {
         // ALIGN(8) with location counter 0 → 0
         assert_eq!(
-            eval_const(&Expression::Align(Box::new(Expression::Number(8)))).unwrap(),
+            eval_const(&Expression::Align(Box::new(Expression::Number(8)), None)).unwrap(),
             0
         );
         // ALIGN(1) → 0
         assert_eq!(
-            eval_const(&Expression::Align(Box::new(Expression::Number(1)))).unwrap(),
+            eval_const(&Expression::Align(Box::new(Expression::Number(1)), None)).unwrap(),
             0
         );
     }
 
     #[test]
     fn test_align_zero_is_error() {
-        assert!(eval_const(&Expression::Align(Box::new(Expression::Number(0)))).is_err());
+        assert!(eval_const(&Expression::Align(Box::new(Expression::Number(0)), None)).is_err());
     }
 
     #[test]

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -230,7 +230,7 @@ fn evaluate_expression_value<'data, P: Platform>(
                 },
                 |e| eval!(e),
             )?;
-            Ok(expr.wrapping_add(align - 1) & !(align - 1))
+            Ok(expr.next_multiple_of(align))
         }
 
         Expression::Min(l, r) => Ok(eval!(l)?.min(eval!(r)?)),

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -231,7 +231,7 @@ pub(crate) enum Expression<'a> {
     Length(&'a [u8]),
     Addr(&'a [u8]),
     Loadaddr(&'a [u8]),
-    Align(Box<Expression<'a>>),
+    Align(Box<Expression<'a>>, Option<Box<Expression<'a>>>),
     /// MIN and MAX functions (take two expressions)
     Min(Box<Expression<'a>>, Box<Expression<'a>>),
     Max(Box<Expression<'a>>, Box<Expression<'a>>),
@@ -314,11 +314,12 @@ impl<'a> Expression<'a> {
             | Expression::LeftShift(l, r)
             | Expression::RightShift(l, r)
             | Expression::LogicalAnd(l, r)
-            | Expression::LogicalOr(l, r) => {
+            | Expression::LogicalOr(l, r)
+            | Expression::Align(l, Some(r)) => {
                 l.visit_expressions(cb);
                 r.visit_expressions(cb);
             }
-            Expression::Align(e)
+            Expression::Align(e, None)
             | Expression::LogicalNot(e)
             | Expression::BitwiseNot(e)
             | Expression::Negate(e)
@@ -968,10 +969,22 @@ fn parse_identifier_or_function<'a>(input: &mut &'a BStr) -> winnow::Result<Expr
             }
             b"ALIGN" => {
                 '('.parse_next(input)?;
-                let arg_expr = parse_expression.parse_next(input)?;
+                let arg_0 = parse_expression.parse_next(input)?;
                 multispace0.parse_next(input)?;
+                let arg_1 = if opt(',').parse_next(input)?.is_some() {
+                    multispace0.parse_next(input)?;
+                    let arg_1 = parse_expression.parse_next(input)?;
+                    multispace0.parse_next(input)?;
+                    Some(arg_1)
+                } else {
+                    None
+                };
                 ')'.parse_next(input)?;
-                Ok(Expression::Align(Box::new(arg_expr)))
+                if let Some(arg_1) = arg_1 {
+                    Ok(Expression::Align(Box::new(arg_1), Some(Box::new(arg_0))))
+                } else {
+                    Ok(Expression::Align(Box::new(arg_0), None))
+                }
             }
             b"MIN" => {
                 // MIN takes two expressions separated by comma
@@ -1784,7 +1797,7 @@ mod tests {
                                 address: Expression::Number(0x1000000),
                             }),
                             SectionCommand::SetLocation(Location {
-                                address: Expression::Align(Box::new(Expression::Number(16))),
+                                address: Expression::Align(Box::new(Expression::Number(16)), None),
                             }),
                             SectionCommand::Section(Section {
                                 output_section_name: b".foo",
@@ -1802,9 +1815,10 @@ mod tests {
                                         }],
                                     }),
                                     ContentsCommand::SetLocation(Location {
-                                        address: Expression::Align(Box::new(Expression::Number(
-                                            32,
-                                        ))),
+                                        address: Expression::Align(
+                                            Box::new(Expression::Number(32)),
+                                            None,
+                                        ),
                                     }),
                                     ContentsCommand::SymbolAssignment(SymbolAssignment {
                                         name: b"end_foo",

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
@@ -72,3 +72,4 @@ ASSERT(symbol9 == 0x160, "symbol9 must be 0x160");
 symbol12 = ASSERT(ASSERT(0x5000 < 0x10000, "0x5000 < 0x10000 must be true") == 1, "ASSERT must return 1");
 . = ASSERT(symbol12 == 1, "must be 1");
 ASSERT(ALIGN(0x38, 16) == 0x40, "ALIGN value is incorrect");
+ASSERT(ALIGN(0x38, 18) == 0x48, "ALIGN value is incorrect");

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
@@ -71,3 +71,4 @@ ASSERT(symbol9 == 0x160, "symbol9 must be 0x160");
 
 symbol12 = ASSERT(ASSERT(0x5000 < 0x10000, "0x5000 < 0x10000 must be true") == 1, "ASSERT must return 1");
 . = ASSERT(symbol12 == 1, "must be 1");
+ASSERT(ALIGN(0x38, 16) == 0x40, "ALIGN value is incorrect");


### PR DESCRIPTION
The `ALIGN` function in linker scripts can have a second expression passed, which is used in place of the default, which is the current location counter.