### PR TITLE
fix: don't panic on unsupported R_AARCH64_FUNCINIT64 relocation

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -6080,6 +6080,18 @@ fn classify_symbol_relocation<
         next_modifier = relaxation.next_modifier();
         relaxation.rel_info()
     } else {
+        // R_AARCH64_FUNCINIT64 has specific restrictions.
+        if r_type == object::elf::RelocationType(0x13d) {
+            if flags.is_ifunc() {
+                let sym_name = symbol_db.symbol_name_for_display(local_symbol_id);
+                bail!(
+                    "relocation R_AARCH64_FUNCINIT64 cannot be used against ifunc symbol '{sym_name}'"
+                );
+            } else if !flags.is_dynamic() && !flags.is_interposable() {
+                bail!("relocation R_AARCH64_FUNCINIT64 cannot be used against local symbol");
+            }
+        }
+
         A::relocation_from_raw(r_type)?
     };
 

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -6080,8 +6080,9 @@ fn classify_symbol_relocation<
         next_modifier = relaxation.next_modifier();
         relaxation.rel_info()
     } else {
+        let rel_info = A::relocation_from_raw(r_type)?;
         // R_AARCH64_FUNCINIT64 has specific restrictions.
-        if r_type == object::elf::RelocationType(0x13d) {
+        if rel_info.kind == RelocationKind::FuncInit {
             if flags.is_ifunc() {
                 let sym_name = symbol_db.symbol_name_for_display(local_symbol_id);
                 bail!(
@@ -6091,8 +6092,7 @@ fn classify_symbol_relocation<
                 bail!("relocation R_AARCH64_FUNCINIT64 cannot be used against local symbol");
             }
         }
-
-        A::relocation_from_raw(r_type)?
+        rel_info
     };
 
     Ok(ClassifiedSymbolRelocation {

--- a/libwild/src/elf_aarch64.rs
+++ b/libwild/src/elf_aarch64.rs
@@ -176,7 +176,7 @@ impl crate::platform::Arch for ElfAArch64 {
     where
         Self: std::marker::Sized,
     {
-        let mut relocation = ElfAArch64::relocation_from_raw(relocation_kind).unwrap();
+        let mut relocation = ElfAArch64::relocation_from_raw(relocation_kind).ok()?;
         let interposable = flags.is_interposable();
 
         // IFuncs cannot be referenced directly, they always need to go via the GOT.

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -3035,7 +3035,7 @@ fn apply_relocation<
     let mut addend = rel.addend();
 
     match A::relocation_from_raw(r_type)?.kind {
-        RelocationKind::None => return Ok(RelocationModifier::Normal),
+        RelocationKind::None | RelocationKind::FuncInit => return Ok(RelocationModifier::Normal),
         RelocationKind::Alignment => {
             let addend = addend as u64;
             let removed_bytes =
@@ -3468,7 +3468,7 @@ fn apply_relocation<
             .bitand(mask.got_entry)
             .wrapping_sub(layout.got_base().bitand(mask.got)),
         RelocationKind::None | RelocationKind::TlsDescCall => 0,
-        RelocationKind::Alignment => unreachable!(),
+        RelocationKind::Alignment | RelocationKind::FuncInit => unreachable!(),
     };
 
     let offset_in_section = offset_in_section as usize;

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3099,9 +3099,10 @@ pub(crate) fn resolution_flags(rel_kind: RelocationKind) -> ValueFlags {
         | RelocationKind::TpOff
         | RelocationKind::SymRelGotBase
         | RelocationKind::PairSubtractionULEB128(..) => ValueFlags::DIRECT,
-        RelocationKind::None | RelocationKind::AbsoluteLowPart | RelocationKind::Alignment => {
-            ValueFlags::empty()
-        }
+        RelocationKind::None
+        | RelocationKind::AbsoluteLowPart
+        | RelocationKind::Alignment
+        | RelocationKind::FuncInit => ValueFlags::empty(),
     }
 }
 

--- a/linker-diff/src/asm_diff.rs
+++ b/linker-diff/src/asm_diff.rs
@@ -2558,7 +2558,8 @@ impl<'data> RelaxationTester<'data> {
             | RelocationKind::TlsDescCall
             | RelocationKind::PairSubtractionULEB128(..)
             | RelocationKind::None
-            | RelocationKind::Alignment => 0,
+            | RelocationKind::Alignment
+            | RelocationKind::FuncInit => 0,
         };
 
         relative_to &= A::get_relocation_base_mask(&relocation_info);
@@ -2780,7 +2781,8 @@ fn value_kind_for_relocation<A: Arch>(
         RelocationKind::TlsDescCall
         | RelocationKind::None
         | RelocationKind::PairSubtractionULEB128(..)
-        | RelocationKind::Alignment => {
+        | RelocationKind::Alignment
+        | RelocationKind::FuncInit => {
             return None;
         }
     };
@@ -3755,7 +3757,8 @@ impl<'data> GotIndex<'data> {
                 | RelocationKind::GotRelativeLoongArch64
                 | RelocationKind::None
                 | RelocationKind::PairSubtractionULEB128(..)
-                | RelocationKind::Alignment => Ok(Referent::Absolute(raw_value)),
+                | RelocationKind::Alignment
+                | RelocationKind::FuncInit => Ok(Referent::Absolute(raw_value)),
                 RelocationKind::TlsGd
                 | RelocationKind::TlsGdGot
                 | RelocationKind::TlsGdGotBase

--- a/linker-utils/src/aarch64.rs
+++ b/linker-utils/src/aarch64.rs
@@ -977,6 +977,14 @@ pub const fn relocation_type_from_raw(
             1,
         ),
 
+        object::elf::RelocationType(0x13d) => (
+            RelocationKind::FuncInit,
+            RelocationSize::ByteSize(8),
+            None,
+            AllowedRange::no_check(),
+            1,
+        ),
+
         _ => return None,
     };
 

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -546,6 +546,10 @@ pub enum RelocationKind {
 
     /// The address must fulfill the alignment requirement.
     Alignment,
+
+    /// Function pointer initialization (R_AARCH64_FUNCINIT64).
+    /// Only valid for non-local, non-ifunc symbols.
+    FuncInit,
 }
 
 impl RelocationKind {

--- a/wild/tests/external_tests/lld_skip_tests.toml
+++ b/wild/tests/external_tests/lld_skip_tests.toml
@@ -71,6 +71,8 @@ tests = [
   "x86-64-tls-ie-err.s",
   "x86-64-split-stack-prologue-adjust-fail.s",
   "x86-64-gotpc-no-relax-err.s",
+  # Wild stops at first error; test requires two errors reported simultaneously
+  "aarch64-funcinit64-invalid.s",
 ]
 
 [skipped_groups.relocation_bugs]
@@ -158,7 +160,6 @@ tests = [
   "aarch64-fpic-prel16.s",
   "aarch64-fpic-prel32.s",
   "aarch64-fpic-prel64.s",
-  "aarch64-funcinit64-invalid.s",
   "aarch64-funcinit64.s",
   "aarch64-gnu-ifunc2.s",
   "aarch64-gnu-ifunc-address.s",


### PR DESCRIPTION
new_relaxation() called unwrap() on the result of relocation_from_raw(), causing a panic when encountering unknown relocation types such as R_AARCH64_FUNCINIT64 (0x13d). Changed to ok()? so unknown relocations return None (no relaxation available) instead of panicking.

