### PR TITLE
feat: implement --emit-relocs

### DIFF
--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -127,6 +127,7 @@ pub struct ElfArgs {
 
     pub(crate) should_output_executable: bool,
     pub(crate) should_output_partial_object: bool,
+    pub(crate) emit_relocs: bool,
 
     pub(crate) nmagic: bool,
     pub(crate) rosegment: bool,
@@ -274,6 +275,7 @@ impl Default for ElfArgs {
             lib_search_path: Vec::new(),
             should_output_executable: true,
             should_output_partial_object: false,
+            emit_relocs: false,
             dynamic_linker: None,
             strip: Strip::Nothing,
             // For now, we default to --gc-sections. This is different to other linkers, but other
@@ -852,6 +854,17 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
             args.relro = false;
             args.should_write_linker_identity = false;
             args.merge_sections = false;
+            args.emit_relocs = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .short("q")
+        .long("emit-relocs")
+        .help("Leaves relocation sections in the output")
+        .execute(|args, _modifier_stack| {
+            args.emit_relocs = true;
             Ok(())
         });
 
@@ -2053,6 +2066,10 @@ impl platform::Args for ElfArgs {
 
     fn should_output_partial_object(&self) -> bool {
         self.should_output_partial_object
+    }
+
+    fn emit_relocs(&self) -> bool {
+        self.emit_relocs
     }
 
     fn should_write_gdb_index(&self) -> bool {

--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -859,16 +859,6 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
         });
 
     parser
-        .declare()
-        .short("q")
-        .long("emit-relocs")
-        .help("Leaves relocation sections in the output")
-        .execute(|args, _modifier_stack| {
-            args.emit_relocs = true;
-            Ok(())
-        });
-
-    parser
         .declare_with_param()
         .long("pack-dyn-relocs")
         .help("Specify dynamic relocation packing format")
@@ -1813,6 +1803,16 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
         .help("Discard SFrame section")
         .execute(|args, _modifier_stack| {
             args.discard_sframe = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .short("q")
+        .long("emit-relocs")
+        .help("Leaves relocation sections in the output")
+        .execute(|args, _modifier_stack| {
+            args.emit_relocs = true;
             Ok(())
         });
 

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -2072,14 +2072,31 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
                     num_globals += 1;
                 }
                 strings_size += symtab_name_for_strtab(info.name).len() + 1;
-            } else if symbol_db.args.should_output_partial_object
+            } else if (symbol_db.args.emit_relocs())
                 && sym.is_undefined()
-                && symbol_db.is_canonical(symbol_id)
                 && let Ok(name) = state.object.symbol_name(sym)
                 && !name.is_empty()
             {
-                num_globals += 1;
-                strings_size += symtab_name_for_strtab(name).len() + 1;
+                let canonical = symbol_db.definition(symbol_id);
+                let def_file = symbol_db.file_id_for_symbol(canonical);
+                let is_dynamic = per_symbol_flags
+                    .get_atomic(canonical)
+                    .get()
+                    .contains(ValueFlags::DYNAMIC);
+                if (symbol_db.is_canonical(symbol_id) || is_dynamic)
+                    && def_file != crate::input_data::PRELUDE_FILE_ID
+                {
+                    let old_flags = per_symbol_flags
+                        .get_atomic(canonical)
+                        .fetch_or(ValueFlags::SYMTAB_INSTALLED);
+                    if !old_flags.contains(ValueFlags::SYMTAB_INSTALLED) {
+                        per_symbol_flags
+                            .get_atomic(symbol_id)
+                            .fetch_or(ValueFlags::SYMTAB_INSTALLED);
+                        num_globals += 1;
+                        strings_size += symtab_name_for_strtab(name).len() + 1;
+                    }
+                }
             }
         }
         let entry_size = C::SYMTAB_ENTRY_SIZE;
@@ -2296,7 +2313,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
         };
 
         let mut rules = Vec::with_capacity(
-            DEFAULT_SECTION_PLACEMENT_RULES.len() + LINKER_MANAGED_SECTION_RULES.len() + 1,
+            DEFAULT_SECTION_PLACEMENT_RULES.len() + LINKER_MANAGED_SECTION_RULES.len() + 3,
         );
 
         if args.gdb_index {
@@ -2309,6 +2326,13 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
                 SectionRuleOutcome::DebugIndex,
             ));
         }
+        let reloc_rule = if args.emit_relocs() {
+            SectionRuleOutcome::Custom
+        } else {
+            SectionRuleOutcome::Discard
+        };
+        rules.push(SectionRule::prefix(secnames::RELA_SECTION_NAME, reloc_rule));
+        rules.push(SectionRule::prefix(secnames::CREL_SECTION_NAME, reloc_rule));
 
         rules.extend(DEFAULT_SECTION_PLACEMENT_RULES.iter().cloned());
         rules.extend(LINKER_MANAGED_SECTION_RULES.iter().cloned());
@@ -3202,6 +3226,14 @@ impl<'data, C: ElfClass> platform::ObjectFile<'data> for File<'data, C> {
                 RelocationList::Rela(&[])
             },
         )
+    }
+
+    fn relocation_section(
+        &self,
+        index: object::SectionIndex,
+        relocations: &RelocationSections,
+    ) -> Option<object::SectionIndex> {
+        relocations.get(index)
     }
 
     fn symbol(&self, index: object::SymbolIndex) -> Result<&SymtabEntry<C>> {
@@ -6477,8 +6509,6 @@ const DEFAULT_SECTION_PLACEMENT_RULES: &[SectionRule<'static>] = &[
 /// Rules for input sections that the linker processes itself instead of copying them into an output
 /// section.
 const LINKER_MANAGED_SECTION_RULES: &[SectionRule<'static>] = &[
-    SectionRule::prefix(secnames::RELA_SECTION_NAME, SectionRuleOutcome::Discard),
-    SectionRule::prefix(secnames::CREL_SECTION_NAME, SectionRuleOutcome::Discard),
     SectionRule::exact(
         secnames::NOTE_GNU_STACK_SECTION_NAME,
         SectionRuleOutcome::NoteGnuStack,

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -2072,7 +2072,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
                     num_globals += 1;
                 }
                 strings_size += symtab_name_for_strtab(info.name).len() + 1;
-            } else if (symbol_db.args.emit_relocs())
+            } else if symbol_db.args.emit_relocs()
                 && sym.is_undefined()
                 && let Ok(name) = state.object.symbol_name(sym)
                 && !name.is_empty()

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -117,10 +117,12 @@ use linker_utils::elf::riscvattr::TAG_RISCV_STACK_ALIGN;
 use linker_utils::elf::riscvattr::TAG_RISCV_UNALIGNED_ACCESS;
 use linker_utils::elf::riscvattr::TAG_RISCV_WHOLE_FILE;
 use linker_utils::elf::secnames;
+use linker_utils::elf::secnames::CREL_SECTION_NAME;
 use linker_utils::elf::secnames::DEBUG_LOC_SECTION_NAME;
 use linker_utils::elf::secnames::DEBUG_RANGES_SECTION_NAME;
 use linker_utils::elf::secnames::DYNSYM_SECTION_NAME_STR;
 use linker_utils::elf::secnames::NOTE_GNU_BUILD_ID_SECTION_NAME_STR;
+use linker_utils::elf::secnames::RELA_SECTION_NAME;
 use linker_utils::elf::shf;
 use linker_utils::elf::sht;
 use linker_utils::loongarch64::highest_relocation_with_bias;
@@ -269,7 +271,7 @@ fn write_file_contents<'data, C: ElfClass, A: Arch<Platform = elf::Elf<C>>>(
         }
     }
 
-    let sym_index_map = if layout.args().should_output_partial_object() {
+    let sym_index_map = if layout.args().emit_relocs() {
         build_sym_index_map(layout)
     } else {
         Vec::new()
@@ -1707,7 +1709,7 @@ fn write_object<'data, C: ElfClass, A: Arch<Platform = elf::Elf<C>>>(
         }
     }
 
-    if layout.args().should_output_partial_object() {
+    if layout.args().emit_relocs() {
         write_symbols(object, &mut table_writer.debug_symbol_writer, layout)?;
 
         write_rela_sections(object, buffers, layout, sym_index_map)?;
@@ -1877,14 +1879,26 @@ fn build_sym_index_map<C: ElfClass>(layout: &ElfLayout<'_, C>) -> Vec<Option<u32
                     continue;
                 }
                 let symbol_id = object.symbol_id_range.input_to_id(sym_index);
-                if !layout.symbol_db.is_canonical(symbol_id) {
-                    continue;
-                }
-                if let Ok(name) = object.object.symbol_name(sym)
-                    && !name.is_empty()
+                let canonical = layout.symbol_db.definition(symbol_id);
+                let def_file = layout.symbol_db.file_id_for_symbol(canonical);
+                let is_dynamic = layout.per_symbol_flags.flags[canonical.as_usize()]
+                    .get()
+                    .contains(ValueFlags::DYNAMIC);
+                if (layout.symbol_db.is_canonical(symbol_id) || is_dynamic)
+                    && def_file != crate::input_data::PRELUDE_FILE_ID
                 {
-                    map[symbol_id.as_usize()] = Some(group_global_base);
-                    group_global_base += 1;
+                    if map[canonical.as_usize()].is_none()
+                        && let Ok(name) = object.object.symbol_name(sym)
+                        && !name.is_empty()
+                    {
+                        map[canonical.as_usize()] = Some(group_global_base);
+                        map[symbol_id.as_usize()] = Some(group_global_base);
+                        group_global_base += 1;
+                    } else if let Some(&idx) = map[canonical.as_usize()].as_ref() {
+                        map[symbol_id.as_usize()] = Some(idx);
+                    }
+                } else if let Some(&idx) = map[canonical.as_usize()].as_ref() {
+                    map[symbol_id.as_usize()] = Some(idx);
                 }
             }
         }
@@ -1926,7 +1940,9 @@ fn write_rela_sections<'data, C: ElfClass>(
 
     for (sec_idx, header) in object.object.enumerate_sections() {
         let section_name = object.object.section_name(sec_idx).unwrap_or_default();
-        if !section_name.starts_with(b".rela") && !section_name.starts_with(b".crel") {
+        if !section_name.starts_with(RELA_SECTION_NAME)
+            && !section_name.starts_with(CREL_SECTION_NAME)
+        {
             continue;
         }
 
@@ -1939,9 +1955,9 @@ fn write_rela_sections<'data, C: ElfClass>(
         let part_id = section_id.part_id_with_alignment::<elf::Elf<C>>(C::RELA_ENTRY_ALIGNMENT);
 
         let target_sec_idx = object::SectionIndex(header.sh_info(e) as usize);
-        let section_address = object.section_resolutions[target_sec_idx.0]
-            .address()
-            .unwrap_or(0);
+        let Some(section_address) = object.section_resolutions[target_sec_idx.0].address() else {
+            continue;
+        };
 
         let relocations = object.relocations(target_sec_idx).with_context(|| {
             format!(
@@ -1991,7 +2007,14 @@ fn write_rela_sections<'data, C: ElfClass>(
                         return None;
                     }
                     let sec_idx = object.object.symbol_section(sym_entry, s).ok()??;
-                    object.section_resolutions[sec_idx.0].address()
+                    let sec_addr = object.section_resolutions[sec_idx.0].address()?;
+                    let part_id =
+                        object.section_part_id(sec_idx, &layout.symbol_db.section_part_ids);
+                    let primary_id = layout
+                        .output_sections
+                        .primary_output_section(part_id.output_section_id::<elf::Elf<C>>());
+                    let output_sec_addr = layout.section_layouts.get(primary_id).mem_offset;
+                    Some(sec_addr.saturating_sub(output_sec_addr))
                 })
                 .map_or(addend, |offset| addend + offset as i64);
             out.set_offset(section_address + offset)?;
@@ -2028,7 +2051,7 @@ fn write_object_section<'data, C: ElfClass, A: Arch<Platform = elf::Elf<C>>>(
     trace: &TraceOutput,
 ) -> Result {
     let part_id = object.section_part_id(section_index, &layout.symbol_db.section_part_ids);
-    if layout.args().should_output_partial_object() {
+    if layout.args().emit_relocs() {
         let section_type = layout
             .output_sections
             .output_info(part_id.output_section_id::<elf::Elf<C>>())
@@ -2376,7 +2399,7 @@ fn write_symbols<'data, C: ElfClass>(
         }
     }
 
-    if layout.args().should_output_partial_object() {
+    if layout.args().emit_relocs() {
         for (sym_index, sym) in object.object.symbols.enumerate() {
             if !platform::Symbol::is_undefined(sym) {
                 continue;
@@ -2388,20 +2411,20 @@ fn write_symbols<'data, C: ElfClass>(
                 continue;
             }
             let symbol_id = object.symbol_id_range.input_to_id(sym_index);
-            if !layout.symbol_db.is_canonical(symbol_id) {
-                continue;
+            let flags = layout.per_symbol_flags.flags[symbol_id.as_usize()].get();
+            if flags.contains(ValueFlags::SYMTAB_INSTALLED) {
+                let name = RawSymbolName::parse(name).name;
+                let entry = symbol_writer
+                    .undefined_symbol(false, name)
+                    .with_context(|| {
+                        format!(
+                            "Failed to write undefined symbol `{}`",
+                            String::from_utf8_lossy(name)
+                        )
+                    })?;
+                entry.set_info(sym.st_info());
+                entry.set_other(sym.st_other());
             }
-            let name = RawSymbolName::parse(name).name;
-            let entry = symbol_writer
-                .undefined_symbol(false, name)
-                .with_context(|| {
-                    format!(
-                        "Failed to write undefined symbol `{}` for partial link",
-                        String::from_utf8_lossy(name)
-                    )
-                })?;
-            entry.set_info(sym.st_info());
-            entry.set_other(sym.st_other());
         }
     }
 
@@ -3997,7 +4020,7 @@ fn write_symbol_table_entries<C: ElfClass>(
     // Define symbol 0. This needs to be a null placeholder.
     symbol_writer.undefined_symbol(true, &[])?;
 
-    if layout.args().should_output_partial_object() {
+    if layout.args().emit_relocs() {
         write_section_symbols(symbol_writer, layout)?;
     }
 
@@ -5663,8 +5686,8 @@ fn write_section_headers<C: ElfClass>(out: &mut [u8], layout: &ElfLayout<C>) -> 
 
         let mut info_value = *info_values.get(section_id);
 
-        if layout.args().should_output_partial_object()
-            && section_type == sht::RELA
+        if (layout.args().emit_relocs())
+            && (section_type == sht::RELA || section_type == sht::REL)
             && section_id.is_custom::<elf::Elf<C>>()
         {
             if let Some(symtab_idx) =
@@ -5672,9 +5695,13 @@ fn write_section_headers<C: ElfClass>(out: &mut [u8], layout: &ElfLayout<C>) -> 
             {
                 link = symtab_idx;
             }
-            if let Some(target_name) = name.bytes().strip_prefix(b".rela")
-                && let Some(target_id) = output_sections
-                    .custom_identity_to_id(SectionIdentity::new(SectionName(target_name), ()))
+            let name_bytes = name.bytes();
+            let target_name = name_bytes
+                .strip_prefix(RELA_SECTION_NAME)
+                .or_else(|| name_bytes.strip_prefix(CREL_SECTION_NAME));
+            if let Some(target_name) = target_name
+                && let Some(target_id) =
+                    output_sections.section_id_by_name(SectionName(target_name))
                 && let Some(target_idx) = output_sections.output_index_of_section(target_id)
             {
                 info_value = target_idx;

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3278,7 +3278,7 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
 
         let entry_size = size_of::<P::SymtabEntry>() as u64;
 
-        if resources.symbol_db.args.should_output_partial_object() {
+        if resources.symbol_db.args.emit_relocs() {
             let mut num_section_syms = 0;
             for (id, _) in output_sections.ids_with_info() {
                 if output_sections.will_emit_section_symbol_for_partial_objects(id) {
@@ -4193,6 +4193,7 @@ impl<'data, P: Platform<GcUnit = SectionGcUnit>> ObjectLayoutState<'data, P> {
                 queue,
                 scope,
             )?;
+            self.load_relocation_section(frame_data_section_index, common, resources)?;
         }
 
         if let Some(section_index) = note_gnu_property_section {
@@ -4309,6 +4310,8 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
             SectionSlot::Loaded(section)
         };
 
+        self.load_relocation_section(section_index, common, resources)?;
+
         common.store_section_attributes(part_id, header);
 
         if let Some(config) = A::thunk_config()
@@ -4354,6 +4357,7 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
         );
         common.store_section_attributes(part_id, header);
         self.sections[section_index.0] = SectionSlot::LoadedDebugInfo(section);
+        self.load_relocation_section(section_index, common, resources)?;
 
         Ok(())
     }
@@ -4694,6 +4698,34 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
 
     pub(crate) fn relocations(&self, index: SectionIndex) -> Result<P::RelocationList<'data>> {
         self.object.relocations(index, &self.relocations)
+    }
+
+    fn load_relocation_section(
+        &mut self,
+        section_index: SectionIndex,
+        common: &mut CommonGroupState<'data, P>,
+        resources: &GraphResources<'data, '_, P>,
+    ) -> Result {
+        if resources.symbol_db.args.emit_relocs()
+            && let Some(rel_sec_idx) = self
+                .object
+                .relocation_section(section_index, &self.relocations)
+            && matches!(
+                self.sections.get(rel_sec_idx.0),
+                Some(SectionSlot::Unloaded(..))
+            )
+        {
+            let part_id = self.section_part_id(rel_sec_idx, &resources.symbol_db.section_part_ids);
+            let header = self.object.section(rel_sec_idx)?;
+            let section = Section::create(header, self, part_id)?;
+            common.allocate(
+                part_id,
+                section.capacity(part_id, resources.output_sections),
+            );
+            common.store_section_attributes(part_id, header);
+            self.sections[rel_sec_idx.0] = SectionSlot::Loaded(section);
+        }
+        Ok(())
     }
 
     pub(crate) fn section_part_id(

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -1177,6 +1177,14 @@ pub(crate) trait ObjectFile<'data>: Sized + Send + Sync + std::fmt::Debug + 'dat
         relocations: &<Self::Platform as Platform>::RelocationSections,
     ) -> Result<<Self::Platform as Platform>::RelocationList<'data>>;
 
+    fn relocation_section(
+        &self,
+        _index: object::SectionIndex,
+        _relocations: &<Self::Platform as Platform>::RelocationSections,
+    ) -> Option<object::SectionIndex> {
+        None
+    }
+
     fn parse_relocations(&self) -> Result<<Self::Platform as Platform>::RelocationSections>;
 
     /// Get the version of a symbol. Only intended for diagnostic purposes since it's potentially

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -1653,4 +1653,8 @@ pub(crate) trait Args: std::fmt::Debug + Send + Sync + 'static {
     fn output_format_endian(&self) -> Option<Endianness> {
         None
     }
+
+    fn emit_relocs(&self) -> bool {
+        false
+    }
 }

--- a/libwild/src/value_flags.rs
+++ b/libwild/src/value_flags.rs
@@ -106,6 +106,9 @@ bitflags! {
 
         /// Whether the symbol has a reference from non-IR code.
         const HAS_NON_IR_REF = 1 << 16;
+
+        /// Set when space for the symbol has been allocated in the symbol table.
+        const SYMTAB_INSTALLED = 1 << 17;
     }
 }
 

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -10,9 +10,6 @@ tests = [
   "depaudit.sh",
   "depaudit2.sh",
   "dynamic-list-data.sh",
-  "emit-relocs-cpp.sh",
-  "emit-relocs-dead-sections.sh",
-  "emit-relocs.sh",
   "execute-only.sh",
   "fatal-warnings.sh",                     # `-warn-common` and `-fatal-warnings`
   "filter.sh",

--- a/wild/tests/sources/elf/emit-relocs/emit-relocs.c
+++ b/wild/tests/sources/elf/emit-relocs/emit-relocs.c
@@ -1,0 +1,14 @@
+//#Object:runtime.c
+//#LinkArgs:--emit-relocs
+//#ExpectSection:.rela.text
+//#ExpectSym:_start section=".text"
+//#ExpectSym:exit_syscall section=".text"
+//#DiffIgnore:rel.R_X86_64_PLT32.R_X86_64_PLT32
+//#DiffIgnore:rel.R_AARCH64_CALL26.R_AARCH64_CALL26
+
+#include "../common/runtime.h"
+
+void _start(void) {
+  runtime_init();
+  exit_syscall(42);
+}


### PR DESCRIPTION
Adds support for `--emit-relocs`. This flag is used to retain all relocations from input files, similar to a partial object.