### PR TITLE
fix: Support LTO with `clang -ffat-lto-objects`

### DIFF
--- a/libwild/src/file_kind.rs
+++ b/libwild/src/file_kind.rs
@@ -54,6 +54,8 @@ impl FileKind {
                 object::elf::ET_REL => {
                     if is_gcc_bitcode(bytes, header).unwrap_or(false) {
                         Ok(FileKind::GccIr)
+                    } else if is_llvm_bitcode(bytes, header).unwrap_or(false) {
+                        Ok(FileKind::LlvmIr)
                     } else {
                         Ok(FileKind::ElfObject)
                     }
@@ -136,6 +138,25 @@ fn is_gcc_bitcode(data: &[u8], header: &crate::elf::FileHeader64) -> Option<bool
     const MAX_SCAN: usize = 200;
     let strings = data.get(start_offset + START..start_offset + (START + MAX_SCAN).min(len))?;
     Some(memchr::memmem::find(strings, b"\0.gnu.lto_.").is_some())
+}
+
+fn is_llvm_bitcode(data: &[u8], header: &crate::elf::FileHeader64) -> Option<bool> {
+    // If we don't have plugin support, then we skip checking if the file contains LLVM IR. If it
+    // is, then we'll figure that out later on and report an error. We do this because this code
+    // has a measurable performance impact.
+    if !cfg!(all(feature = "plugins", unix)) {
+        return Some(false);
+    }
+    let e = LittleEndian;
+    let section_headers = header.section_headers(e, data).ok()?;
+    let sh_str_index = header.shstrndx(e, data).ok()?;
+    let strings_section_header = section_headers.get(sh_str_index as usize)?;
+    let start_offset = strings_section_header.sh_offset(e) as usize;
+    let len = strings_section_header.sh_size(e) as usize;
+    const START: usize = 0;
+    const MAX_SCAN: usize = 100;
+    let strings = data.get(start_offset + START..start_offset + (START + MAX_SCAN).min(len))?;
+    Some(memchr::memmem::find(strings, b"\0.llvm.lto").is_some())
 }
 
 impl std::fmt::Display for FileKind {

--- a/libwild/src/file_kind.rs
+++ b/libwild/src/file_kind.rs
@@ -140,6 +140,9 @@ fn is_gcc_bitcode(data: &[u8], header: &crate::elf::FileHeader64) -> Option<bool
     Some(memchr::memmem::find(strings, b"\0.gnu.lto_.").is_some())
 }
 
+// FIXME: Add to object crate.
+const SHT_LLVM_LTO: object::elf::SectionType = object::elf::SectionType(0x6fff4c0c);
+
 fn is_llvm_bitcode(data: &[u8], header: &crate::elf::FileHeader64) -> Option<bool> {
     // If we don't have plugin support, then we skip checking if the file contains LLVM IR. If it
     // is, then we'll figure that out later on and report an error. We do this because this code
@@ -149,14 +152,7 @@ fn is_llvm_bitcode(data: &[u8], header: &crate::elf::FileHeader64) -> Option<boo
     }
     let e = LittleEndian;
     let section_headers = header.section_headers(e, data).ok()?;
-    let sh_str_index = header.shstrndx(e, data).ok()?;
-    let strings_section_header = section_headers.get(sh_str_index as usize)?;
-    let start_offset = strings_section_header.sh_offset(e) as usize;
-    let len = strings_section_header.sh_size(e) as usize;
-    const START: usize = 0;
-    const MAX_SCAN: usize = 100;
-    let strings = data.get(start_offset + START..start_offset + (START + MAX_SCAN).min(len))?;
-    Some(memchr::memmem::find(strings, b"\0.llvm.lto").is_some())
+    Some(section_headers.iter().any(|s| s.sh_type(e) == SHT_LLVM_LTO))
 }
 
 impl std::fmt::Display for FileKind {

--- a/libwild/src/file_kind.rs
+++ b/libwild/src/file_kind.rs
@@ -140,7 +140,7 @@ fn is_gcc_bitcode(data: &[u8], header: &crate::elf::FileHeader64) -> Option<bool
     Some(memchr::memmem::find(strings, b"\0.gnu.lto_.").is_some())
 }
 
-// FIXME: Add to object crate.
+// TODO: Use object crate once a new version is up.
 const SHT_LLVM_LTO: object::elf::SectionType = object::elf::SectionType(0x6fff4c0c);
 
 fn is_llvm_bitcode(data: &[u8], header: &crate::elf::FileHeader64) -> Option<bool> {

--- a/wild/tests/sources/elf/linker-plugin-lto/linker-plugin-lto.c
+++ b/wild/tests/sources/elf/linker-plugin-lto/linker-plugin-lto.c
@@ -109,6 +109,16 @@
 //#LinkArgs:--plugin=/does/not/exist
 //#ExpectError:No such file or directory
 
+//#Config:gcc-fat-objects:default
+//#Compiler:gcc
+//#CompArgs:-flto -ffat-lto-objects -O1
+//#LinkerDriver:gcc
+//#LinkArgs:-Wl,-znow -flto -ffat-lto-objects -nostdlib
+//#Object:runtime.c
+//#Object:linker-plugin-lto-2.c
+//#DiffIgnore:section-diff-failed..text
+//#DoesNotContain: foo
+
 //#Config:clang-fat-objects:default
 //#Compiler:clang
 //#CompArgs:-flto -ffat-lto-objects -O1

--- a/wild/tests/sources/elf/linker-plugin-lto/linker-plugin-lto.c
+++ b/wild/tests/sources/elf/linker-plugin-lto/linker-plugin-lto.c
@@ -109,6 +109,16 @@
 //#LinkArgs:--plugin=/does/not/exist
 //#ExpectError:No such file or directory
 
+//#Config:clang-fat-objects:default
+//#Compiler:clang
+//#CompArgs:-flto -ffat-lto-objects -O1
+//#LinkerDriver:clang
+//#LinkArgs:-Wl,-znow -flto -ffat-lto-objects -nostdlib
+//#Object:runtime.c
+//#Object:linker-plugin-lto-2.c
+//#DiffIgnore:section-diff-failed..text
+//#DoesNotContain: foo
+
 #include "../common/runtime.h"
 
 int foo();


### PR DESCRIPTION
Previously we were just using the regular non-LTO symbols in this case.

Also added GCC counterpart test which seems fine, but there is a strange symbol there:
```
Symbol table '.symtab' contains 9 entries:
...
3: 0000000000000000     0 FILE    LOCAL  DEFAULT  ABS <artificial>
```