### PR TITLE
perf: Use HashMap for CommonGroupState::section_attributes

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1261,7 +1261,7 @@ impl<'data, P: Platform> SymbolRequestHandler<'data, P> for SyntheticSymbolsLayo
 pub(crate) struct CommonGroupState<'data, P: Platform> {
     mem_sizes: OutputSectionPartMap<u64>,
 
-    section_attributes: OutputSectionMap<Option<P::SectionAttributes>>,
+    section_attributes: HashMap<OutputSectionId, P::SectionAttributes>,
 
     /// Dynamic symbols that need to be defined. Because of the ordering requirements for symbol
     /// hashes, these get defined by the epilogue. The object on which a particular dynamic symbol
@@ -1276,7 +1276,7 @@ impl<'data, P: Platform> CommonGroupState<'data, P> {
     fn new(output_sections: &OutputSections<P>) -> Self {
         Self {
             mem_sizes: output_sections.new_part_map(),
-            section_attributes: output_sections.new_section_map(),
+            section_attributes: Default::default(),
             dynamic_symbol_definitions: Default::default(),
             format_specific: Default::default(),
         }
@@ -1327,16 +1327,18 @@ impl<'data, P: Platform> CommonGroupState<'data, P> {
     }
 
     fn store_section_attributes(&mut self, part_id: PartId, header: &P::SectionHeader) {
-        let existing_attributes = self
-            .section_attributes
-            .get_mut(part_id.output_section_id::<P>());
-
         let new_attributes = P::section_attributes(header);
 
-        if let Some(existing) = existing_attributes {
-            existing.merge(new_attributes);
-        } else {
-            *existing_attributes = Some(new_attributes);
+        match self
+            .section_attributes
+            .entry(part_id.output_section_id::<P>())
+        {
+            hashbrown::hash_map::Entry::Occupied(occupied_entry) => {
+                occupied_entry.into_mut().merge(new_attributes);
+            }
+            hashbrown::hash_map::Entry::Vacant(vacant_entry) => {
+                vacant_entry.insert(new_attributes);
+            }
         }
     }
 }
@@ -2199,10 +2201,9 @@ fn propagate_section_attributes<'data, P: Platform>(
         group_state
             .common
             .section_attributes
-            .for_each(|section_id, attributes| {
-                if let Some(attributes) = attributes {
-                    attributes.apply(output_sections, section_id);
-                }
+            .iter()
+            .for_each(|(&section_id, attributes)| {
+                attributes.apply(output_sections, section_id);
             });
     }
 }


### PR DESCRIPTION
Issue #2433

None of the non-partial linking benchmarks that I ran showed any change in performance.

For partial linking, the main gains are reduced peak RSS which is down by about 30%.

```
Benchmark 1 (282 runs): /home/d/save/ripgrep-partial/run-with /home/d/wild-builds/ospm-sparse/000-qpqpqmwo-43c22bc5 --no-fork
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           638ms ± 10.7ms     629ms …  799ms         12 ( 4%)        0%
  peak_rss            407MB ±  660KB     406MB …  409MB          0 ( 0%)        0%
  cpu_cycles         1.66G  ± 22.7M     1.59G  … 1.71G           6 ( 2%)        0%
  instructions       1.49G  ± 4.03M     1.48G  … 1.50G           2 ( 1%)        0%
  cache_references   65.3M  ± 1.38M     61.9M  … 71.6M          43 (15%)        0%
  cache_misses       11.7M  ± 98.4K     11.4M  … 11.9M           2 ( 1%)        0%
  branch_misses      5.42M  ± 36.8K     5.27M  … 5.51M           7 ( 2%)        0%
Benchmark 2 (289 runs): /home/d/save/ripgrep-partial/run-with /home/d/wild-builds/ospm-sparse/001-wntkylvx-9552bcdd --no-fork
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           623ms ± 4.38ms     615ms …  642ms         12 ( 4%)        ⚡-  2.4% ±  0.2%
  peak_rss            287MB ± 1.01MB     285MB …  291MB          7 ( 2%)        ⚡- 29.5% ±  0.0%
  cpu_cycles         1.60G  ± 22.4M     1.53G  … 1.67G           6 ( 2%)        ⚡-  3.4% ±  0.2%
  instructions       1.46G  ± 7.82M     1.44G  … 1.48G          30 (10%)        ⚡-  2.4% ±  0.1%
  cache_references   54.7M  ± 1.41M     51.4M  … 59.9M          38 (13%)        ⚡- 16.3% ±  0.4%
  cache_misses       11.6M  ± 87.2K     11.3M  … 11.8M           4 ( 1%)          -  0.4% ±  0.1%
  branch_misses      5.41M  ± 41.4K     5.22M  … 5.51M           2 ( 1%)          -  0.1% ±  0.1%
```