### PR TITLE
chore: address cargo clippy warnings

### DIFF
--- a/libwild/src/export_list.rs
+++ b/libwild/src/export_list.rs
@@ -41,11 +41,7 @@ impl<'data> ExportList<'data> {
             }
         }
 
-        if self.0.general.matches_all() || self.0.cxx.matches_all() {
-            return true;
-        }
-
-        false
+        self.0.general.matches_all() || self.0.cxx.matches_all()
     }
 
     pub(crate) fn add_symbol(&mut self, symbol: &'data str, without_semicolon: bool) -> Result<()> {


### PR DESCRIPTION
Addresses:
```
warning: this `if` guard returns a bool literal and is followed by another
  --> libwild/src/export_list.rs:44:9
   |
44 | /         if self.0.general.matches_all() || self.0.cxx.matches_all() {
45 | |             return true;
...  |
48 | |         false
   | |_____________^ help: you can reduce it to: `self.0.general.matches_all() || self.0.cxx.matches_all()`
```