### PR TITLE
port(MachO): Align `__thread_data` and `__thread_bss`

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -291,6 +291,8 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>, F: FileSystem>(
         unreachable!();
     };
 
+    P::finalise_output_section_alignments(&section_part_sizes, &mut output_sections);
+
     let (mut section_part_layouts, mut section_layouts, mut resolved_location_counters) =
         compute_layout_sections::<A::Platform>(
             &section_part_sizes,
@@ -5539,7 +5541,11 @@ fn compute_layout_sections<'data, P: Platform>(
 
                 for (part_id, part_size) in part_sizes.chain(empty_part) {
                     let part_layout = records_out.get_mut(part_id);
-                    let alignment = part_id.alignment(output_sections).min(max_alignment);
+                    let alignment = if is_first_part {
+                        max_alignment
+                    } else {
+                        part_id.alignment(output_sections).min(max_alignment)
+                    };
                     let mem_size = if Some(section_id) == P::RELRO_PADDING_SECTION_ID {
                         let page_alignment = args.loadable_segment_alignment();
                         let aligned_offset = page_alignment.align_up(mem_offset);

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -41,6 +41,7 @@ use crate::part_id::PartId;
 use crate::platform;
 use crate::platform::Args;
 use crate::platform::ObjectFile;
+use crate::platform::SectionAttributes as _;
 use crate::program_segments::ProgramSegmentId;
 use crate::program_segments::ProgramSegments;
 use crate::resolution;
@@ -1928,6 +1929,29 @@ impl platform::Platform for MachO {
         match segment_name {
             Some(segment_name) => write!(f, "{segment_name},{section_name}"),
             None => write!(f, "{section_name}"),
+        }
+    }
+
+    fn finalise_output_section_alignments(
+        sizes: &OutputSectionPartMap<u64>,
+        output_sections: &mut crate::output_section_id::OutputSections<'_, Self>,
+    ) {
+        let tlv_sections = output_sections
+            .ids_with_info()
+            .filter_map(|(section_id, info)| info.section_attributes.is_tls().then_some(section_id))
+            .collect_vec();
+
+        let max_align = tlv_sections
+            .iter()
+            .map(|&section_id| {
+                sizes.max_alignment(section_id.part_id_range::<MachO>(), output_sections)
+            })
+            .max();
+
+        if let Some(max_align) = max_align {
+            for section_id in tlv_sections {
+                output_sections.bump_min_alignment(section_id, max_align);
+            }
         }
     }
 }

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -1031,6 +1031,12 @@ pub(crate) trait Platform:
     ) -> Self::SectionAttributes {
         output_attributes
     }
+
+    fn finalise_output_section_alignments(
+        _sizes: &OutputSectionPartMap<u64>,
+        _output_sections: &mut OutputSections<'_, Self>,
+    ) {
+    }
 }
 
 /// Abstracts over the different object file formats that we support (or may support). e.g. ELF.

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -5990,20 +5990,38 @@ fn verify_macho_tlv_template_layout(obj: &object::File) -> Result {
             bail!("Expected Mach-O section flags");
         };
 
-        sections.push((section.name()?, flags.typ()));
+        sections.push((
+            section.name()?,
+            flags.typ(),
+            section.align(),
+            section.address(),
+        ));
     }
 
     let is_tlv_template = |ty| matches!(ty, S_THREAD_LOCAL_REGULAR | S_THREAD_LOCAL_ZEROFILL);
 
     let (Some(start), Some(end)) = (
-        sections.iter().position(|&(_, ty)| is_tlv_template(ty)),
-        sections.iter().rposition(|&(_, ty)| is_tlv_template(ty)),
+        sections
+            .iter()
+            .position(|&(_, ty, _, _)| is_tlv_template(ty)),
+        sections
+            .iter()
+            .rposition(|&(_, ty, _, _)| is_tlv_template(ty)),
     ) else {
         return Ok(());
     };
 
     let template = &sections[start..=end];
-    let types = template.iter().map(|&(_, ty)| ty).dedup().collect_vec();
+    let types = template
+        .iter()
+        .map(|&(_, ty, _, _)| ty)
+        .dedup()
+        .collect_vec();
+    let max_align = template
+        .iter()
+        .map(|(_, _, align, _)| *align)
+        .max()
+        .expect("Mach-O TLV template sections should have a maximum alignment");
 
     ensure!(
         matches!(
@@ -6015,7 +6033,27 @@ fn verify_macho_tlv_template_layout(obj: &object::File) -> Result {
         "Mach-O TLV template sections must be contiguous: {}",
         template
             .iter()
-            .map(|(name, ty)| format!("{name} ({ty:?})"))
+            .map(|(name, ty, _, _)| format!("{name} ({ty:?})"))
+            .join(", ")
+    );
+
+    ensure!(
+        template.iter().all(|(_, _, align, _)| *align == max_align),
+        "Mach-O TLV template sections must use maximum alignment {max_align}: {}",
+        template
+            .iter()
+            .map(|(name, _, align, _)| { format!("{name} alignment: {align}") })
+            .join(", ")
+    );
+
+    ensure!(
+        template
+            .iter()
+            .all(|(_, _, align, address)| address.is_multiple_of(*align)),
+        "Mach-O TLV template section addresses must satisfy their maximum alignment: {}",
+        template
+            .iter()
+            .map(|(name, _, align, address)| { format!("{name} {address:#x} alignment: {align}") })
             .join(", ")
     );
 

--- a/wild/tests/sources/macho/trivial-tls/trivial-tls.c
+++ b/wild/tests/sources/macho/trivial-tls/trivial-tls.c
@@ -9,6 +9,6 @@
 #include "../common/runtime.h"
 
 _Thread_local int initialized = 1;
-_Thread_local int uninitialized;
+_Thread_local int uninitialized __attribute__((aligned(64)));
 
 void main(void) { exit_syscall(42); }


### PR DESCRIPTION
TLV template sections (`__thread_data` and `__thread_bss`) are copied contiguously at runtime to initialize thread-local storage, and each descriptor in `__thread_vars` contains an offset from the start of this storage to its corresponding thread-local variable. If a later TLV template section requires a stricter alignment than the previous one, then the offsets might not preserve that alignment in each thread-local copy. Therefore, this requires that we find the maximum alignment in all TLV template sections and normalize each section's alignment to this maximum.

`__thread_vars` is not included in this normalization and requires its own alignment requirement, which I plan on implementing next.

**Before**:
```
failures:

---- macho/aarch64/trivial-tls/default ----
  Caused by:
    Mach-O TLV template sections must use maximum alignment 64: __thread_data alignment: 4, __thread_bss alignment: 64
```

**After:**
```
running 1 test
test macho/aarch64/trivial-tls/default ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 24 filtered out; finished in 0.05s
```

Part of #2071 