### PR TITLE
feat: fetch symbols defined in a linker script in a location counter

### DIFF
--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -9,19 +9,20 @@ use crate::error::Result;
 use crate::grouping::Group;
 use crate::input_data::InputRef;
 use crate::layout;
-use crate::layout::EarlyObjectSymbolValue;
 use crate::layout::FileLayoutState;
 use crate::layout::GroupState;
 use crate::layout::InputSectionPositions;
 use crate::layout::MemoryRegion;
 use crate::layout::OutputRecordLayout;
 use crate::linker_script::Expression;
+use crate::output_section_id::OutputSectionId;
 use crate::output_section_id::OutputSections;
 use crate::output_section_id::SectionName;
 use crate::output_section_map::OutputSectionMap;
 use crate::output_section_part_map::OutputSectionPartMap;
 use crate::parsing::SymbolLoc;
 use crate::parsing::SymbolPlacement;
+use crate::part_id::PartId;
 use crate::platform::Args;
 use crate::platform::Platform;
 use crate::symbol::UnversionedSymbolName;
@@ -43,9 +44,85 @@ pub(crate) struct ResolvedLocationCounter {
     pub(crate) section_offset: Option<u64>,
 }
 
-pub(crate) enum ResolvedSymbolValue {
+pub(crate) enum SymbolValue {
     Absolute(u64),
-    SectionRelative(u64),
+    PartRelative {
+        part_id: PartId,
+        offset: u64,
+    },
+    SectionRelative {
+        section_id: OutputSectionId,
+        address: u64,
+    },
+}
+
+fn evaluate_symbol_value<P: Platform>(
+    symbol_value: &SymbolValue,
+    loc: &SymbolLoc,
+    output_sections: &OutputSections<'_, P>,
+    section_layouts: &OutputSectionMap<OutputRecordLayout>,
+    laid_out_mem_offsets: &OutputSectionPartMap<Option<u64>>,
+    value_kind: &mut ExpressionValueKind,
+    name: &[u8],
+) -> Result<u64> {
+    let current_section = loc
+        .relative_section_id()
+        .map(|id| output_sections.primary_output_section(id));
+    match symbol_value {
+        SymbolValue::Absolute(value) => {
+            value_kind.contains_absolute = true;
+            Ok(*value)
+        }
+        SymbolValue::SectionRelative {
+            section_id,
+            address,
+        } => {
+            let primary_section = output_sections.primary_output_section(*section_id);
+            if current_section == Some(primary_section) {
+                value_kind.contains_section_relative = true;
+                let section_base = section_layouts.get(primary_section).mem_offset;
+                let offset = address.checked_sub(section_base).with_context(|| {
+                    format!(
+                        "address of symbol '{}' is before its output section",
+                        String::from_utf8_lossy(name)
+                    )
+                })?;
+                Ok(offset)
+            } else if let Some(section) = current_section {
+                value_kind.contains_absolute = true;
+                let section_base = section_layouts.get(section).mem_offset;
+                Ok(address + section_base)
+            } else {
+                value_kind.contains_absolute = true;
+                Ok(*address)
+            }
+        }
+        SymbolValue::PartRelative { part_id, offset } => {
+            let Some(part_address) = laid_out_mem_offsets.get(*part_id) else {
+                bail!(
+                    "cannot resolve address of symbol '{}' because its output section part has not been laid out yet",
+                    String::from_utf8_lossy(name)
+                );
+            };
+            let address = part_address + offset;
+            let symbol_section =
+                output_sections.primary_output_section(part_id.output_section_id::<P>());
+            if current_section == Some(symbol_section) {
+                value_kind.contains_section_relative = true;
+                let section_base = section_layouts.get(symbol_section).mem_offset;
+                let offset = address.checked_sub(section_base).with_context(|| {
+                    format!(
+                        "address of symbol '{}' is before its output section",
+                        String::from_utf8_lossy(name)
+                    )
+                })?;
+                Ok(offset)
+            } else {
+                value_kind.contains_absolute = true;
+                Ok(address)
+            }
+        }
+    }
 }
 
 #[derive(Default)]
@@ -106,7 +183,8 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
     symbol_db: &SymbolDb<'data, P>,
     sizeof_headers: u64,
     resolved_location_counters: &[ResolvedLocationCounter],
-    symbol_resolution_callback: &mut dyn FnMut(&[u8]) -> Result<ResolvedSymbolValue>,
+    laid_out_mem_offsets: &OutputSectionPartMap<Option<u64>>,
+    symbol_resolution_callback: &mut dyn FnMut(&[u8]) -> Result<SymbolValue>,
 ) -> Result<u64> {
     let mut value_kind = ExpressionValueKind::default();
     let value = evaluate_expression_value(
@@ -120,6 +198,7 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
         sizeof_headers,
         resolved_location_counters,
         &mut value_kind,
+        laid_out_mem_offsets,
         symbol_resolution_callback,
     )?;
 
@@ -149,7 +228,8 @@ fn evaluate_expression_value<'data, P: Platform>(
     sizeof_headers: u64,
     resolved_location_counters: &[ResolvedLocationCounter],
     value_kind: &mut ExpressionValueKind,
-    symbol_resolution_callback: &mut dyn FnMut(&[u8]) -> Result<ResolvedSymbolValue>,
+    laid_out_mem_offsets: &OutputSectionPartMap<Option<u64>>,
+    symbol_resolution_callback: &mut dyn FnMut(&[u8]) -> Result<SymbolValue>,
 ) -> Result<u64> {
     macro_rules! eval {
         ($e:expr) => {
@@ -164,6 +244,7 @@ fn evaluate_expression_value<'data, P: Platform>(
                 sizeof_headers,
                 resolved_location_counters,
                 value_kind,
+                laid_out_mem_offsets,
                 symbol_resolution_callback,
             )
         };
@@ -181,6 +262,7 @@ fn evaluate_expression_value<'data, P: Platform>(
                 symbol_db,
                 sizeof_headers,
                 resolved_location_counters,
+                laid_out_mem_offsets,
                 symbol_resolution_callback,
             )
         };
@@ -203,16 +285,18 @@ fn evaluate_expression_value<'data, P: Platform>(
             )
         }
 
-        Expression::Symbol(name) => match symbol_resolution_callback(name)? {
-            ResolvedSymbolValue::Absolute(value) => {
-                value_kind.contains_absolute = true;
-                Ok(value)
-            }
-            ResolvedSymbolValue::SectionRelative(value) => {
-                value_kind.contains_section_relative = true;
-                Ok(value)
-            }
-        },
+        Expression::Symbol(name) => {
+            let value = symbol_resolution_callback(name)?;
+            evaluate_symbol_value(
+                &value,
+                expr_loc,
+                output_sections,
+                section_layouts,
+                laid_out_mem_offsets,
+                value_kind,
+                name,
+            )
+        }
 
         Expression::Add(l, r) => Ok(eval!(l)?.wrapping_add(eval!(r)?)),
         Expression::Subtract(l, r) => Ok(eval!(l)?.wrapping_sub(eval!(r)?)),
@@ -422,6 +506,7 @@ pub(crate) fn evaluate_early_expression<'data, P: Platform>(
         symbol_db,
         sizeof_headers,
         resolved_lc,
+        laid_out_mem_offsets,
         &mut |name| {
             let Some(symbol_id) =
                 symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(name))
@@ -437,7 +522,7 @@ pub(crate) fn evaluate_early_expression<'data, P: Platform>(
             let file = group_states
                 .get(file_id.group())
                 .and_then(|group| group.files.get(file_id.file()));
-            let symbol_value = match file {
+            match file {
                 Some(FileLayoutState::Object(obj)) => layout::resolve_early_object_symbol(
                     canonical_id,
                     obj,
@@ -461,7 +546,7 @@ pub(crate) fn evaluate_early_expression<'data, P: Platform>(
                     match &def_info.placement {
                         SymbolPlacement::Redirect(redirect) => {
                             if !visited_nodes.insert(canonical_id) {
-                                return Ok(ResolvedSymbolValue::Absolute(0));
+                                return Ok(SymbolValue::Absolute(0));
                             }
                             let value = evaluate_early_expression(
                                 &redirect.expression,
@@ -485,12 +570,12 @@ pub(crate) fn evaluate_early_expression<'data, P: Platform>(
                                 .relative_section_id()
                                 .map(|id| output_sections.primary_output_section(id));
                             if let Some(symbol_section) = symbol_section {
-                                Ok(EarlyObjectSymbolValue::SectionRelative {
+                                Ok(SymbolValue::SectionRelative {
                                     section_id: symbol_section,
                                     address: value,
                                 })
                             } else {
-                                Ok(EarlyObjectSymbolValue::Absolute(value))
+                                Ok(SymbolValue::Absolute(value))
                             }
                         }
                         _ => {
@@ -504,63 +589,7 @@ pub(crate) fn evaluate_early_expression<'data, P: Platform>(
                         symbol_db.symbol_name_for_display(canonical_id)
                     );
                 }
-            };
-
-            let symbol_value = match symbol_value? {
-                EarlyObjectSymbolValue::Absolute(value) => ResolvedSymbolValue::Absolute(value),
-                EarlyObjectSymbolValue::SectionRelative {
-                    section_id,
-                    address,
-                } => {
-                    let current_section = loc
-                        .relative_section_id()
-                        .map(|id| output_sections.primary_output_section(id));
-                    if current_section == Some(section_id) {
-                        let section_base = section_layouts.get(section_id).mem_offset;
-                        ResolvedSymbolValue::SectionRelative(
-                            address.checked_sub(section_base).with_context(|| {
-                                format!(
-                                    "address of symbol '{}' is before its output section",
-                                    String::from_utf8_lossy(name)
-                                )
-                            })?,
-                        )
-                    } else if let Some(section) = current_section {
-                        let section_base = section_layouts.get(section).mem_offset;
-                        ResolvedSymbolValue::Absolute(address + section_base)
-                    } else {
-                        ResolvedSymbolValue::Absolute(address)
-                    }
-                }
-                EarlyObjectSymbolValue::PartRelative { part_id, offset } => {
-                    let Some(part_address) = laid_out_mem_offsets.get(part_id) else {
-                        bail!(
-                            "cannot resolve address of symbol '{}' because its output section part has not been laid out yet",
-                            String::from_utf8_lossy(name)
-                        );
-                    };
-                    let address = part_address + offset;
-                    let symbol_section =
-                        output_sections.primary_output_section(part_id.output_section_id::<P>());
-                    let current_section = loc
-                        .relative_section_id()
-                        .map(|id| output_sections.primary_output_section(id));
-                    if current_section == Some(symbol_section) {
-                        let section_base = section_layouts.get(symbol_section).mem_offset;
-                        ResolvedSymbolValue::SectionRelative(
-                            address.checked_sub(section_base).with_context(|| {
-                                format!(
-                                    "address of symbol '{}' is before its output section",
-                                    String::from_utf8_lossy(name)
-                                )
-                            })?,
-                        )
-                    } else {
-                        ResolvedSymbolValue::Absolute(address)
-                    }
-                }
-            };
-            Ok(symbol_value)
+            }
         },
     )
 }
@@ -672,7 +701,8 @@ mod tests {
                 symbol_db,
                 0,
                 &[],
-                &mut |_| Ok(ResolvedSymbolValue::Absolute(1)),
+                &OutputSectionPartMap::default(),
+                &mut |_| Ok(SymbolValue::Absolute(1)),
             )
         })
     }
@@ -1042,6 +1072,7 @@ mod tests {
                 symbol_db,
                 sizeof_headers,
                 resolved_location_counters,
+                &OutputSectionPartMap::default(),
                 &mut |_| unreachable!(),
             )?;
         }
@@ -1128,7 +1159,8 @@ mod tests {
                     symbol_db,
                     0,
                     &[],
-                    &mut |_| Ok(ResolvedSymbolValue::Absolute(0)),
+                    &OutputSectionPartMap::default(),
+                    &mut |_| Ok(SymbolValue::Absolute(0)),
                 )
             };
             assert_eq!(eval(&Expression::Origin(b"rom")).unwrap(), 0x08000000);

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -461,10 +461,7 @@ pub(crate) fn evaluate_early_expression<'data, P: Platform>(
                     match &def_info.placement {
                         SymbolPlacement::Redirect(redirect) => {
                             if !visited_nodes.insert(canonical_id) {
-                                bail!(
-                                    "symbol cycle detected for '{}'",
-                                    symbol_db.symbol_name_for_display(canonical_id)
-                                );
+                                return Ok(ResolvedSymbolValue::Absolute(0));
                             }
                             let value = evaluate_early_expression(
                                 &redirect.expression,

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -4,20 +4,31 @@
 /// features. Symbol resolution and full location counter semantics (e.g. ALIGN with a non-zero
 /// current address) will be implemented in future work.
 use crate::bail;
+use crate::error::Context;
 use crate::error::Result;
+use crate::grouping::Group;
 use crate::input_data::InputRef;
 use crate::layout;
+use crate::layout::EarlyObjectSymbolValue;
+use crate::layout::FileLayoutState;
+use crate::layout::GroupState;
+use crate::layout::InputSectionPositions;
+use crate::layout::MemoryRegion;
 use crate::layout::OutputRecordLayout;
 use crate::linker_script::Expression;
 use crate::output_section_id::OutputSections;
 use crate::output_section_id::SectionName;
 use crate::output_section_map::OutputSectionMap;
+use crate::output_section_part_map::OutputSectionPartMap;
 use crate::parsing::SymbolLoc;
+use crate::parsing::SymbolPlacement;
 use crate::platform::Args;
 use crate::platform::Platform;
 use crate::symbol::UnversionedSymbolName;
 use crate::symbol_db::SymbolDb;
+use crate::symbol_db::SymbolId;
 use hashbrown::HashMap;
+use std::cell::OnceCell;
 
 /// Compute 1-based line number by counting newlines before `remainder` in `file_bytes`.
 fn line_number(file_bytes: &[u8], remainder: &[u8]) -> u32 {
@@ -95,7 +106,7 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
     symbol_db: &SymbolDb<'data, P>,
     sizeof_headers: u64,
     resolved_location_counters: &[ResolvedLocationCounter],
-    symbol_resolution_callback: &dyn Fn(&[u8]) -> Result<ResolvedSymbolValue>,
+    symbol_resolution_callback: &mut dyn FnMut(&[u8]) -> Result<ResolvedSymbolValue>,
 ) -> Result<u64> {
     let mut value_kind = ExpressionValueKind::default();
     let value = evaluate_expression_value(
@@ -113,18 +124,12 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
     )?;
 
     let offset = if value_kind.needs_section_base() {
-        match expr_loc {
-            SymbolLoc::SectionStartRelative(id) | SymbolLoc::SectionEndRelative(id) => {
-                let primary_id = output_sections.primary_output_section(*id);
-                let section_layout = section_layouts.get(primary_id);
-                section_layout.mem_offset
-            }
-            SymbolLoc::LocationCounter(_, Some(id)) => {
-                let primary_id = output_sections.primary_output_section(*id);
-                let section_layout = section_layouts.get(primary_id);
-                section_layout.mem_offset
-            }
-            _ => 0,
+        if let Some(id) = expr_loc.relative_section_id() {
+            let primary_id = output_sections.primary_output_section(id);
+            let section_layout = section_layouts.get(primary_id);
+            section_layout.mem_offset
+        } else {
+            0
         }
     } else {
         0
@@ -144,7 +149,7 @@ fn evaluate_expression_value<'data, P: Platform>(
     sizeof_headers: u64,
     resolved_location_counters: &[ResolvedLocationCounter],
     value_kind: &mut ExpressionValueKind,
-    symbol_resolution_callback: &dyn Fn(&[u8]) -> Result<ResolvedSymbolValue>,
+    symbol_resolution_callback: &mut dyn FnMut(&[u8]) -> Result<ResolvedSymbolValue>,
 ) -> Result<u64> {
     macro_rules! eval {
         ($e:expr) => {
@@ -184,12 +189,19 @@ fn evaluate_expression_value<'data, P: Platform>(
     match expr {
         Expression::Number(n) => Ok(*n),
 
-        Expression::LocationCounter => evaluate_location(
-            expr_loc,
-            section_layouts,
-            output_sections,
-            resolved_location_counters,
-        ),
+        Expression::LocationCounter => {
+            if expr_loc.relative_section_id().is_some() {
+                value_kind.contains_section_relative = true;
+            } else {
+                value_kind.contains_absolute = true;
+            }
+            evaluate_location(
+                expr_loc,
+                section_layouts,
+                output_sections,
+                resolved_location_counters,
+            )
+        }
 
         Expression::Symbol(name) => match symbol_resolution_callback(name)? {
             ResolvedSymbolValue::Absolute(value) => {
@@ -385,6 +397,177 @@ pub(crate) fn evaluate_const<'data>(expr: &Expression<'data>) -> Result<u64> {
     }
 }
 
+pub(crate) fn evaluate_early_expression<'data, P: Platform>(
+    expr: &Expression<'data>,
+    loc: &SymbolLoc,
+    memory_regions: &HashMap<&[u8], MemoryRegion>,
+    section_layouts: &OutputSectionMap<OutputRecordLayout>,
+    resolved_lc: &[ResolvedLocationCounter],
+    laid_out_mem_offsets: &OutputSectionPartMap<Option<u64>>,
+    group_states: &[GroupState<'data, P>],
+    sizes: &OutputSectionPartMap<u64>,
+    output_sections: &OutputSections<'data, P>,
+    symbol_db: &SymbolDb<'data, P>,
+    sizeof_headers: u64,
+    section_positions: &OnceCell<InputSectionPositions>,
+    visited_nodes: &mut hashbrown::HashSet<SymbolId>,
+) -> Result<u64> {
+    crate::expression_eval::evaluate_expression(
+        expr,
+        loc,
+        None,
+        section_layouts,
+        output_sections,
+        memory_regions,
+        symbol_db,
+        sizeof_headers,
+        resolved_lc,
+        &mut |name| {
+            let Some(symbol_id) =
+                symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(name))
+            else {
+                bail!(
+                    "undefined symbol '{}' in linker script expression",
+                    String::from_utf8_lossy(name)
+                );
+            };
+
+            let canonical_id = symbol_db.definition(symbol_id);
+            let file_id = symbol_db.file_id_for_symbol(canonical_id);
+            let file = group_states
+                .get(file_id.group())
+                .and_then(|group| group.files.get(file_id.file()));
+            let symbol_value = match file {
+                Some(FileLayoutState::Object(obj)) => layout::resolve_early_object_symbol(
+                    canonical_id,
+                    obj,
+                    section_positions.get_or_init(|| {
+                        layout::compute_input_section_positions(
+                            group_states,
+                            sizes.new_empty_like(),
+                            symbol_db,
+                            output_sections,
+                        )
+                    }),
+                    symbol_db,
+                ),
+                Some(FileLayoutState::LinkerScript(ls))
+                    if let Group::LinkerScripts(scripts) = &symbol_db.groups[file_id.group()] =>
+                {
+                    let script = &scripts[file_id.file()];
+                    let symbol_offset = ls.symbol_id_range.id_to_offset(canonical_id);
+
+                    let def_info = &script.parsed.symbol_defs[symbol_offset];
+                    match &def_info.placement {
+                        SymbolPlacement::Redirect(redirect) => {
+                            if !visited_nodes.insert(canonical_id) {
+                                bail!(
+                                    "symbol cycle detected for '{}'",
+                                    symbol_db.symbol_name_for_display(canonical_id)
+                                );
+                            }
+                            let value = evaluate_early_expression(
+                                &redirect.expression,
+                                &redirect.loc,
+                                memory_regions,
+                                section_layouts,
+                                resolved_lc,
+                                laid_out_mem_offsets,
+                                group_states,
+                                sizes,
+                                output_sections,
+                                symbol_db,
+                                sizeof_headers,
+                                section_positions,
+                                visited_nodes,
+                            );
+                            visited_nodes.remove(&canonical_id);
+                            let value = value?;
+                            let symbol_section = redirect
+                                .loc
+                                .relative_section_id()
+                                .map(|id| output_sections.primary_output_section(id));
+                            if let Some(symbol_section) = symbol_section {
+                                Ok(EarlyObjectSymbolValue::SectionRelative {
+                                    section_id: symbol_section,
+                                    address: value,
+                                })
+                            } else {
+                                Ok(EarlyObjectSymbolValue::Absolute(value))
+                            }
+                        }
+                        _ => {
+                            bail!("Unsupported symbol type");
+                        }
+                    }
+                }
+                _ => {
+                    bail!(
+                        "symbol '{}' is not defined by an input object",
+                        symbol_db.symbol_name_for_display(canonical_id)
+                    );
+                }
+            };
+
+            let symbol_value = match symbol_value? {
+                EarlyObjectSymbolValue::Absolute(value) => ResolvedSymbolValue::Absolute(value),
+                EarlyObjectSymbolValue::SectionRelative {
+                    section_id,
+                    address,
+                } => {
+                    let current_section = loc
+                        .relative_section_id()
+                        .map(|id| output_sections.primary_output_section(id));
+                    if current_section == Some(section_id) {
+                        let section_base = section_layouts.get(section_id).mem_offset;
+                        ResolvedSymbolValue::SectionRelative(
+                            address.checked_sub(section_base).with_context(|| {
+                                format!(
+                                    "address of symbol '{}' is before its output section",
+                                    String::from_utf8_lossy(name)
+                                )
+                            })?,
+                        )
+                    } else if let Some(section) = current_section {
+                        let section_base = section_layouts.get(section).mem_offset;
+                        ResolvedSymbolValue::Absolute(address + section_base)
+                    } else {
+                        ResolvedSymbolValue::Absolute(address)
+                    }
+                }
+                EarlyObjectSymbolValue::PartRelative { part_id, offset } => {
+                    let Some(part_address) = laid_out_mem_offsets.get(part_id) else {
+                        bail!(
+                            "cannot resolve address of symbol '{}' because its output section part has not been laid out yet",
+                            String::from_utf8_lossy(name)
+                        );
+                    };
+                    let address = part_address + offset;
+                    let symbol_section =
+                        output_sections.primary_output_section(part_id.output_section_id::<P>());
+                    let current_section = loc
+                        .relative_section_id()
+                        .map(|id| output_sections.primary_output_section(id));
+                    if current_section == Some(symbol_section) {
+                        let section_base = section_layouts.get(symbol_section).mem_offset;
+                        ResolvedSymbolValue::SectionRelative(
+                            address.checked_sub(section_base).with_context(|| {
+                                format!(
+                                    "address of symbol '{}' is before its output section",
+                                    String::from_utf8_lossy(name)
+                                )
+                            })?,
+                        )
+                    } else {
+                        ResolvedSymbolValue::Absolute(address)
+                    }
+                }
+            };
+            Ok(symbol_value)
+        },
+    )
+}
+
 fn section_size<'data, P: Platform>(
     name: &[u8],
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
@@ -492,7 +675,7 @@ mod tests {
                 symbol_db,
                 0,
                 &[],
-                &|_| Ok(ResolvedSymbolValue::Absolute(1)),
+                &mut |_| Ok(ResolvedSymbolValue::Absolute(1)),
             )
         })
     }
@@ -862,7 +1045,7 @@ mod tests {
                 symbol_db,
                 sizeof_headers,
                 resolved_location_counters,
-                &|_| unreachable!(),
+                &mut |_| unreachable!(),
             )?;
         }
         Ok(())
@@ -948,7 +1131,7 @@ mod tests {
                     symbol_db,
                     0,
                     &[],
-                    &|_| Ok(ResolvedSymbolValue::Absolute(0)),
+                    &mut |_| Ok(ResolvedSymbolValue::Absolute(0)),
                 )
             };
             assert_eq!(eval(&Expression::Origin(b"rom")).unwrap(), 0x08000000);

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -11,6 +11,7 @@ use crate::input_data::InputRef;
 use crate::layout;
 use crate::layout::FileLayoutState;
 use crate::layout::GroupState;
+use crate::layout::HandlerData;
 use crate::layout::InputSectionPositions;
 use crate::layout::MemoryRegion;
 use crate::layout::OutputRecordLayout;
@@ -543,45 +544,43 @@ pub(crate) fn evaluate_early_expression<'data, P: Platform>(
                     let symbol_offset = ls.symbol_id_range.id_to_offset(canonical_id);
 
                     let def_info = &script.parsed.symbol_defs[symbol_offset];
-                    match &def_info.placement {
-                        SymbolPlacement::Redirect(redirect) => {
-                            if !visited_nodes.insert(canonical_id) {
-                                return Ok(SymbolValue::Absolute(0));
-                            }
-                            let value = evaluate_early_expression(
-                                &redirect.expression,
-                                &redirect.loc,
-                                memory_regions,
-                                section_layouts,
-                                resolved_lc,
-                                laid_out_mem_offsets,
-                                group_states,
-                                sizes,
-                                output_sections,
-                                symbol_db,
-                                sizeof_headers,
-                                section_positions,
-                                visited_nodes,
-                            );
-                            visited_nodes.remove(&canonical_id);
-                            let value = value?;
-                            let symbol_section = redirect
-                                .loc
-                                .relative_section_id()
-                                .map(|id| output_sections.primary_output_section(id));
-                            if let Some(symbol_section) = symbol_section {
-                                Ok(SymbolValue::SectionRelative {
-                                    section_id: symbol_section,
-                                    address: value,
-                                })
-                            } else {
-                                Ok(SymbolValue::Absolute(value))
-                            }
-                        }
-                        _ => {
-                            bail!("Unsupported symbol type");
-                        }
-                    }
+                    evaluate_early_expression_internal_symbol(
+                        memory_regions,
+                        section_layouts,
+                        resolved_lc,
+                        laid_out_mem_offsets,
+                        group_states,
+                        sizes,
+                        output_sections,
+                        symbol_db,
+                        sizeof_headers,
+                        section_positions,
+                        visited_nodes,
+                        canonical_id,
+                        def_info,
+                    )
+                }
+                Some(FileLayoutState::Prelude(prelude))
+                    if let Group::Prelude(p) = &symbol_db.groups[file_id.group()] =>
+                {
+                    let def_info =
+                        &p.symbol_definitions[prelude.symbol_id_range().id_to_offset(canonical_id)];
+
+                    evaluate_early_expression_internal_symbol(
+                        memory_regions,
+                        section_layouts,
+                        resolved_lc,
+                        laid_out_mem_offsets,
+                        group_states,
+                        sizes,
+                        output_sections,
+                        symbol_db,
+                        sizeof_headers,
+                        section_positions,
+                        visited_nodes,
+                        canonical_id,
+                        def_info,
+                    )
                 }
                 _ => {
                     bail!(
@@ -592,6 +591,70 @@ pub(crate) fn evaluate_early_expression<'data, P: Platform>(
             }
         },
     )
+}
+
+fn evaluate_early_expression_internal_symbol<'data, P: Platform>(
+    memory_regions: &HashMap<&[u8], MemoryRegion>,
+    section_layouts: &OutputSectionMap<OutputRecordLayout>,
+    resolved_lc: &[ResolvedLocationCounter],
+    laid_out_mem_offsets: &OutputSectionPartMap<Option<u64>>,
+    group_states: &[GroupState<'data, P>],
+    sizes: &OutputSectionPartMap<u64>,
+    output_sections: &OutputSections<'data, P>,
+    symbol_db: &SymbolDb<'data, P>,
+    sizeof_headers: u64,
+    section_positions: &OnceCell<InputSectionPositions>,
+    visited_nodes: &mut hashbrown::HashSet<SymbolId>,
+    canonical_id: SymbolId,
+    def_info: &crate::parsing::InternalSymDefInfo<'data, P>,
+) -> Result<SymbolValue> {
+    match &def_info.placement {
+        SymbolPlacement::Redirect(redirect) => {
+            if !visited_nodes.insert(canonical_id) {
+                return Ok(SymbolValue::Absolute(0));
+            }
+            let value = evaluate_early_expression(
+                &redirect.expression,
+                &redirect.loc,
+                memory_regions,
+                section_layouts,
+                resolved_lc,
+                laid_out_mem_offsets,
+                group_states,
+                sizes,
+                output_sections,
+                symbol_db,
+                sizeof_headers,
+                section_positions,
+                visited_nodes,
+            );
+            visited_nodes.remove(&canonical_id);
+            let value = value?;
+            let symbol_section = redirect
+                .loc
+                .relative_section_id()
+                .map(|id| output_sections.primary_output_section(id));
+            if let Some(symbol_section) = symbol_section {
+                Ok(SymbolValue::SectionRelative {
+                    section_id: symbol_section,
+                    address: value,
+                })
+            } else {
+                Ok(SymbolValue::Absolute(value))
+            }
+        }
+        SymbolPlacement::SectionStart(section_id) => Ok(SymbolValue::SectionRelative {
+            section_id: *section_id,
+            address: 0,
+        }),
+        SymbolPlacement::SectionEnd(section_id) => Ok(SymbolValue::SectionRelative {
+            section_id: *section_id,
+            address: section_layouts.get(*section_id).mem_size,
+        }),
+        _ => {
+            bail!("Unsupported symbol type");
+        }
+    }
 }
 
 fn section_size<'data, P: Platform>(

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -16,7 +16,7 @@ use crate::error::Context;
 use crate::error::Error;
 use crate::error::Result;
 use crate::expression_eval::ResolvedLocationCounter;
-use crate::expression_eval::ResolvedSymbolValue;
+use crate::expression_eval::SymbolValue;
 use crate::expression_eval::evaluate_const;
 use crate::expression_eval::evaluate_early_expression;
 use crate::file_writer;
@@ -579,11 +579,6 @@ fn update_defsym_symbol_resolution<'data, P: Platform>(
     resolved_location_counters: &[ResolvedLocationCounter],
 ) -> Result {
     if let SymbolPlacement::Redirect(redirect) = &def_info.placement {
-        let current_section_base = redirect.loc.relative_section_id().map(|id| {
-            let primary_id = output_sections.primary_output_section(id);
-            section_layouts.get(primary_id).mem_offset
-        });
-
         let value = crate::expression_eval::evaluate_expression(
             &redirect.expression,
             &redirect.loc,
@@ -594,6 +589,8 @@ fn update_defsym_symbol_resolution<'data, P: Platform>(
             symbol_db,
             sizeof_headers,
             resolved_location_counters,
+            // During late evaluation of linker scripts, we don't have any part relative symbols.
+            &OutputSectionPartMap::default(),
             &mut |name| {
                 let Some(target_symbol_id) =
                     symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(name))
@@ -607,15 +604,14 @@ fn update_defsym_symbol_resolution<'data, P: Platform>(
                     .as_ref()
                     .ok_or_else(|| redirect.missing_resolution(name))?;
 
-                if let Some(section_base) = current_section_base
-                    && resolution.raw_value >= section_base
-                {
-                    return Ok(ResolvedSymbolValue::SectionRelative(
-                        resolution.raw_value - section_base,
-                    ));
-                }
-
-                Ok(ResolvedSymbolValue::Absolute(resolution.raw_value))
+                let symbol_value = match symbol_db.output_section_id(canonical_target_id) {
+                    Some(section_id) => SymbolValue::SectionRelative {
+                        section_id,
+                        address: resolution.raw_value,
+                    },
+                    None => SymbolValue::Absolute(resolution.raw_value),
+                };
+                Ok(symbol_value)
             },
         )?;
 
@@ -5150,30 +5146,18 @@ fn compute_section_and_symbol_addresses<'data, P: Platform>(
     (section_positions, SymbolOutputInfos { addresses })
 }
 
-pub(crate) enum EarlyObjectSymbolValue {
-    Absolute(u64),
-    PartRelative {
-        part_id: PartId,
-        offset: u64,
-    },
-    SectionRelative {
-        section_id: OutputSectionId,
-        address: u64,
-    },
-}
-
 pub(crate) fn resolve_early_object_symbol<'data, P: Platform>(
     canonical_id: SymbolId,
     obj: &ObjectLayoutState<'data, P>,
     section_positions: &InputSectionPositions,
     symbol_db: &SymbolDb<'data, P>,
-) -> Result<EarlyObjectSymbolValue> {
+) -> Result<SymbolValue> {
     let file_id = symbol_db.file_id_for_symbol(canonical_id);
     let local_index = canonical_id.to_input(obj.symbol_id_range);
     let symbol = obj.object.symbol(local_index)?;
     let Some(section_index) = obj.object.symbol_section(symbol, local_index)? else {
         if symbol.is_absolute() {
-            return Ok(EarlyObjectSymbolValue::Absolute(symbol.value()));
+            return Ok(SymbolValue::Absolute(symbol.value()));
         }
         bail!(
             "cannot resolve address of symbol '{}'",
@@ -5207,7 +5191,7 @@ pub(crate) fn resolve_early_object_symbol<'data, P: Platform>(
     let input_offset = obj.object.symbol_offset_in_section(symbol, section_index)?;
     let output_offset =
         opt_input_to_output(obj.section_relax_deltas.get(section_index.0), input_offset);
-    Ok(EarlyObjectSymbolValue::PartRelative {
+    Ok(SymbolValue::PartRelative {
         part_id: section_position.part_id,
         offset: section_position.address + output_offset,
     })

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -18,6 +18,7 @@ use crate::error::Result;
 use crate::expression_eval::ResolvedLocationCounter;
 use crate::expression_eval::ResolvedSymbolValue;
 use crate::expression_eval::evaluate_const;
+use crate::expression_eval::evaluate_early_expression;
 use crate::file_writer;
 use crate::grouping::Group;
 use crate::grouping::SequencedLinkerScript;
@@ -80,6 +81,7 @@ use crate::verbose_timing_phase;
 use crossbeam_queue::ArrayQueue;
 use crossbeam_queue::SegQueue;
 use hashbrown::HashMap;
+use hashbrown::HashSet;
 use itertools::Itertools;
 use linker_utils::elf::RelocationKind;
 use linker_utils::relaxation::RelaxDeltaMap;
@@ -577,15 +579,10 @@ fn update_defsym_symbol_resolution<'data, P: Platform>(
     resolved_location_counters: &[ResolvedLocationCounter],
 ) -> Result {
     if let SymbolPlacement::Redirect(redirect) = &def_info.placement {
-        let current_section_base = match redirect.loc {
-            SymbolLoc::SectionStartRelative(id)
-            | SymbolLoc::SectionEndRelative(id)
-            | SymbolLoc::LocationCounter(_, Some(id)) => {
-                let primary_id = output_sections.primary_output_section(id);
-                Some(section_layouts.get(primary_id).mem_offset)
-            }
-            _ => None,
-        };
+        let current_section_base = redirect.loc.relative_section_id().map(|id| {
+            let primary_id = output_sections.primary_output_section(id);
+            section_layouts.get(primary_id).mem_offset
+        });
 
         let value = crate::expression_eval::evaluate_expression(
             &redirect.expression,
@@ -597,7 +594,7 @@ fn update_defsym_symbol_resolution<'data, P: Platform>(
             symbol_db,
             sizeof_headers,
             resolved_location_counters,
-            &|name| {
+            &mut |name| {
                 let Some(target_symbol_id) =
                     symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(name))
                 else {
@@ -4961,7 +4958,7 @@ const MAX_RELAXATION_ITERATIONS: usize = 5;
 const SYMBOL_ADDRESS_UNRESOLVED: u64 = u64::MAX;
 
 #[derive(Debug, Clone, Copy)]
-struct InputSectionPosition {
+pub(crate) struct InputSectionPosition {
     part_id: PartId,
     address: u64,
 }
@@ -4969,7 +4966,7 @@ struct InputSectionPosition {
 /// Input-section positions in the coordinate system supplied by the initial part offsets.
 /// Zero initial offsets produce part-relative positions, while final part offsets produce output
 /// addresses.
-type InputSectionPositions = Vec<Vec<Vec<Option<InputSectionPosition>>>>;
+pub(crate) type InputSectionPositions = Vec<Vec<Vec<Option<InputSectionPosition>>>>;
 
 /// Stores precomputed output-address information for every symbol.
 struct SymbolOutputInfos {
@@ -5032,7 +5029,7 @@ fn compute_object_section_positions<'data, P: Platform>(
     positions
 }
 
-fn compute_input_section_positions<'data, P: Platform>(
+pub(crate) fn compute_input_section_positions<'data, P: Platform>(
     group_states: &[GroupState<'data, P>],
     mem_offsets: OutputSectionPartMap<u64>,
     symbol_db: &SymbolDb<'data, P>,
@@ -5153,29 +5150,25 @@ fn compute_section_and_symbol_addresses<'data, P: Platform>(
     (section_positions, SymbolOutputInfos { addresses })
 }
 
-enum EarlyObjectSymbolValue {
+pub(crate) enum EarlyObjectSymbolValue {
     Absolute(u64),
-    PartRelative { part_id: PartId, offset: u64 },
+    PartRelative {
+        part_id: PartId,
+        offset: u64,
+    },
+    SectionRelative {
+        section_id: OutputSectionId,
+        address: u64,
+    },
 }
 
-fn resolve_early_object_symbol<'data, P: Platform>(
-    symbol_id: SymbolId,
-    group_states: &[GroupState<'data, P>],
+pub(crate) fn resolve_early_object_symbol<'data, P: Platform>(
+    canonical_id: SymbolId,
+    obj: &ObjectLayoutState<'data, P>,
     section_positions: &InputSectionPositions,
     symbol_db: &SymbolDb<'data, P>,
 ) -> Result<EarlyObjectSymbolValue> {
-    let canonical_id = symbol_db.definition(symbol_id);
     let file_id = symbol_db.file_id_for_symbol(canonical_id);
-    let Some(FileLayoutState::Object(obj)) = group_states
-        .get(file_id.group())
-        .and_then(|group| group.files.get(file_id.file()))
-    else {
-        bail!(
-            "symbol '{}' is not defined by an input object",
-            symbol_db.symbol_name_for_display(canonical_id)
-        );
-    };
-
     let local_index = canonical_id.to_input(obj.symbol_id_range);
     let symbol = obj.object.symbol(local_index)?;
     let Some(section_index) = obj.object.symbol_section(symbol, local_index)? else {
@@ -5506,77 +5499,21 @@ fn compute_layout_sections<'data, P: Platform>(
          section_layouts: &OutputSectionMap<OutputRecordLayout>,
          resolved_lc: &[ResolvedLocationCounter],
          laid_out_mem_offsets: &OutputSectionPartMap<Option<u64>>| {
-            crate::expression_eval::evaluate_expression(
+            let mut visited_nodes = HashSet::new();
+            evaluate_early_expression(
                 expr,
                 loc,
-                None,
-                section_layouts,
-                output_sections,
                 memory_regions,
+                section_layouts,
+                resolved_lc,
+                laid_out_mem_offsets,
+                group_states,
+                sizes,
+                output_sections,
                 symbol_db,
                 sizeof_headers,
-                resolved_lc,
-                &|name| {
-                    let Some(symbol_id) =
-                        symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(name))
-                    else {
-                        bail!(
-                            "undefined symbol '{}' in linker script expression",
-                            String::from_utf8_lossy(name)
-                        );
-                    };
-
-                    let symbol_value = match resolve_early_object_symbol(
-                        symbol_id,
-                        group_states,
-                        section_positions.get_or_init(|| {
-                            compute_input_section_positions(
-                                group_states,
-                                sizes.new_empty_like(),
-                                symbol_db,
-                                output_sections,
-                            )
-                        }),
-                        symbol_db,
-                    )? {
-                        EarlyObjectSymbolValue::Absolute(value) => {
-                            ResolvedSymbolValue::Absolute(value)
-                        }
-                        EarlyObjectSymbolValue::PartRelative { part_id, offset } => {
-                            let Some(part_address) = laid_out_mem_offsets.get(part_id) else {
-                                bail!(
-                                    "cannot resolve address of symbol '{}' because its output section part has not been laid out yet",
-                                    String::from_utf8_lossy(name)
-                                );
-                            };
-                            let address = part_address + offset;
-                            let symbol_section = output_sections
-                                .primary_output_section(part_id.output_section_id::<P>());
-                            let current_section = match loc {
-                                SymbolLoc::SectionStartRelative(id)
-                                | SymbolLoc::SectionEndRelative(id)
-                                | SymbolLoc::LocationCounter(_, Some(id)) => {
-                                    Some(output_sections.primary_output_section(*id))
-                                }
-                                _ => None,
-                            };
-                            if current_section == Some(symbol_section) {
-                                let section_base = section_layouts.get(symbol_section).mem_offset;
-                                ResolvedSymbolValue::SectionRelative(
-                                    address.checked_sub(section_base).with_context(|| {
-                                        format!(
-                                            "address of symbol '{}' is before its output section",
-                                            String::from_utf8_lossy(name)
-                                        )
-                                    })?,
-                                )
-                            } else {
-                                ResolvedSymbolValue::Absolute(address)
-                            }
-                        }
-                    };
-                    Ok(symbol_value)
-                },
+                &section_positions,
+                &mut visited_nodes,
             )
         };
 

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -43,6 +43,15 @@ impl<T: Default> OutputSectionPartMap<T> {
     }
 }
 
+impl<T> Default for OutputSectionPartMap<T> {
+    fn default() -> Self {
+        Self {
+            parts: Vec::new(),
+            sparse: None,
+        }
+    }
+}
+
 pub(crate) enum RangeIterator<'a, T> {
     Dense(PartId, &'a [T]),
     Sparse(std::collections::btree_map::Range<'a, PartId, T>),

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -111,6 +111,27 @@ pub(crate) enum SymbolLoc {
     None,
 }
 
+impl SymbolLoc {
+    pub(crate) fn section_id(&self) -> Option<OutputSectionId> {
+        match self {
+            SymbolLoc::SectionStartRelative(id)
+            | SymbolLoc::SectionEndRelative(id)
+            | SymbolLoc::SectionEnd(id) => Some(*id),
+            SymbolLoc::LocationCounter(_, section_id) => *section_id,
+            SymbolLoc::FirstSection | SymbolLoc::None => None,
+        }
+    }
+
+    pub(crate) fn relative_section_id(&self) -> Option<OutputSectionId> {
+        match self {
+            SymbolLoc::SectionStartRelative(id)
+            | SymbolLoc::SectionEndRelative(id)
+            | SymbolLoc::LocationCounter(_, Some(id)) => Some(*id),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Redirect<'data> {
     pub(crate) kind: RedirectKind,

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -2135,16 +2135,9 @@ impl std::fmt::Display for SymbolId {
 impl<P: Platform> InternalSymDefInfo<'_, P> {
     pub(crate) fn section_id(&self) -> Option<OutputSectionId> {
         match self.placement {
-            SymbolPlacement::Redirect(Redirect {
-                loc:
-                    SymbolLoc::SectionEnd(i)
-                    | SymbolLoc::SectionStartRelative(i)
-                    | SymbolLoc::SectionEndRelative(i),
-                ..
-            }) => Some(i),
+            SymbolPlacement::Redirect(Redirect { ref loc, .. }) => loc.section_id(),
             SymbolPlacement::Undefined
             | SymbolPlacement::ForceUndefined
-            | SymbolPlacement::Redirect(_)
             | SymbolPlacement::PlatformSpecific(_) => None,
             SymbolPlacement::SectionStart(i) => Some(i),
             SymbolPlacement::SectionEnd(i) => Some(i),

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -851,6 +851,31 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
         }
     }
 
+    pub(crate) fn output_section_id(&self, symbol_id: SymbolId) -> Option<OutputSectionId> {
+        let file_id = self.file_id_for_symbol(symbol_id);
+        match self.file(file_id) {
+            SequencedInput::Object(obj) => {
+                let local_index = symbol_id.to_input(obj.symbol_id_range);
+                let sym = obj.parsed.object.symbol(local_index).ok()?;
+                let sec_idx = obj.parsed.object.symbol_section(sym, local_index).ok()??;
+                let part_id = self
+                    .section_part_ids
+                    .get(obj.section_id_range.start().as_usize() + sec_idx.0)?;
+                Some(part_id.output_section_id::<P>())
+            }
+            SequencedInput::LinkerScript(script) => {
+                let local_index = symbol_id.to_input(script.symbol_id_range);
+                let def_info = script.parsed.symbol_defs.get(local_index.0)?;
+                if let crate::parsing::SymbolPlacement::Redirect(redirect) = &def_info.placement {
+                    redirect.loc.relative_section_id()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
     pub(crate) fn is_mapping_symbol(&self, symbol_id: SymbolId) -> bool {
         let Ok(name) = self.symbol_name(symbol_id) else {
             // We don't want to bother the caller with an error here. If there's a problem getting

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-cyclic-symbol.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-cyclic-symbol.ld
@@ -1,0 +1,18 @@
+ENTRY(begin_here)
+
+first = second;
+second = first;
+
+SECTIONS
+{
+    . = first;
+    .text : {
+        *(.text)
+    }
+    .data : {
+        *(.data)
+    }
+    .bss : {
+        KEEP(*(.bss))
+    }
+}

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-symbols.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-symbols.ld
@@ -1,14 +1,22 @@
 ENTRY(begin_here)
 
+offset1 = 0x200;
+
 SECTIONS
 {
     . = 0x600000;
 
+	offset3 = 0x500;
+
     .custom : {
         *(.custom.1)
+		offset2 = 0x40;
         *(.custom.2)
         . = custom_two + 0x100;
         *(.custom.3)
+		before_offset2 = .;
+		. += offset2;
+		after_offset2_custom = .;
         . = 0x1000;
     }
 
@@ -31,12 +39,33 @@ SECTIONS
 
     after_abs_between = .;
 
+	. += offset1;
+
+	after_offset1 = .;
+
+	. += offset2;
+
+	after_offset2 = .;
+
+	. += offset3;
+
+	after_offset3 = .;
+
     . = abs_symbol;
 
     after_abs = .;
 
     .data : {
         *(.data)
+		data_offset = .;
+		. += offset1;
+		after_offset1_data = .;
+
+		. += offset2;
+		after_offset2_data = .;
+
+		. += offset3;
+		after_offset3_data = .;
         *(.data.*)
     }
 }
@@ -49,3 +78,10 @@ ASSERT(after_foo == foo + 0x100000, "after_foo is incorrect");
 ASSERT(after_abs_between == abs_between + 0x100, "after_abs_between is incorrect");
 ASSERT(after_abs == abs_symbol, "after_abs is incorrect");
 ASSERT(ADDR(.data) == after_abs, ".data must start at after_abs");
+ASSERT(after_offset1 == after_abs_between + offset1, "after_offset1 is incorrect");
+ASSERT(after_offset2 == after_offset1 + offset2, "after_offset2 is incorrect");
+ASSERT(after_offset3 == after_offset2 + offset3, "after_offset3 is incorrect");
+ASSERT(after_offset1_data == data_offset + offset1, "after_offset1_data is incorrect");
+ASSERT(after_offset2_data == after_offset1_data + offset2 + after_abs, "after_offset2_data is incorrect");
+ASSERT(after_offset3_data == after_offset2_data + offset3, "after_offset3_data is incorrect");
+ASSERT(after_offset2_custom == before_offset2 + 0x40, "after_offset2_custom is incorrect");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-symbols.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-symbols.ld
@@ -51,6 +51,10 @@ SECTIONS
 
 	after_offset3 = .;
 
+	. += offset4;
+
+	after_offset4 = .;
+
     . = abs_symbol;
 
     after_abs = .;
@@ -67,6 +71,9 @@ SECTIONS
 		. += offset3;
 		after_offset3_data = .;
         *(.data.*)
+
+		. += offset4;
+		after_offset4_data = .;
     }
 }
 
@@ -81,7 +88,9 @@ ASSERT(ADDR(.data) == after_abs, ".data must start at after_abs");
 ASSERT(after_offset1 == after_abs_between + offset1, "after_offset1 is incorrect");
 ASSERT(after_offset2 == after_offset1 + offset2, "after_offset2 is incorrect");
 ASSERT(after_offset3 == after_offset2 + offset3, "after_offset3 is incorrect");
+ASSERT(after_offset4 == after_offset3 + offset4, "after_offset3 is incorrect");
 ASSERT(after_offset1_data == data_offset + offset1, "after_offset1_data is incorrect");
 ASSERT(after_offset2_data == after_offset1_data + offset2 + after_abs, "after_offset2_data is incorrect");
 ASSERT(after_offset3_data == after_offset2_data + offset3, "after_offset3_data is incorrect");
+ASSERT(after_offset4_data == after_offset3_data + offset4, "after_offset3_data is incorrect");
 ASSERT(after_offset2_custom == before_offset2 + 0x40, "after_offset2_custom is incorrect");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
@@ -42,6 +42,7 @@
 
 //#Config:symbols
 //#LinkerScript:linker-script-location-counter-symbols.ld
+//#LinkArgs:--defsym=offset4=0x300
 //#Object:runtime.c
 // RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
 //#SkipArch:riscv64,ppc64le

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
@@ -93,6 +93,15 @@
 //#DiffIgnore:segment.LOAD.RX.alignment
 //#DiffIgnore:segment.LOAD.RWX.alignment
 
+//#Config:cyclic_symbol
+//#LinkerScript:linker-script-location-counter-cyclic-symbol.ld
+//#ReferenceLinkers:bfd,lld
+//#Object:runtime.c
+// RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
+//#SkipArch:riscv64,ppc64le
+// The binary created is not valid, so we can't run it.
+//#RunEnabled:false
+
 #include <stddef.h>
 
 #include "../common/runtime.h"


### PR DESCRIPTION
Adds support for fetching the value of a symbol defined in a linker script, within a location counter. For now, we only support fetching the first value, i.e. if a linker script has multiple symbol redefinitions, we only fetch the first one.