### PR TITLE
port(wasm): Support `--shared-memory`

### DIFF
--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -46,6 +46,9 @@ pub struct WasmArgs {
     // page-aligned). `None` means size is derived from data / stack layout only.
     pub(crate) initial_memory: Option<u64>,
     pub(crate) max_memory: Option<u64>,
+    // Emit a shared linear memory (`memory.shared`). Requires the `atomics` and `bulk-memory`
+    // target features.
+    pub(crate) shared_memory: bool,
     pub(crate) gc_sections: bool,
     pub(crate) allow_undefined: bool,
 }
@@ -77,6 +80,7 @@ impl Default for WasmArgs {
             entry: Some(DEFAULT_ENTRY.to_owned()),
             initial_memory: None,
             max_memory: None,
+            shared_memory: false,
             export_memory: None,
             gc_sections: true,
             allow_undefined: false,
@@ -363,6 +367,15 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
         .help("Maximum size of the linear memory in bytes")
         .execute(|args, _modifier_stack, value| {
             args.max_memory = Some(parse_number(value)?);
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("shared-memory")
+        .help("Use shared linear memory")
+        .execute(|args, _modifier_stack| {
+            args.shared_memory = true;
             Ok(())
         });
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1837,10 +1837,13 @@ fn wasm_symbol_name_str<'data>(data: &'data [u8], sym: &WasmSymbol) -> Option<&'
     core::str::from_utf8(bytes).ok()
 }
 
-/// Merge `target_features` from linked objects and encode the output custom section.
-fn build_target_features_section<'data>(
+/// Collect used / disallowed `target_features` entries from all objects.
+fn collect_target_feature_sets<'data>(
     layout_inputs: &[WasmObjectLayoutInput<'data>],
-) -> Result<Option<wasm_encoder::CustomSection<'static>>> {
+) -> Result<(
+    HashSet<&'data str>,
+    HashMap<&'data str, crate::input_data::FileId>,
+)> {
     let mut used: HashSet<&'data str> = HashSet::new();
     // First file that disallowed each feature.
     let mut disallowed: HashMap<&'data str, crate::input_data::FileId> = HashMap::new();
@@ -1863,6 +1866,35 @@ fn build_target_features_section<'data>(
             }
         }
     }
+
+    Ok((used, disallowed))
+}
+
+/// Shared memory requires `atomics` and `bulk-memory`.
+fn validate_shared_memory_features(
+    layout_inputs: &[WasmObjectLayoutInput<'_>],
+    symbol_db: &SymbolDb<'_, Wasm>,
+) -> Result {
+    let (used, disallowed) = collect_target_feature_sets(layout_inputs)?;
+    if let Some(&file_id) = disallowed.get("shared-mem") {
+        bail!(
+            "--shared-memory is disallowed by {} because it was not compiled with 'atomics' or 'bulk-memory' features.",
+            symbol_db.file(file_id)
+        );
+    }
+    for feature in ["atomics", "bulk-memory"] {
+        if !used.contains(feature) {
+            bail!("'{feature}' feature must be used in order to use shared memory");
+        }
+    }
+    Ok(())
+}
+
+/// Merge `target_features` from linked objects and encode the output custom section.
+fn build_target_features_section<'data>(
+    layout_inputs: &[WasmObjectLayoutInput<'data>],
+) -> Result<Option<wasm_encoder::CustomSection<'static>>> {
+    let (used, disallowed) = collect_target_feature_sets(layout_inputs)?;
 
     for name in &used {
         if let Some(&file_id) = disallowed.get(name) {
@@ -5339,6 +5371,7 @@ fn ensure_memory_covers(
     stack_first: bool,
     initial_memory: Option<u64>,
     max_memory: Option<u64>,
+    shared_memory: bool,
 ) -> Result<u64> {
     let page = wasm_page_size();
     let mut bytes_needed = u64::from(layout.data_end.max(layout.memory_base));
@@ -5394,6 +5427,15 @@ fn ensure_memory_covers(
         }
     }
 
+    if shared_memory {
+        for memory in &mut layout.memories {
+            memory.shared = true;
+            // Shared memories must declare a maximum. Default to the final initial size.
+            let max = memory.maximum.unwrap_or(memory.initial).max(memory.initial);
+            memory.maximum = Some(max);
+        }
+    }
+
     Ok(initial_pages)
 }
 
@@ -5426,7 +5468,7 @@ fn fill_stack_pointer_init(
     Ok(())
 }
 
-fn linker_output_memory_type(inputs: &[WasmObjectLayoutInput<'_>]) -> MemoryType {
+fn linker_output_memory_type(inputs: &[WasmObjectLayoutInput<'_>], shared: bool) -> MemoryType {
     let mut initial = 2u64;
     for input in inputs {
         for import in &input.memory_imports {
@@ -5438,7 +5480,7 @@ fn linker_output_memory_type(inputs: &[WasmObjectLayoutInput<'_>]) -> MemoryType
     }
     MemoryType {
         memory64: false,
-        shared: false,
+        shared,
         initial,
         maximum: None,
         page_size_log2: None,
@@ -5715,6 +5757,10 @@ where
             .collect::<Result<Vec<_>>>()?
     };
 
+    if symbol_db.args.shared_memory {
+        validate_shared_memory_features(&layout_inputs, symbol_db)?;
+    }
+
     let file_id_to_index = layout_file_id_to_index(&layout_inputs);
     let mut import_resolutions =
         resolve_cross_object_imports(&layout_inputs, symbol_db, &file_id_to_index)?;
@@ -5768,6 +5814,7 @@ where
     let stack_first = symbol_db.args.stack_first;
     let initial_memory = symbol_db.args.initial_memory;
     let max_memory = symbol_db.args.max_memory;
+    let shared_memory = symbol_db.args.shared_memory;
     if stack_size > 0 {
         ensure_stack_size_aligned(stack_size)?;
     }
@@ -5909,7 +5956,7 @@ where
         if linker_memory && layout.memories.is_empty() {
             layout
                 .memories
-                .push(linker_output_memory_type(&layout_inputs));
+                .push(linker_output_memory_type(&layout_inputs, shared_memory));
         }
         if !layout.memories.is_empty() {
             ensure_memory_export(&mut layout.exports, symbol_db.args.memory_export_name());
@@ -5921,6 +5968,7 @@ where
             stack_first,
             initial_memory,
             max_memory,
+            shared_memory,
         )?;
         // wasm-ld only defines `__heap_end` when linear memory exists (end of `memory.initial`).
         let heap_end = if layout.memories.is_empty() {
@@ -7942,13 +7990,14 @@ mod tests {
         };
 
         let pages =
-            ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, true, None, None).unwrap();
+            ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, true, None, None, false).unwrap();
         assert_eq!(pages, 1);
         assert_eq!(layout.memories[0].initial, 1);
         assert_eq!(layout.memories[0].maximum, None);
+        assert!(!layout.memories[0].shared);
 
-        let pages =
-            ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, false, None, None).unwrap();
+        let pages = ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, false, None, None, false)
+            .unwrap();
         let expected_pages = (u64::from(data_end) + u64::from(DEFAULT_STACK_SIZE))
             .div_ceil(wasm_page_size())
             .max(1);

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -85,6 +85,9 @@
 //!
 //! ExpectFuncImportCount:{count} (Wasm) Asserts the total number of function imports.
 //!
+//! ExpectSharedMemory:{bool} (Wasm) When true, asserts that the output module defines a shared
+//! linear memory with a maximum.
+//!
 //! ExpectSection:{section_name} [properties] Checks that the specified section exists in the
 //! output binary. Optional properties:
 //!   max_entries=N: Asserts the section has at most N entries (uses the section's sh_entsize,
@@ -546,6 +549,7 @@ struct WasmModuleInfo {
     imported_global_count: u32,
     defined_global_i32: Vec<Option<i32>>,
     export_global_indices: HashMap<String, u32>,
+    memories: Vec<wasmparser::MemoryType>,
 }
 
 fn i32_const_from_expr(expr: wasmparser::ConstExpr<'_>) -> Option<i32> {
@@ -571,6 +575,7 @@ impl WasmModuleInfo {
         let mut imported_global_count = 0u32;
         let mut defined_global_i32 = Vec::new();
         let mut export_global_indices = HashMap::new();
+        let mut memories = Vec::new();
 
         for payload in Parser::new(0).parse_all(&bytes) {
             match payload? {
@@ -615,8 +620,13 @@ impl WasmModuleInfo {
                 Payload::TableSection(_) => {
                     section_names.insert("Table".to_owned());
                 }
-                Payload::MemorySection(_) => {
+                Payload::MemorySection(section) => {
                     section_names.insert("Memory".to_owned());
+                    for memory in section {
+                        memories.push(memory.with_context(|| {
+                            format!("Invalid memory entry in {}", path.display())
+                        })?);
+                    }
                 }
                 Payload::GlobalSection(section) => {
                     section_names.insert("Global".to_owned());
@@ -671,6 +681,7 @@ impl WasmModuleInfo {
             imported_global_count,
             defined_global_i32,
             export_global_indices,
+            memories,
         })
     }
 
@@ -817,6 +828,30 @@ impl WasmModuleInfo {
         }
         Ok(())
     }
+
+    fn ensure_shared_memory(&self, expected: bool, linker_name: &str) -> Result {
+        if !expected {
+            return Ok(());
+        }
+        ensure!(
+            !self.memories.is_empty(),
+            "Expected a shared memory in {linker_name} output ({}), but the module has no memory",
+            self.path.display()
+        );
+        for (index, memory) in self.memories.iter().enumerate() {
+            ensure!(
+                memory.shared,
+                "Expected memory {index} to be shared in {linker_name} output ({})",
+                self.path.display()
+            );
+            ensure!(
+                memory.maximum.is_some(),
+                "Expected shared memory {index} to have a maximum in {linker_name} output ({})",
+                self.path.display()
+            );
+        }
+        Ok(())
+    }
 }
 
 fn validate_wasm(wasm_file: &Path, linker_name: &str) -> Result {
@@ -838,6 +873,7 @@ fn validate_wasm(wasm_file: &Path, linker_name: &str) -> Result {
 fn run_wasm_with_wasmtime(wasm_file: &Path, linker_name: &str) -> Result {
     let output = Command::new("wasmtime")
         .arg("run")
+        .args(["-W", "threads,shared-memory"])
         .arg(wasm_file)
         .output()
         .context("Failed to run wasmtime")?;
@@ -1882,6 +1918,8 @@ struct Assertions {
     expected_func_imports: Vec<(String, String, usize)>,
     /// Wasm: total number of function imports in the import section.
     expected_func_import_count: Option<usize>,
+    /// Wasm: require a shared linear memory with a maximum.
+    expect_shared_memory: bool,
     relr_count: Option<u64>,
     expected_gdb_index_cu_count: Option<usize>,
     expected_gdb_index_symbols: Vec<String>,
@@ -2434,6 +2472,10 @@ fn process_directive(
                     .parse()
                     .with_context(|| format!("Invalid ExpectFuncImportCount: `{arg}`"))?,
             );
+        }
+        "ExpectSharedMemory" => {
+            config.assertions.expect_shared_memory =
+                arg.parse().context("Invalid bool for ExpectSharedMemory")?;
         }
         "ExpectSection" => {
             let arg = arg.trim();
@@ -4960,6 +5002,7 @@ impl Assertions {
             no_sym: self.no_sym.clone(),
             expected_func_imports: self.expected_func_imports.clone(),
             expected_func_import_count: self.expected_func_import_count,
+            expect_shared_memory: self.expect_shared_memory,
             ..Default::default()
         };
         ensure!(
@@ -4991,6 +5034,7 @@ impl Assertions {
         )?;
         info.ensure_func_types_unique(linker_name)?;
         info.ensure_exports(&self.expected_symtab_entries, &self.no_sym, linker_name)?;
+        info.ensure_shared_memory(self.expect_shared_memory, linker_name)?;
         self.verify_strings(&info.bytes)?;
         Ok(())
     }

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -2474,8 +2474,7 @@ fn process_directive(
             );
         }
         "ExpectSharedMemory" => {
-            config.assertions.expect_shared_memory =
-                arg.parse().context("Invalid bool for ExpectSharedMemory")?;
+            config.assertions.expect_shared_memory = arg.parse()?;
         }
         "ExpectSection" => {
             let arg = arg.trim();

--- a/wild/tests/sources/wasm/shared-memory-disallowed/shared-memory-disallowed.s
+++ b/wild/tests/sources/wasm/shared-memory-disallowed/shared-memory-disallowed.s
@@ -7,7 +7,7 @@ _start:
   end_function
 
   .section .custom_section.target_features,"",@
-  .int8 1
-  .int8 45
-  .int8 10
+  .int8 1 # Number of target features
+  .int8 45 # '-'
+  .int8 10 # Length of target features string
   .ascii "shared-mem"

--- a/wild/tests/sources/wasm/shared-memory-disallowed/shared-memory-disallowed.s
+++ b/wild/tests/sources/wasm/shared-memory-disallowed/shared-memory-disallowed.s
@@ -1,0 +1,13 @@
+//#LinkArgs: --shared-memory --max-memory=131072 --no-entry
+//#ExpectError: --shared-memory is disallowed
+
+  .globl _start
+_start:
+  .functype _start () -> ()
+  end_function
+
+  .section .custom_section.target_features,"",@
+  .int8 1
+  .int8 45
+  .int8 10
+  .ascii "shared-mem"

--- a/wild/tests/sources/wasm/shared-memory-no-bulk/shared-memory-no-bulk.s
+++ b/wild/tests/sources/wasm/shared-memory-no-bulk/shared-memory-no-bulk.s
@@ -1,0 +1,13 @@
+//#LinkArgs: --shared-memory --max-memory=131072 --no-entry
+//#ExpectError: 'bulk-memory' feature must be used in order to use shared memory
+
+  .globl _start
+_start:
+  .functype _start () -> ()
+  end_function
+
+  .section .custom_section.target_features,"",@
+  .int8 1
+  .int8 43
+  .int8 7
+  .ascii "atomics"

--- a/wild/tests/sources/wasm/shared-memory-no-bulk/shared-memory-no-bulk.s
+++ b/wild/tests/sources/wasm/shared-memory-no-bulk/shared-memory-no-bulk.s
@@ -7,7 +7,7 @@ _start:
   end_function
 
   .section .custom_section.target_features,"",@
-  .int8 1
-  .int8 43
-  .int8 7
+  .int8 1 # Number of target features
+  .int8 43 # '+'
+  .int8 7 # Length of target features string
   .ascii "atomics"

--- a/wild/tests/sources/wasm/shared-memory/shared-memory.c
+++ b/wild/tests/sources/wasm/shared-memory/shared-memory.c
@@ -1,0 +1,22 @@
+//#Config:default
+//#LinkArgs: --shared-memory --max-memory=131072
+//#CompArgs: -matomics
+//#ExpectSharedMemory: true
+//#Contains: atomics
+//#Contains: bulk-memory
+
+//#Config:no-max
+//#LinkArgs: --shared-memory
+//#CompArgs: -matomics
+//#ExpectSharedMemory: true
+
+//#Config:missing-atomics
+//#LinkArgs: --shared-memory
+//#ExpectError: 'atomics' feature must be used in order to use shared memory
+
+//#Config:unaligned
+//#LinkArgs: --shared-memory --max-memory=100000
+//#CompArgs: -matomics
+//#ExpectError: maximum memory must be aligned
+
+void _start(void) {}

--- a/wild/tests/sources/wasm/shared-memory/shared-memory.c
+++ b/wild/tests/sources/wasm/shared-memory/shared-memory.c
@@ -19,4 +19,10 @@
 //#CompArgs: -matomics
 //#ExpectError: maximum memory must be aligned
 
-void _start(void) {}
+int value = 42;
+
+void _start(void) {
+  if (value != 42) {
+    __builtin_trap();
+  }
+}


### PR DESCRIPTION
This option specifies the use of shared linear memory. Note that wasm-ld emits errors when the option is specified and both `atomics` and `bulk-memory` features absent.

Part of #1431

Close #2336