### PR TITLE
fix: correctly resolve location counter addresses after a section in linker scripts

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -5404,7 +5404,14 @@ fn compute_layout_sections<'data, P: Platform>(
 
     for event in output_order {
         match event {
-            OrderEvent::SetLocation(expr, loc, idx) => {
+            OrderEvent::SetLocation(expr, mut loc, idx) => {
+                if matches!(loc, SymbolLoc::SectionEnd(_)) {
+                    resolved_lc[idx] = ResolvedLocationCounter {
+                        value: mem_offset,
+                        section_offset: None,
+                    };
+                    loc = SymbolLoc::LocationCounter(idx, None);
+                }
                 let value =
                     expression_eval(&expr, &loc, memory_regions, &section_layouts, &resolved_lc)?;
                 pending_location = Some(value);

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-lc-after-section.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-lc-after-section.ld
@@ -1,0 +1,27 @@
+ENTRY(begin_here)
+
+SECTIONS
+{
+    . = 0x600000;
+    .text : {
+        *(.text)
+    }
+	text_end = .;
+
+    . += 0x40;
+
+    .data : {
+        *(.data)
+        *(.data.*)
+    }
+
+    . = . + 0x40;
+
+    .bss : {
+        KEEP(*(.bss))
+    }
+}
+
+ASSERT(ADDR(.text.foo) > ADDR(.text), ".data should be placed after .text");
+ASSERT(ADDR(.text.foo) < ADDR(.data), ".data should be placed after .text");
+ASSERT(text_end == ADDR(.text) + SIZEOF(.text), "text_end is incorrect");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-lc-after-section.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-lc-after-section.ld
@@ -22,6 +22,6 @@ SECTIONS
     }
 }
 
-ASSERT(ADDR(.text.foo) == ADDR(.text) + SIZEOF(.text), ".text.foo should be placed after .text");
+ASSERT(ADDR(.text.foo) >= ADDR(.text) + SIZEOF(.text), ".text.foo should be placed after .text");
 ASSERT(ADDR(.text.foo) < ADDR(.data), ".data should be placed after .text.foo");
 ASSERT(text_end == ADDR(.text) + SIZEOF(.text), "text_end is incorrect");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-lc-after-section.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-lc-after-section.ld
@@ -22,6 +22,6 @@ SECTIONS
     }
 }
 
-ASSERT(ADDR(.text.foo) > ADDR(.text), ".data should be placed after .text");
-ASSERT(ADDR(.text.foo) < ADDR(.data), ".data should be placed after .text");
+ASSERT(ADDR(.text.foo) == ADDR(.text) + SIZEOF(.text), ".text.foo should be placed after .text");
+ASSERT(ADDR(.text.foo) < ADDR(.data), ".data should be placed after .text.foo");
 ASSERT(text_end == ADDR(.text) + SIZEOF(.text), "text_end is incorrect");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
@@ -32,6 +32,14 @@
 //#LinkerScript:linker-script-location-counter-underflow.ld
 //#ExpectError:(?i-u)cannot move location counter backwards
 
+//#Config:lc_after_section
+//#LinkerScript:linker-script-lc-after-section.ld
+//#Object:runtime.c
+// RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
+//#SkipArch:riscv64,ppc64le
+//#DiffIgnore:segment.LOAD.RX.alignment
+//#DiffIgnore:segment.LOAD.RWX.alignment
+
 #include <stddef.h>
 
 #include "../common/runtime.h"


### PR DESCRIPTION
Location counters defined immediately after an output section should be resolved to the last placed section, not just the previous section. For example,
```ld
SECTION {
  .text {
   *(.text)
  }
  . += 0x40;
  .data {
    *(.data)
  }
}
```
The linker might place other executable sections that are not defined in the script after `.text`. In such cases, the location counter must continue after all implicitly placed sections.