### PR TITLE
test: Verify that linker script ALIGN is correctly applied

### DIFF
--- a/wild/tests/sources/elf/linker-script-alignof-pass/linker-script-alignof-pass.c
+++ b/wild/tests/sources/elf/linker-script-alignof-pass/linker-script-alignof-pass.c
@@ -1,6 +1,7 @@
 //#LinkArgs:-T ./linker-script-alignof-pass.ld
 //#RunEnabled:false
 //#DiffEnabled:false
+//#ExpectSym:aligned_data alignment=2048
 
 __attribute__((section(".data.aligned"))) int aligned_data = 42;
 void _start() {}


### PR DESCRIPTION
This changed test fails without the fix to `layout.rs` from #2455.