### PR TITLE
test: Pass macOS SDK and libSystem args to direct linkers

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -4304,6 +4304,9 @@ impl LinkCommand {
                             }
                         }
                         PlatformKind::MachO => {
+                            let (_, sdk) = macos_toolchain()
+                                .map_err(|err| error!("Unable to locate macOS toolchain: {err}"))?;
+                            command.arg("-syslibroot").arg(sdk).arg("-lSystem");
                             if linker.is_lld() {
                                 let arch = cross_arch.unwrap_or(arch);
                                 command.arg("-arch").arg(arch.darwin_arch_name());
@@ -7043,7 +7046,7 @@ fn available_linkers_for_linux() -> Result<Vec<Linker>> {
 
 fn available_linkers_for_mac() -> Result<LinkerCatalog> {
     let mut linkers = Vec::new();
-    let (path, sdk_path) = macos_toolchain()
+    let (path, _) = macos_toolchain()
         .map_err(|reason| error!("Apple linker `ld` is required for Mach-O tests: {reason}"))?;
 
     linkers.push(Linker::ThirdParty(ThirdPartyLinker {
@@ -7051,11 +7054,7 @@ fn available_linkers_for_mac() -> Result<LinkerCatalog> {
         gcc_name: "ld",
         path: path.clone(),
         cross_paths: HashMap::new(),
-        direct_args: vec![
-            OsString::from("-syslibroot"),
-            sdk_path.as_os_str().to_owned(),
-            OsString::from("-lSystem"),
-        ],
+        direct_args: Vec::new(),
         enabled_by_default: true,
     }));
 

--- a/wild/tests/sources/macho/trivial-tls/trivial-tls.c
+++ b/wild/tests/sources/macho/trivial-tls/trivial-tls.c
@@ -1,4 +1,3 @@
-//#LinkerDriver:clang
 // TODO: We don't emit fixups for `__tlv_bootstrap` yet, so we need to disable `RunEnabled` and
 // `DiffEnabled` for now.
 //#RunEnabled:false


### PR DESCRIPTION
Passes in `-syslibroot <SDK> -lSystem` args to all linkers when linking directly on macOS. Clang provides these automatically, but when linking directly in our integration harness, all linkers need them explicitly passed in to resolve references to symbols found in system libraries/frameworks.

**Before**:
```
running 1 test
  test macho/aarch64/trivial-tls/default ... FAILED

  failures:

  ---- macho/aarch64/trivial-tls/default ----
  Test failed: `trivial-tls.c` with linker `lld` config `default`
    Caused by:
      Linker failed:
  ld64.lld: error: undefined symbol: __tlv_bootstrap
```
```
running 1 test
  test macho/aarch64/trivial-tls/default ... FAILED

  failures:

  ---- macho/aarch64/trivial-tls/default ----
  Test failed: `trivial-tls.c` with linker `wild` config `default`
    Caused by:
    Undefined symbol __tlv_bootstrap,
```

**After**:
```
  running 1 test
  test macho/aarch64/trivial-tls/default ... ok

  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.23s
```