### PR TITLE
port(MachO): Align `__thread_vars`

### DIFF
--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -65,6 +65,7 @@ use object::macho::S_ATTR_PURE_INSTRUCTIONS;
 use object::macho::S_ATTR_SOME_INSTRUCTIONS;
 use object::macho::S_GB_ZEROFILL;
 use object::macho::S_THREAD_LOCAL_REGULAR;
+use object::macho::S_THREAD_LOCAL_VARIABLES;
 use object::macho::S_THREAD_LOCAL_ZEROFILL;
 use object::macho::S_ZEROFILL;
 use object::macho::SECTION_ATTRIBUTES;
@@ -1941,6 +1942,13 @@ impl platform::Platform for MachO {
             .filter_map(|(section_id, info)| info.section_attributes.is_tls().then_some(section_id))
             .collect_vec();
 
+        let tlv_descriptors = output_sections
+            .ids_with_info()
+            .filter_map(|(section_id, info)| {
+                (info.section_attributes.ty() == S_THREAD_LOCAL_VARIABLES).then_some(section_id)
+            })
+            .collect_vec();
+
         let max_align = tlv_sections
             .iter()
             .map(|&section_id| {
@@ -1952,6 +1960,10 @@ impl platform::Platform for MachO {
             for section_id in tlv_sections {
                 output_sections.bump_min_alignment(section_id, max_align);
             }
+        }
+
+        for section_id in tlv_descriptors {
+            output_sections.bump_min_alignment(section_id, alignment::USIZE);
         }
     }
 }

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -355,6 +355,7 @@ use object::macho::LC_CODE_SIGNATURE;
 use object::macho::LC_DYLD_CHAINED_FIXUPS;
 use object::macho::LC_DYLD_EXPORTS_TRIE;
 use object::macho::S_THREAD_LOCAL_REGULAR;
+use object::macho::S_THREAD_LOCAL_VARIABLES;
 use object::macho::S_THREAD_LOCAL_ZEROFILL;
 use object::macho::SEG_LINKEDIT;
 use object::macho::SEG_TEXT;
@@ -5984,6 +5985,8 @@ fn verify_macho_tlv_template_layout(obj: &object::File) -> Result {
         return Ok(());
     };
 
+    const MACHO64_POINTER_ALIGNMENT: u64 = 8;
+
     let mut sections = Vec::new();
     for section in obj.sections() {
         let object::SectionFlags::MachO { flags, .. } = section.flags() else {
@@ -5997,6 +6000,24 @@ fn verify_macho_tlv_template_layout(obj: &object::File) -> Result {
             section.address(),
         ));
     }
+
+    let descriptors = sections
+        .iter()
+        .copied()
+        .filter(|(_, ty, _, _)| *ty == S_THREAD_LOCAL_VARIABLES)
+        .collect_vec();
+
+    ensure!(
+        descriptors
+            .iter()
+            .all(|(_, _, align, address)| *align >= MACHO64_POINTER_ALIGNMENT
+                && address.is_multiple_of(*align)),
+        "Mach-O TLV descriptors must satisfy a minimum alignment of pointer size {MACHO64_POINTER_ALIGNMENT}: {}",
+        descriptors
+            .iter()
+            .map(|(name, _, align, address)| { format!("{name} {address:#x} alignment: {align}") })
+            .join(", ")
+    );
 
     let is_tlv_template = |ty| matches!(ty, S_THREAD_LOCAL_REGULAR | S_THREAD_LOCAL_ZEROFILL);
 

--- a/wild/tests/sources/macho/trivial-tls/trivial-tls.c
+++ b/wild/tests/sources/macho/trivial-tls/trivial-tls.c
@@ -5,6 +5,7 @@
 //#Object:runtime.c
 //#ExpectSection:__thread_data
 //#ExpectSection:__thread_bss
+//#ExpectSection:__thread_vars
 
 #include "../common/runtime.h"
 


### PR DESCRIPTION
It seems like Clang emits `__thread_vars` with an alignment of 1. However, the descriptors themselves are comprised of one function pointer and two word-sized fields, meaning that `__thread_vars` should at least have an alignment of pointer size.

**Before:**
```
running 1 test
test macho/aarch64/trivial-tls/default ... FAILED

failures:

---- macho/aarch64/trivial-tls/default ----
  Caused by:
    Mach-O TLV descriptors must satisfy a minimum alignment of pointer size 8: __thread_vars 0x100008000 alignment: 1
```
**After:**
```
running 1 test
test macho/aarch64/trivial-tls/default ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 24 filtered out; finished in 0.05s
```

Part of #2071