### PR TITLE
ci: install llvm-tools in ubuntu-base image

### DIFF
--- a/docker/ci/ubuntu-base.Dockerfile
+++ b/docker/ci/ubuntu-base.Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
         git \
         lld \
         llvm \
+        llvm-tools \
         perl \
         wget \
         xz-utils \


### PR DESCRIPTION
Prerequisite for #2440.