### PR TITLE
perf: Make OutputSectionPartMap sparse for custom sections

### DIFF
--- a/libwild/src/compression.rs
+++ b/libwild/src/compression.rs
@@ -360,7 +360,7 @@ fn build_regular_debug_section<C: ElfClass, A: Arch<Platform = elf::Elf<C>>>(
         .group_layouts
         .iter()
         .map(|group| {
-            let size: usize = group.file_sizes[part_range.clone()].iter().sum();
+            let size: usize = group.file_sizes.values_in_range(part_range.clone()).sum();
             let group_buf = remaining.split_off_mut(..size).unwrap();
             (group, group_buf)
         })

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -853,7 +853,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
     }
 
     fn validate_sizes(mem_sizes: &OutputSectionPartMap<u64>) -> Result {
-        if *mem_sizes.get(part_id::GNU_VERSION) > 0 {
+        if mem_sizes.get(part_id::GNU_VERSION) > 0 {
             let num_dynamic_symbols = mem_sizes.get(part_id::DYNSYM) / C::SYMTAB_ENTRY_SIZE;
             let num_versym = mem_sizes.get(part_id::GNU_VERSION) / size_of::<Versym>() as u64;
             if num_versym != num_dynamic_symbols {
@@ -869,7 +869,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
 
     fn finalise_group_layout(memory_offsets: &OutputSectionPartMap<u64>) -> Self::GroupLayoutExt {
         GroupLayoutExt {
-            eh_frame_start_address: *memory_offsets.get(part_id::EH_FRAME),
+            eh_frame_start_address: memory_offsets.get(part_id::EH_FRAME),
         }
     }
 
@@ -877,7 +877,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
         // References to symbols defined in .eh_frame are a bit weird, since it's a section where
         // we're GCing stuff, but crtbegin.o and crtend.o use them in order to find the start and
         // end of the whole .eh_frame section.
-        *memory_offsets.get(part_id::EH_FRAME)
+        memory_offsets.get(part_id::EH_FRAME)
     }
 
     fn post_gc<'data>(
@@ -984,7 +984,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
                 .section_layouts
                 .get(output_section_id::GNU_VERSION_R);
 
-            is_last_verneed = *memory_offsets.get(part_id::GNU_VERSION_R)
+            is_last_verneed = memory_offsets.get(part_id::GNU_VERSION_R)
                 == version_r_layout.mem_offset + version_r_layout.mem_size;
         }
 
@@ -1828,7 +1828,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
         format_specific: &Self::FinaliseSizesExt<'_>,
         args: &ElfArgs,
     ) -> Result {
-        if format_specific.has_eh_frame_input || *current_sizes.get(part_id::EH_FRAME) != 0 {
+        if format_specific.has_eh_frame_input || current_sizes.get(part_id::EH_FRAME) != 0 {
             extra_sizes.increment(part_id::EH_FRAME, size_of::<u32>() as u64);
             state.needs_eh_frame_terminator = true;
         }
@@ -1837,7 +1837,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
             allocate_sysv_hash(state, current_sizes, extra_sizes, dynamic_symbol_defs)?;
         }
         if args.is_relr_enabled() {
-            let got_relr_size = *current_sizes.get(part_id::GOT_RELR);
+            let got_relr_size = current_sizes.get(part_id::GOT_RELR);
             let n = got_relr_size / C::GOT_ENTRY_SIZE;
             let relr_entries = got_relr_bitmap_relr_count::<C>(n);
             if relr_entries > 0 {
@@ -1852,7 +1852,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
         extra_sizes: &mut OutputSectionPartMap<u64>,
         args: &ElfArgs,
     ) -> Result {
-        if args.should_write_eh_frame_hdr && *current_sizes.get(part_id::EH_FRAME_HDR) != 0 {
+        if args.should_write_eh_frame_hdr && current_sizes.get(part_id::EH_FRAME_HDR) != 0 {
             extra_sizes.increment(part_id::EH_FRAME_HDR, size_of::<EhFrameHdr>() as u64);
         }
         Ok(())
@@ -2154,7 +2154,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
         }
 
         let tlsld_got_entry = prelude.format_specific.needs_tlsld_got_entry.then(|| {
-            let address = NonZeroU64::new(*memory_offsets.get(part_id::GOT))
+            let address = NonZeroU64::new(memory_offsets.get(part_id::GOT))
                 .expect("GOT address must never be zero");
             memory_offsets.increment(part_id::GOT, C::GOT_ENTRY_SIZE * 2);
             address
@@ -2865,7 +2865,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
         let locals = group_sizes.get(part_id::SYMTAB_LOCAL) / C::SYMTAB_ENTRY_SIZE;
         let globals = group_sizes.get(part_id::SYMTAB_GLOBAL) / C::SYMTAB_ENTRY_SIZE;
 
-        let mut extra_sizes = OutputSectionPartMap::with_size(group_sizes.num_parts());
+        let mut extra_sizes = group_sizes.new_empty_like();
         extra_sizes.increment(
             part_id::SYMTAB_SHNDX_LOCAL,
             locals * SYMTAB_SHNDX_ENTRY_SIZE,
@@ -3776,7 +3776,7 @@ fn allocate_sysv_hash<C: ElfClass>(
     let bucket_count = (num_defs / 2).max(1).next_power_of_two() as u32;
     // Whereas `num_defs` above is the number of definitions, this is the number of dynamic
     // symbols, which also includes undefined dynamic symbols.
-    let num_dynsym = *current_sizes.get(part_id::DYNSYM) / C::SYMTAB_ENTRY_SIZE;
+    let num_dynsym = current_sizes.get(part_id::DYNSYM) / C::SYMTAB_ENTRY_SIZE;
     let chain_count = num_dynsym
         .try_into()
         .context("Too many dynamic symbols for .hash")?;
@@ -6314,19 +6314,19 @@ fn allocate_got<C: ElfClass>(
     num_entries: u64,
     memory_offsets: &mut OutputSectionPartMap<u64>,
 ) -> NonZeroU64 {
-    let got_address = NonZeroU64::new(*memory_offsets.get(part_id::GOT)).unwrap();
+    let got_address = NonZeroU64::new(memory_offsets.get(part_id::GOT)).unwrap();
     memory_offsets.increment(part_id::GOT, C::GOT_ENTRY_SIZE * num_entries);
     got_address
 }
 
 fn allocate_got_relr<C: ElfClass>(memory_offsets: &mut OutputSectionPartMap<u64>) -> NonZeroU64 {
-    let got_address = NonZeroU64::new(*memory_offsets.get(part_id::GOT_RELR)).unwrap();
+    let got_address = NonZeroU64::new(memory_offsets.get(part_id::GOT_RELR)).unwrap();
     memory_offsets.increment(part_id::GOT_RELR, C::GOT_ENTRY_SIZE);
     got_address
 }
 
 fn allocate_plt(memory_offsets: &mut OutputSectionPartMap<u64>) -> NonZeroU64 {
-    let plt_address = NonZeroU64::new(*memory_offsets.get(part_id::PLT_GOT)).unwrap();
+    let plt_address = NonZeroU64::new(memory_offsets.get(part_id::PLT_GOT)).unwrap();
     memory_offsets.increment(part_id::PLT_GOT, elf::PLT_ENTRY_SIZE);
     plt_address
 }

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -607,7 +607,7 @@ impl<'out> VersionWriter<'out> {
             return Err(excessive_allocation(
                 ".gnu.version",
                 versym.len() as u64 * elf::GNU_VERSION_ENTRY_SIZE,
-                *mem_sizes.get(part_id::GNU_VERSION),
+                mem_sizes.get(part_id::GNU_VERSION),
             ));
         }
         if !self.version_r.is_empty() {
@@ -780,7 +780,7 @@ impl<'layout, 'out, C: ElfClass> TableWriter<'layout, 'out, C> {
         {
             *got_entry = elf::Word::<C>::from_u64(0)?;
             debug_assert_bail!(
-                *compute_allocations::<elf::Elf<C>>(res, self.output_kind, args)
+                compute_allocations::<elf::Elf<C>>(res, self.output_kind, args)
                     .get(part_id::RELA_DYN_GENERAL)
                     > 0,
                 "Tried to write glob-dat with no allocation. {}",
@@ -863,7 +863,7 @@ impl<'layout, 'out, C: ElfClass> TableWriter<'layout, 'out, C> {
                 elf::Word::<C>::from_u64(address.wrapping_sub(A::tp_offset_start(layout)))?;
         } else {
             debug_assert_bail!(
-                *compute_allocations::<elf::Elf<C>>(res, self.output_kind, layout.args())
+                compute_allocations::<elf::Elf<C>>(res, self.output_kind, layout.args())
                     .get(part_id::RELA_DYN_GENERAL)
                     > 0,
                 "Tried to write tpoff with no allocation. {}",
@@ -887,7 +887,7 @@ impl<'layout, 'out, C: ElfClass> TableWriter<'layout, 'out, C> {
             *got_entry = elf::Word::<C>::from_u64(0)?;
             let dynamic_symbol_index = res.dynamic_symbol_index.map_or(0, std::num::NonZero::get);
             debug_assert_bail!(
-                *compute_allocations::<elf::Elf<C>>(res, self.output_kind, args)
+                compute_allocations::<elf::Elf<C>>(res, self.output_kind, args)
                     .get(part_id::RELA_DYN_GENERAL)
                     > 0,
                 "Tried to write dtpmod with no allocation. {}",
@@ -933,7 +933,7 @@ impl<'layout, 'out, C: ElfClass> TableWriter<'layout, 'out, C> {
 
         let dynamic_symbol_index = res.dynamic_symbol_index.map_or(0, std::num::NonZero::get);
         debug_assert_bail!(
-            *compute_allocations::<elf::Elf<C>>(res, self.output_kind, args)
+            compute_allocations::<elf::Elf<C>>(res, self.output_kind, args)
                 .get(part_id::RELA_DYN_GENERAL)
                 > 0,
             "Tried to write TLS descriptor with no allocation. {}",
@@ -1021,28 +1021,28 @@ impl<'layout, 'out, C: ElfClass> TableWriter<'layout, 'out, C> {
             return Err(excessive_allocation(
                 ".got",
                 self.got.len() as u64 * C::GOT_ENTRY_SIZE,
-                *mem_sizes.get(part_id::GOT),
+                mem_sizes.get(part_id::GOT),
             ));
         }
         if !self.got_relr.is_empty() {
             return Err(excessive_allocation(
                 ".got (relr)",
                 self.got_relr.len() as u64 * C::GOT_ENTRY_SIZE,
-                *mem_sizes.get(part_id::GOT_RELR),
+                mem_sizes.get(part_id::GOT_RELR),
             ));
         }
         if !self.rela_dyn_relative.is_empty() {
             return Err(excessive_allocation(
                 ".rela.dyn (relative)",
                 self.rela_dyn_relative.len() as u64 * C::RELA_ENTRY_SIZE,
-                *mem_sizes.get(part_id::RELA_DYN_RELATIVE),
+                mem_sizes.get(part_id::RELA_DYN_RELATIVE),
             ));
         }
         if !self.rela_dyn_general.is_empty() {
             return Err(excessive_allocation(
                 ".rela.dyn (general)",
                 self.rela_dyn_general.len() as u64 * C::RELA_ENTRY_SIZE,
-                *mem_sizes.get(part_id::RELA_DYN_GENERAL),
+                mem_sizes.get(part_id::RELA_DYN_GENERAL),
             ));
         }
         if let Some(relr_dyn) = &self.relr_dyn
@@ -1051,7 +1051,7 @@ impl<'layout, 'out, C: ElfClass> TableWriter<'layout, 'out, C> {
             return Err(excessive_allocation(
                 ".relr.dyn",
                 relr_dyn.len() as u64 * C::RELR_ENTRY_SIZE,
-                *mem_sizes.get(part_id::RELR_DYN),
+                mem_sizes.get(part_id::RELR_DYN),
             ));
         }
         self.dynsym_writer.check_exhausted()?;
@@ -1061,21 +1061,21 @@ impl<'layout, 'out, C: ElfClass> TableWriter<'layout, 'out, C> {
             return Err(excessive_allocation(
                 ".eh_frame",
                 self.eh_frame.len() as u64,
-                *mem_sizes.get(part_id::EH_FRAME),
+                mem_sizes.get(part_id::EH_FRAME),
             ));
         }
         if !self.eh_frame_hdr.is_empty() {
             return Err(excessive_allocation(
                 ".eh_frame_hdr",
                 self.eh_frame_hdr.len() as u64,
-                *mem_sizes.get(part_id::EH_FRAME_HDR),
+                mem_sizes.get(part_id::EH_FRAME_HDR),
             ));
         }
         if !self.dynamic.out.is_empty() {
             return Err(excessive_allocation(
                 ".dynamic",
                 std::mem::size_of_val(self.dynamic.out) as u64,
-                *mem_sizes.get(part_id::DYNAMIC),
+                mem_sizes.get(part_id::DYNAMIC),
             ));
         }
         Ok(())

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -193,7 +193,6 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>, F: FileSystem>(
 
     finalise_all_sizes::<P, A>(
         &mut group_states,
-        &output_sections,
         &atomic_per_symbol_flags,
         &finalise_sizes_resources,
     )?;
@@ -242,7 +241,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>, F: FileSystem>(
 
     let got_relr_n = A::Platform::GOT_RELR_SECTION_ID
         .and_then(A::Platform::single_part_id)
-        .map_or(0, |part_id| *section_part_sizes.get(part_id) / 8);
+        .map_or(0, |part_id| section_part_sizes.get(part_id) / 8);
 
     let thunk_blocks = thunk_layout_builder
         .map(|builder| {
@@ -326,10 +325,12 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>, F: FileSystem>(
     {
         let last_part_id =
             PartId::from_usize(last_section_id.part_id_range::<P>().end.as_usize() - 1);
+
         let extra_file_size = A::Platform::last_part_size_to_extend(
-            section_part_layouts.get(last_part_id),
+            &section_part_layouts.get(last_part_id),
             last_part_id,
         )?;
+
         if extra_file_size > 0 {
             section_part_sizes.increment(last_part_id, extra_file_size as u64);
 
@@ -661,7 +662,6 @@ fn update_dynamic_symbol_resolutions<'data, P: Platform>(
 
 fn finalise_all_sizes<'data, P: Platform, A: Arch<Platform = P>>(
     group_states: &mut [GroupState<'data, P>],
-    output_sections: &OutputSections<P>,
     per_symbol_flags: &AtomicPerSymbolFlags,
     resources: &FinaliseSizesResources<'data, '_, P>,
 ) -> Result {
@@ -669,7 +669,7 @@ fn finalise_all_sizes<'data, P: Platform, A: Arch<Platform = P>>(
 
     group_states.par_iter_mut().try_for_each(|state| {
         verbose_timing_phase!("Finalise sizes for group");
-        state.finalise_sizes::<A>(output_sections, per_symbol_flags, resources)
+        state.finalise_sizes::<A>(per_symbol_flags, resources)
     })
 }
 
@@ -1065,7 +1065,7 @@ pub(crate) fn compute_allocations<P: Platform>(
     args: &P::Args,
 ) -> OutputSectionPartMap<u64> {
     let mut sizes =
-        OutputSectionPartMap::with_size(crate::part_id::regular_part_base::<P>().as_usize());
+        OutputSectionPartMap::with_dense_size(crate::part_id::regular_part_base::<P>().as_usize());
     P::allocate_resolution(resolution.flags, &mut sizes, output_kind, args);
     sizes
 }
@@ -1315,7 +1315,7 @@ impl<'data, P: Platform> CommonGroupState<'data, P> {
         .flatten()
         {
             if let Some(part_id) = P::single_part_id(section_id) {
-                memory_offsets.increment(part_id, *self.mem_sizes.get(part_id));
+                memory_offsets.increment(part_id, self.mem_sizes.get(part_id));
             }
         }
 
@@ -2164,8 +2164,7 @@ fn allocate_thunk_block_space<P: Platform>(
     let emit_symbols = !symbol_db.args.should_strip_all();
 
     for group_state in group_states.iter_mut() {
-        let mut extra_thunk_sizes: OutputSectionPartMap<u64> =
-            OutputSectionPartMap::with_size(total_sizes.num_parts());
+        let mut extra_thunk_sizes: OutputSectionPartMap<u64> = total_sizes.new_empty_like();
         for file in &group_state.files {
             if let FileLayoutState::Object(obj) = file
                 && let Some(config) = P::file_thunk_config(obj.object)
@@ -2488,17 +2487,11 @@ impl<'data, P: Platform> GroupState<'data, P> {
 
     fn finalise_sizes<A: Arch<Platform = P>>(
         &mut self,
-        output_sections: &OutputSections<P>,
         per_symbol_flags: &AtomicPerSymbolFlags,
         resources: &FinaliseSizesResources<'data, '_, P>,
     ) -> Result {
         for file_state in &mut self.files {
-            file_state.finalise_sizes::<A>(
-                &mut self.common,
-                output_sections,
-                per_symbol_flags,
-                resources,
-            )?;
+            file_state.finalise_sizes::<A>(&mut self.common, per_symbol_flags, resources)?;
         }
 
         self.common.validate_sizes()?;
@@ -2549,7 +2542,7 @@ impl<'data, P: Platform> GroupState<'data, P> {
                 let start = (memory_offsets.get(part_id)
                     - resources.section_layouts.get(section_id).mem_offset)
                     as u32;
-                memory_offsets.increment(part_id, *self.common.mem_sizes.get(part_id));
+                memory_offsets.increment(part_id, self.common.mem_sizes.get(part_id));
                 start
             });
 
@@ -2713,13 +2706,12 @@ impl<'data, P: Platform> FileLayoutState<'data, P> {
     fn finalise_sizes<A: Arch<Platform = P>>(
         &mut self,
         common: &mut CommonGroupState<'data, P>,
-        output_sections: &OutputSections<P>,
         per_symbol_flags: &AtomicPerSymbolFlags,
         resources: &FinaliseSizesResources<'data, '_, P>,
     ) -> Result {
         match self {
             FileLayoutState::Object(s) => {
-                s.finalise_sizes(common, output_sections, per_symbol_flags, resources)?;
+                s.finalise_sizes(common, per_symbol_flags, resources)?;
                 s.finalise_symbol_sizes::<A>(common, per_symbol_flags, resources)?;
             }
             FileLayoutState::Dynamic(s) => {
@@ -3261,7 +3253,7 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
         // Total section  sizes have already been computed. So any allocations we do need to update
         // both `total_sizes` and the size records in `common`. We track the extra sizes in
         // `extra_sizes` which we can then later add to both.
-        let mut extra_sizes = OutputSectionPartMap::with_size(common.mem_sizes.num_parts());
+        let mut extra_sizes = common.mem_sizes.new_empty_like();
 
         self.determine_header_sizes(
             total_sizes,
@@ -3963,7 +3955,7 @@ impl<'data, P: Platform> EpilogueLayoutState<P> {
         total_sizes: &mut OutputSectionPartMap<u64>,
         resources: &FinaliseSizesResources<'data, '_, P>,
     ) -> Result {
-        let mut extra_sizes = OutputSectionPartMap::with_size(common.mem_sizes.num_parts());
+        let mut extra_sizes = common.mem_sizes.new_empty_like();
         for sec in resources.script_sorted_sections {
             extra_sizes.increment(sec.part_id, sec.size);
         }
@@ -4372,11 +4364,9 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
     fn finalise_sizes(
         &mut self,
         common: &mut CommonGroupState<'data, P>,
-        output_sections: &OutputSections<P>,
         per_symbol_flags: &AtomicPerSymbolFlags,
         resources: &FinaliseSizesResources<'data, '_, P>,
     ) -> Result {
-        common.mem_sizes.resize(output_sections.num_parts());
         if !resources.symbol_db.args.should_strip_all() {
             self.allocate_symtab_space(common, resources.symbol_db, per_symbol_flags)?;
         }
@@ -4432,7 +4422,7 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
         for (slot, &part_id) in self.sections.iter_mut().zip(object_part_ids) {
             let resolution = match slot {
                 SectionSlot::Loaded(sec) => {
-                    let address = *memory_offsets.get(part_id);
+                    let address = memory_offsets.get(part_id);
 
                     // TODO: We probably need to be able to handle sections that are ifuncs and
                     // sections that need a TLS GOT struct.
@@ -4454,7 +4444,7 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
                 },
 
                 &mut SectionSlot::LoadedDebugInfo(sec) => {
-                    let address = *memory_offsets.get(part_id);
+                    let address = memory_offsets.get(part_id);
                     *memory_offsets.get_mut(part_id) +=
                         sec.capacity(part_id, resources.output_sections);
                     SectionResolution { address }
@@ -5011,7 +5001,7 @@ fn compute_section_and_symbol_addresses<'data, P: Platform>(
                                         object::SectionIndex(sec_idx),
                                         &symbol_db.section_part_ids,
                                     );
-                                    addresses[sec_idx] = *offsets.get(part_id);
+                                    addresses[sec_idx] = offsets.get(part_id);
                                     *offsets.get_mut(part_id) +=
                                         sec.capacity(part_id, output_sections);
                                 }
@@ -5114,8 +5104,7 @@ fn relaxation_scan_pass<'data, A: Arch>(
             .par_iter_mut()
             .enumerate()
             .map(|(group_idx, group)| {
-                let mut reductions =
-                    OutputSectionPartMap::with_size(section_part_sizes.num_parts());
+                let mut reductions = section_part_sizes.new_empty_like();
                 let mut file_rescans: Vec<SmallVec<[(usize, u64); 16]>> =
                     Vec::with_capacity(group.files.len());
 
@@ -5233,9 +5222,8 @@ fn relaxation_scan_pass<'data, A: Arch>(
     let mut total_deleted = 0u64;
     let mut next_rescan_candidates: RescanCandidates = Vec::with_capacity(group_results.len());
     for (reduction, file_rescans) in group_results {
-        for (idx, &amount) in reduction.parts.iter().enumerate() {
+        for (part_id, &amount) in reduction.iter() {
             if amount > 0 {
-                let part_id = PartId::from_usize(idx);
                 section_part_sizes.decrement(part_id, amount);
                 total_deleted += amount;
             }
@@ -5528,119 +5516,131 @@ fn compute_layout_sections<'data, P: Platform>(
                 }
                 lma_offset = mem_offset;
 
-                records_out[part_id_range.clone()]
-                    .iter_mut()
-                    .zip(&sizes[part_id_range.clone()])
-                    .enumerate()
-                    .try_for_each(|(offset, (part_layout, &part_size))| -> Result {
-                        let part_id = part_id_range.start.offset(offset);
-                        let alignment = part_id.alignment(output_sections).min(max_alignment);
-                        let merge_target = output_sections.primary_output_section(section_id);
-                        let section_flags = output_sections.section_flags(merge_target);
-                        let mem_size = if Some(section_id) == P::RELRO_PADDING_SECTION_ID {
-                            let page_alignment = args.loadable_segment_alignment();
-                            let aligned_offset = page_alignment.align_up(mem_offset);
-                            aligned_offset - mem_offset
-                        } else {
-                            part_size
-                        };
+                let mut is_first_part = true;
 
-                        // Note, we align up even if our size is zero, otherwise our section will
-                        // start at an unaligned address. We don't however align up for NOBITS
-                        // sections.
-                        if output_sections.has_data_in_file(merge_target) {
-                            file_offset = alignment.align_up_usize(file_offset);
-                        }
+                let merge_target = output_sections.primary_output_section(section_id);
+                let section_flags = output_sections.section_flags(merge_target);
 
-                        if section_flags.is_alloc() {
-                            if args.should_output_partial_object() {
-                                let file_size = if output_sections.has_data_in_file(merge_target) {
-                                    mem_size as usize
-                                } else {
-                                    0
-                                };
+                let mut part_sizes = sizes
+                    .in_range(part_id_range.clone())
+                    .map(|(id, &size)| (id, size))
+                    .peekable();
 
-                                let section_id = part_id.output_section_id::<P>();
-                                let part_mem_offset =
-                                    alignment.align_up(*reloc_alloc_mem_offsets.get(section_id));
-                                *reloc_alloc_mem_offsets.get_mut(section_id) =
-                                    part_mem_offset + mem_size;
+                // For sections with only empty parts, make sure we run the loop below at least once
+                // so as to properly initialise the section's layout.
+                let empty_part = part_sizes
+                    .peek()
+                    .is_none()
+                    .then_some((part_id_range.start, 0));
 
-                                *part_layout = OutputRecordLayout {
-                                    file_size,
-                                    mem_size,
-                                    alignment,
-                                    file_offset,
-                                    mem_offset: part_mem_offset,
-                                    lma_offset: part_mem_offset,
-                                };
+                for (part_id, part_size) in part_sizes.chain(empty_part) {
+                    let part_layout = records_out.get_mut(part_id);
+                    let alignment = part_id.alignment(output_sections).min(max_alignment);
+                    let mem_size = if Some(section_id) == P::RELRO_PADDING_SECTION_ID {
+                        let page_alignment = args.loadable_segment_alignment();
+                        let aligned_offset = page_alignment.align_up(mem_offset);
+                        aligned_offset - mem_offset
+                    } else {
+                        part_size
+                    };
 
-                                file_offset += file_size;
+                    // Note, we align up even if our size is zero, otherwise our section will
+                    // start at an unaligned address. We don't however align up for NOBITS
+                    // sections.
+                    if output_sections.has_data_in_file(merge_target) {
+                        file_offset = alignment.align_up_usize(file_offset);
+                    }
+
+                    if section_flags.is_alloc() {
+                        if args.should_output_partial_object() {
+                            let file_size = if output_sections.has_data_in_file(merge_target) {
+                                mem_size as usize
                             } else {
-                                mem_offset = alignment.align_up(mem_offset);
-                                lma_offset = alignment.align_up(lma_offset);
+                                0
+                            };
 
-                                let file_size = if output_sections.has_data_in_file(merge_target) {
-                                    mem_size as usize
-                                } else {
-                                    0
-                                };
-
-                                *part_layout = OutputRecordLayout {
-                                    file_size,
-                                    mem_size,
-                                    alignment,
-                                    file_offset,
-                                    mem_offset,
-                                    lma_offset,
-                                };
-
-                                file_offset += file_size;
-                                mem_offset += mem_size;
-                                lma_offset += mem_size;
-                            }
-                        } else {
                             let section_id = part_id.output_section_id::<P>();
-                            let mem_offset =
-                                alignment.align_up(*nonalloc_mem_offsets.get(section_id));
-
-                            *nonalloc_mem_offsets.get_mut(section_id) += mem_size;
+                            let part_mem_offset =
+                                alignment.align_up(*reloc_alloc_mem_offsets.get(section_id));
+                            *reloc_alloc_mem_offsets.get_mut(section_id) =
+                                part_mem_offset + mem_size;
 
                             *part_layout = OutputRecordLayout {
-                                file_size: mem_size as usize,
+                                file_size,
+                                mem_size,
+                                alignment,
+                                file_offset,
+                                mem_offset: part_mem_offset,
+                                lma_offset: part_mem_offset,
+                            };
+
+                            file_offset += file_size;
+                        } else {
+                            mem_offset = alignment.align_up(mem_offset);
+                            lma_offset = alignment.align_up(lma_offset);
+
+                            let file_size = if output_sections.has_data_in_file(merge_target) {
+                                mem_size as usize
+                            } else {
+                                0
+                            };
+
+                            *part_layout = OutputRecordLayout {
+                                file_size,
                                 mem_size,
                                 alignment,
                                 file_offset,
                                 mem_offset,
-                                lma_offset: mem_offset,
+                                lma_offset,
                             };
-                            file_offset += mem_size as usize;
-                        }
-                        layout_section_from_part_layouts(
-                            part_layout,
-                            section_layouts.get_mut(section_id),
-                            section_info,
-                            offset == 0,
-                        );
 
-                        if let Some(expr) = section_info
-                            .location_info
-                            .as_ref()
-                            .and_then(|info| info.at_location.as_ref())
-                        {
-                            lma_offset = expression_eval(
-                                expr,
-                                &SymbolLoc::None,
-                                memory_regions,
-                                &section_layouts,
-                                &resolved_lc,
-                            )?;
-                            part_layout.lma_offset = lma_offset;
-                            let section_layout = section_layouts.get_mut(section_id);
-                            section_layout.lma_offset = lma_offset;
+                            file_offset += file_size;
+                            mem_offset += mem_size;
+                            lma_offset += mem_size;
                         }
-                        Ok(())
-                    })?;
+                    } else {
+                        let section_id = part_id.output_section_id::<P>();
+                        let mem_offset = alignment.align_up(*nonalloc_mem_offsets.get(section_id));
+
+                        *nonalloc_mem_offsets.get_mut(section_id) += mem_size;
+
+                        *part_layout = OutputRecordLayout {
+                            file_size: mem_size as usize,
+                            mem_size,
+                            alignment,
+                            file_offset,
+                            mem_offset,
+                            lma_offset: mem_offset,
+                        };
+                        file_offset += mem_size as usize;
+                    }
+
+                    layout_section_from_part_layouts(
+                        part_layout,
+                        section_layouts.get_mut(section_id),
+                        section_info,
+                        is_first_part,
+                    );
+
+                    if let Some(expr) = section_info
+                        .location_info
+                        .as_ref()
+                        .and_then(|info| info.at_location.as_ref())
+                    {
+                        lma_offset = expression_eval(
+                            expr,
+                            &SymbolLoc::None,
+                            memory_regions,
+                            &section_layouts,
+                            &resolved_lc,
+                        )?;
+                        part_layout.lma_offset = lma_offset;
+                        let section_layout = section_layouts.get_mut(section_id);
+                        section_layout.lma_offset = lma_offset;
+                    }
+
+                    is_first_part = false;
+                }
 
                 if let Some(region_name) = section_info.region_name
                     && let Some(region) = memory_regions.get_mut(region_name)

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -2059,13 +2059,13 @@ pub(crate) struct ResolutionExt {
 }
 
 fn allocate_got(memory_offsets: &mut OutputSectionPartMap<u64>) -> NonZeroU64 {
-    let got_address = NonZeroU64::new(*memory_offsets.get(part_id::GOT)).unwrap();
+    let got_address = NonZeroU64::new(memory_offsets.get(part_id::GOT)).unwrap();
     memory_offsets.increment(part_id::GOT, GOT_ENTRY_SIZE);
     got_address
 }
 
 fn allocate_plt(memory_offsets: &mut OutputSectionPartMap<u64>) -> NonZeroU64 {
-    let plt_address = NonZeroU64::new(*memory_offsets.get(part_id::PLT_GOT)).unwrap();
+    let plt_address = NonZeroU64::new(memory_offsets.get(part_id::PLT_GOT)).unwrap();
     memory_offsets.increment(part_id::PLT_GOT, PLT_ENTRY_SIZE);
     plt_address
 }

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -456,13 +456,14 @@ impl<'data, P: Platform> OutputSections<'data, P> {
         self.section_infos.iter()
     }
 
-    pub(crate) fn num_parts(&self) -> usize {
-        crate::part_id::regular_part_base::<P>().as_usize()
-            + (self.num_sections() - regular_section_base::<P>().as_usize()) * NUM_ALIGNMENTS
-    }
-
+    // TODO: Experiment with adjusting the balance between dense and sparse sections. If we decide
+    // not to make it dynamic, then remove this method and construct part maps more directly.
+    #[allow(clippy::unused_self)]
     pub(crate) fn new_part_map<T: Default>(&self) -> OutputSectionPartMap<T> {
-        OutputSectionPartMap::with_size(self.num_parts())
+        OutputSectionPartMap::with_dense_size(
+            P::NUM_SINGLE_PART_SECTIONS as usize
+                + P::NUM_BUILT_IN_REGULAR_SECTIONS * NUM_ALIGNMENTS,
+        )
     }
 
     pub(crate) fn new_section_map<T: Default>(&self) -> OutputSectionMap<T> {

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -5,10 +5,9 @@ use crate::output_section_id::OutputOrder;
 use crate::output_section_id::OutputSections;
 use crate::part_id::PartId;
 use crate::platform::Platform;
+use std::collections::BTreeMap;
 use std::mem::take;
 use std::ops::AddAssign;
-use std::ops::Index;
-use std::ops::IndexMut;
 use std::ops::Range;
 
 /// A map from each part of each output section to some value. Different sections are split into
@@ -22,42 +21,93 @@ pub(crate) struct OutputSectionPartMap<T> {
     // This may be due to an extra pointer indirection and/or bounds checking. Experiment with
     // storing all our built-in parts in an array.
     #[debug(skip)]
-    pub(crate) parts: Vec<T>,
+    parts: Vec<T>,
+
+    #[debug(skip)]
+    sparse: Option<Box<SparsePartMap<T>>>,
+}
+
+#[derive(Clone, PartialEq, Eq, Default)]
+struct SparsePartMap<T> {
+    contents: BTreeMap<PartId, T>,
 }
 
 impl<T: Default> OutputSectionPartMap<T> {
-    pub(crate) fn with_size(size: usize) -> Self {
+    pub(crate) fn with_dense_size(size: usize) -> Self {
         let mut parts = Vec::new();
         parts.resize_with(size, Default::default);
-        Self { parts }
+        Self {
+            parts,
+            sparse: None,
+        }
     }
 }
 
-impl<T> Index<Range<PartId>> for OutputSectionPartMap<T> {
-    type Output = [T];
+pub(crate) enum RangeIterator<'a, T> {
+    Dense(PartId, &'a [T]),
+    Sparse(std::collections::btree_map::Range<'a, PartId, T>),
+}
 
-    fn index(&self, index: Range<PartId>) -> &Self::Output {
-        &self.parts[index.start.as_usize()..index.end.as_usize()]
+impl<'a, T> Iterator for RangeIterator<'a, T> {
+    type Item = (PartId, &'a T);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            RangeIterator::Dense(part_id, items) => {
+                let item = items.split_off_first()?;
+                let id = *part_id;
+                *part_id = part_id.offset(1);
+                Some((id, item))
+            }
+            RangeIterator::Sparse(range) => range.next().map(|(&id, item)| (id, item)),
+        }
     }
 }
 
-impl<T> IndexMut<Range<PartId>> for OutputSectionPartMap<T> {
-    fn index_mut(&mut self, index: Range<PartId>) -> &mut Self::Output {
-        &mut self.parts[index.start.as_usize()..index.end.as_usize()]
-    }
-}
-
-impl<T> OutputSectionPartMap<T> {
-    pub(crate) fn num_parts(&self) -> usize {
-        self.parts.len()
+impl<T: Default> OutputSectionPartMap<T> {
+    pub(crate) fn new_empty_like<U: Default>(&self) -> OutputSectionPartMap<U> {
+        OutputSectionPartMap::with_dense_size(self.parts.len())
     }
 
     pub(crate) fn get_mut(&mut self, part_id: PartId) -> &mut T {
-        &mut self.parts[part_id.as_usize()]
+        self.parts.get_mut(part_id.as_usize()).unwrap_or_else(|| {
+            self.sparse
+                .get_or_insert_default()
+                .contents
+                .entry(part_id)
+                .or_default()
+        })
     }
 
-    pub(crate) fn get(&self, part_id: PartId) -> &T {
-        &self.parts[part_id.as_usize()]
+    /// Note, range must be either entirely dense or entirely sparse. Itended use-case is to get all
+    /// parts for a single section.
+    pub(crate) fn in_range(&self, range: Range<PartId>) -> RangeIterator<'_, T> {
+        if let Some(values) = self.parts.get(range.start.as_usize()..range.end.as_usize()) {
+            RangeIterator::Dense(range.start, values)
+        } else if let Some(sparse) = self.sparse.as_ref() {
+            RangeIterator::Sparse(sparse.contents.range(range))
+        } else {
+            RangeIterator::Sparse(Default::default())
+        }
+    }
+
+    pub(crate) fn values_in_range(&self, range: Range<PartId>) -> impl Iterator<Item = &T> {
+        self.in_range(range).map(|(_, v)| v)
+    }
+}
+
+impl<T: Default + Copy> OutputSectionPartMap<T> {
+    pub(crate) fn get(&self, part_id: PartId) -> T {
+        self.parts
+            .get(part_id.as_usize())
+            .copied()
+            .unwrap_or_else(|| {
+                self.sparse
+                    .as_ref()
+                    .and_then(|sparse| sparse.contents.get(&part_id))
+                    .copied()
+                    .unwrap_or_default()
+            })
     }
 }
 
@@ -96,6 +146,15 @@ impl<T: Default + PartialEq> OutputSectionPartMap<T> {
                 .enumerate()
                 .map(|(i, value)| cb(PartId::from_usize(i), value))
                 .collect(),
+            sparse: self.sparse.as_ref().map(|sparse| {
+                Box::new(SparsePartMap {
+                    contents: sparse
+                        .contents
+                        .iter()
+                        .map(|(id, value)| (*id, cb(*id, value)))
+                        .collect(),
+                })
+            }),
         }
     }
 
@@ -110,7 +169,10 @@ impl<T: Default + PartialEq> OutputSectionPartMap<T> {
     ) -> OutputSectionPartMap<U> {
         let mut parts_out = Vec::new();
         parts_out.resize_with(self.parts.len(), U::default);
-        let mut output = OutputSectionPartMap { parts: parts_out };
+        let mut output = OutputSectionPartMap {
+            parts: parts_out,
+            sparse: None,
+        };
 
         for event in output_order {
             let OrderEvent::Section(section_id) = event else {
@@ -119,15 +181,11 @@ impl<T: Default + PartialEq> OutputSectionPartMap<T> {
 
             let part_id_range = section_id.part_id_range::<P>();
             let max_alignment = self.max_alignment(part_id_range.clone(), output_sections);
-            output[part_id_range.clone()]
-                .iter_mut()
-                .zip(&self[part_id_range.clone()])
-                .enumerate()
-                .for_each(|(offset, (out, input))| {
-                    let part_id = part_id_range.start.offset(offset);
-                    let alignment = part_id.alignment(output_sections).min(max_alignment);
-                    *out = cb(part_id, alignment, input);
-                });
+
+            for (part_id, input) in self.in_range(part_id_range.clone()) {
+                let alignment = part_id.alignment(output_sections).min(max_alignment);
+                *output.get_mut(part_id) = cb(part_id, alignment, input);
+            }
         }
 
         output
@@ -141,11 +199,10 @@ impl<T: Default + PartialEq> OutputSectionPartMap<T> {
         range: Range<PartId>,
         output_sections: &OutputSections<P>,
     ) -> Alignment {
-        self[range.clone()]
-            .iter()
-            .position(|p| *p != T::default())
-            .map_or(alignment::MIN, |o| {
-                range.start.offset(o).alignment(output_sections)
+        self.in_range(range.clone())
+            .find(|(_, value)| **value != T::default())
+            .map_or(alignment::MIN, |(part_id, _)| {
+                part_id.alignment(output_sections)
             })
             .max(
                 range
@@ -158,7 +215,7 @@ impl<T: Default + PartialEq> OutputSectionPartMap<T> {
     /// Zip mutable references to values in `self` with shared references from `other` producing a
     /// new map with the returned values. For custom sections, `other` must be a subset of `self`.
     /// Values not in `other` will not be in the returned map.
-    fn mut_with_map<U, V: Default>(
+    fn mut_with_map<U: Default, V: Default>(
         &mut self,
         other: &OutputSectionPartMap<U>,
         mut cb: impl FnMut(&mut T, &U) -> V,
@@ -170,23 +227,60 @@ impl<T: Default + PartialEq> OutputSectionPartMap<T> {
             .map(|(t, u)| cb(t, u))
             .collect();
 
-        OutputSectionPartMap { parts }
-    }
-}
+        let Some(other_sparse) = other.sparse.as_ref() else {
+            return OutputSectionPartMap {
+                parts,
+                sparse: None,
+            };
+        };
 
-impl<T: Default> OutputSectionPartMap<T> {
-    pub(crate) fn resize(&mut self, num_parts: usize) {
-        self.parts.resize_with(num_parts, Default::default);
+        let self_sparse = self.sparse.get_or_insert_with(|| {
+            Box::new(SparsePartMap {
+                contents: BTreeMap::new(),
+            })
+        });
+
+        let contents = other_sparse
+            .contents
+            .iter()
+            .map(|(part_id, right_value)| {
+                let left_value = self_sparse.contents.entry(*part_id).or_default();
+                (*part_id, cb(left_value, right_value))
+            })
+            .collect();
+
+        OutputSectionPartMap {
+            parts,
+            sparse: Some(Box::new(SparsePartMap { contents })),
+        }
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (PartId, &T)> {
+        self.parts
+            .iter()
+            .enumerate()
+            .map(|(i, value)| (PartId::from_usize(i), value))
+            .chain(
+                self.sparse
+                    .as_ref()
+                    .map(|sparse| sparse.contents.iter())
+                    .unwrap_or_default()
+                    .map(|(part_id, value)| (*part_id, value)),
+            )
     }
 }
 
 impl<T: AddAssign + Copy + Default> OutputSectionPartMap<T> {
     pub(crate) fn merge(&mut self, rhs: &Self) {
-        if self.num_parts() < rhs.num_parts() {
-            self.resize(rhs.num_parts());
-        }
         for (left, right) in self.parts.iter_mut().zip(rhs.parts.iter()) {
             *left += *right;
+        }
+
+        if let Some(rhs_sparse) = rhs.sparse.as_ref() {
+            let lhs_sparse = self.sparse.get_or_insert_default();
+            for (part_id, right) in &rhs_sparse.contents {
+                *lhs_sparse.contents.entry(*part_id).or_default() += *right;
+            }
         }
     }
 }
@@ -214,17 +308,21 @@ fn test_merge_parts() {
             &[],
         )
         .unwrap();
-    let mut expected_sum_of_sums = 0;
-    let all_1 = output_sections.new_part_map::<u32>().output_order_map(
-        &output_order,
-        &output_sections,
-        |_, _, _| {
-            expected_sum_of_sums += 1;
-            1
-        },
-    );
 
-    let num_regular_sections = output_sections.num_regular_sections();
+    let mut part_map = output_sections.new_part_map::<u32>();
+    for (section_id, _) in output_sections.ids_with_info() {
+        if section_id.is_custom::<Elf64>() {
+            let _ =
+                part_map.get_mut(section_id.part_id_with_alignment::<Elf64>(crate::alignment::MIN));
+        }
+    }
+
+    let mut expected_sum_of_sums = 0;
+    let all_1 = part_map.output_order_map(&output_order, &output_sections, |_, _, _| {
+        expected_sum_of_sums += 1;
+        1
+    });
+
     let mut num_sections_with_all_alignments = 0;
 
     let mut sum_of_1s = output_sections.new_section_map::<u32>();
@@ -235,7 +333,7 @@ fn test_merge_parts() {
             return;
         }
         let range = section_id.part_id_range::<Elf64>();
-        *sum = all_1[range].iter().sum();
+        *sum = all_1.values_in_range(range).sum();
     });
 
     let mut sum_of_sums = 0;
@@ -244,15 +342,27 @@ fn test_merge_parts() {
         if *sum == crate::alignment::NUM_ALIGNMENTS as u32 {
             num_sections_with_all_alignments += 1;
         }
+
         let unsupported_single_part = !section_id.is_regular::<Elf64>()
             && <Elf64 as crate::platform::Platform>::single_part_id(section_id).is_none();
-        if section_id == crate::output_section_id::UNMAPPED || unsupported_single_part {
-            assert!(*sum == 0, "Expected zero sum for section {section_id:?}");
-        } else {
-            assert!(*sum > 0, "Expected non-zero sum for section {section_id:?}");
-        }
+
+        let expected =
+            if section_id == crate::output_section_id::UNMAPPED || unsupported_single_part {
+                0
+            } else if section_id.is_custom::<Elf64>() {
+                1
+            } else if section_id.is_regular::<Elf64>() {
+                crate::alignment::NUM_ALIGNMENTS as u32
+            } else {
+                1
+            };
+
+        assert_eq!(*sum, expected, "Unexpected sum for section {section_id:?}");
     });
-    assert_eq!(num_regular_sections, num_sections_with_all_alignments);
+    assert_eq!(
+        <Elf64 as Platform>::NUM_BUILT_IN_REGULAR_SECTIONS,
+        num_sections_with_all_alignments
+    );
     assert_eq!(sum_of_sums, expected_sum_of_sums);
 
     let mut headers_only = output_sections.new_part_map::<u32>();
@@ -266,7 +376,7 @@ fn test_merge_parts() {
             return;
         }
         let range = section_id.part_id_range::<Elf64>();
-        *sum = headers_only[range].iter().sum();
+        *sum = headers_only.values_in_range(range).sum();
     });
 
     assert_eq!(*merged.get(crate::output_section_id::FILE_HEADER), 42);
@@ -296,18 +406,6 @@ fn test_merge() {
     assert_eq!(input1, expected);
 }
 
-#[test]
-fn test_merge_with_custom_sections() {
-    let output_sections =
-        crate::output_section_id::OutputSections::<crate::elf::Elf64>::for_testing();
-    let mut m1 = output_sections.new_part_map::<u32>();
-    let mut m2 = output_sections.new_part_map::<u32>();
-    assert_eq!(m2.num_parts(), output_sections.num_parts());
-    m2.resize(output_sections.num_parts() + 2);
-    m1.merge(&m2);
-    assert_eq!(m1.num_parts(), output_sections.num_parts() + 2);
-}
-
 /// output_order_map and `OutputSections::sections_and_segments_events` used to each independently
 /// define the output order. This test made sure that they were consistent. Now the former uses the
 /// latter, so this test is less important. It's kept for the time being anyway.
@@ -327,7 +425,17 @@ fn test_output_order_map_consistent() {
             &[],
         )
         .unwrap();
-    let part_map = output_sections.new_part_map::<u32>();
+    let mut part_map = output_sections.new_part_map::<u32>();
+
+    let custom_sections = output_sections
+        .ids_with_info()
+        .map(|(section_id, _)| section_id)
+        .filter(|section_id| section_id.is_custom::<Elf64>())
+        .collect_vec();
+
+    for section_id in custom_sections.into_iter().rev() {
+        let _ = part_map.get_mut(section_id.part_id_with_alignment::<Elf64>(crate::alignment::MIN));
+    }
 
     // First, make sure that all our built-in part-ids are here. If they're not, we'd fail anyway,
     // but we can give a much better failure message if we check first.

--- a/libwild/src/string_merging.rs
+++ b/libwild/src/string_merging.rs
@@ -1115,7 +1115,7 @@ impl MergedStringStartAddresses {
             // We already have the offsets of each bucket relative to the start of the section. So
             // now we just need to add the section's start address to all of these.
             let base =
-                *internal_start_offsets.get(section_id.part_id_with_alignment::<P>(alignment::MIN));
+                internal_start_offsets.get(section_id.part_id_with_alignment::<P>(alignment::MIN));
             let bucket_offsets_out = addresses.get_mut(section_id);
             *bucket_offsets_out = sec.bucket_offsets;
             for offset in bucket_offsets_out {

--- a/libwild/src/thunks.rs
+++ b/libwild/src/thunks.rs
@@ -185,7 +185,7 @@ impl ThunkLayoutBuilder {
                 (0..section_id.num_parts::<P>()).map(move |i| base.offset(i))
             })
             .filter(|&part_id| part_id != self.primary_function_part_id)
-            .map(|part_id| *section_part_sizes.get(part_id))
+            .map(|part_id| section_part_sizes.get(part_id))
             .sum();
         non_primary_text_bytes
     }

--- a/libwild/src/verification.rs
+++ b/libwild/src/verification.rs
@@ -77,8 +77,7 @@ impl OffsetVerifier {
     }
 
     fn alignments_ok<P: Platform>(&self, output_sections: &OutputSections<P>) -> bool {
-        self.sizes.parts.iter().enumerate().all(|(i, size)| {
-            let part_id = PartId::from_usize(i);
+        self.sizes.iter().all(|(part_id, size)| {
             size.is_multiple_of(part_id.alignment(output_sections).value())
                 || should_ignore_alignment::<P>(part_id)
         })


### PR DESCRIPTION
This is mostly to help with partial linking, where almost every input section ends up as a separate custom section. Issue #2433.

I was going to apply sparseness only for partial linking, but from the testing I've done, doing it for all custom sections appears to be performance neutral and applying it more generally has the advantage that the code is more generally exercised.