### PR TITLE
perf: Reduce sparse allocation in compute_start_offsets_by_group

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1832,11 +1832,7 @@ fn compute_start_offsets_by_group<P: Platform>(
 
     group_states
         .iter()
-        .map(|group| {
-            let group_mem_starts = mem_offsets.clone();
-            mem_offsets.merge(&group.common.mem_sizes);
-            group_mem_starts
-        })
+        .map(|group| mem_offsets.merge_and_return_start_offsets(&group.common.mem_sizes))
         .collect_vec()
 }
 

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -130,6 +130,16 @@ impl OutputSectionPartMap<u64> {
         );
         *v -= size;
     }
+
+    /// Increment `self` by `sizes`. Returns the pre-increment values, but only for entries actually
+    /// present in `sizes`.
+    pub(crate) fn merge_and_return_start_offsets(&mut self, sizes: &Self) -> Self {
+        self.mut_with_map(sizes, |offset, size| {
+            let start = *offset;
+            *offset += *size;
+            start
+        })
+    }
 }
 
 impl<T: Default + PartialEq> OutputSectionPartMap<T> {


### PR DESCRIPTION
For partial linking, this gives quite a good speedup and also a decent reduction in peak RSS.

```
Benchmark 1 (22 runs): /home/d/save/wild-partial/run-with /home/d/wild-builds/ospm-sparse/000-txlytntw-3203fe7b --no-fork
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           935ms ± 8.06ms     918ms …  954ms          2 ( 9%)        0%
  peak_rss            332MB ± 1.99MB     329MB …  336MB          0 ( 0%)        0%
  cpu_cycles         2.16G  ± 20.1M     2.11G  … 2.20G           1 ( 5%)        0%
  instructions       2.10G  ± 4.38M     2.10G  … 2.11G           0 ( 0%)        0%
  cache_references   81.5M  ± 1.63M     79.8M  … 87.2M           2 ( 9%)        0%
  cache_misses       16.2M  ±  149K     15.8M  … 16.4M           0 ( 0%)        0%
  branch_misses      8.32M  ± 47.5K     8.22M  … 8.41M           0 ( 0%)        0%
Benchmark 2 (83 runs): /home/d/save/wild-partial/run-with /home/d/wild-builds/ospm-sparse/001-opxnuppk-f933b226 --no-fork
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           243ms ± 2.30ms     238ms …  249ms          0 ( 0%)        ⚡- 74.0% ±  0.2%
  peak_rss            213MB ± 1.20MB     210MB …  216MB          0 ( 0%)        ⚡- 35.9% ±  0.2%
  cpu_cycles          818M  ± 14.0M      785M  …  858M           0 ( 0%)        ⚡- 62.2% ±  0.3%
  instructions       1.17G  ± 4.76M     1.16G  … 1.18G           1 ( 1%)        ⚡- 44.4% ±  0.1%
  cache_references   37.5M  ±  394K     36.7M  … 38.7M           3 ( 4%)        ⚡- 54.0% ±  0.5%
  cache_misses       6.81M  ±  131K     6.34M  … 7.17M           4 ( 5%)        ⚡- 57.9% ±  0.4%
  branch_misses      4.82M  ± 40.4K     4.75M  … 4.95M           0 ( 0%)        ⚡- 42.1% ±  0.2%
```