### PR TITLE
port(MachO): Add TLV pointer `ldr` relaxation

### DIFF
--- a/libwild/src/macho_aarch64.rs
+++ b/libwild/src/macho_aarch64.rs
@@ -5,6 +5,7 @@ use crate::bail;
 use crate::ensure;
 use crate::macho::MachO;
 use crate::platform::PreviousRelocationInfo;
+use linker_utils::aarch64::RelaxationKind;
 use linker_utils::elf::AArch64Instruction;
 use linker_utils::elf::AllowedRange;
 use linker_utils::elf::PAGE_MASK_4KB;
@@ -30,15 +31,18 @@ const _ASSERTS: () = {
 };
 
 #[derive(Debug, Clone)]
-pub(crate) struct Relaxation {}
+pub(crate) struct Relaxation {
+    kind: RelaxationKind,
+    rel_info: RelocationKindInfo,
+}
 
 impl crate::platform::Relaxation for Relaxation {
     fn apply(&self, section_bytes: &mut [u8], offset_in_section: &mut u64, addend: &mut i64) {
-        todo!()
+        self.kind.apply(section_bytes, offset_in_section, addend);
     }
 
     fn rel_info(&self) -> linker_utils::elf::RelocationKindInfo {
-        todo!()
+        self.rel_info
     }
 
     fn debug_kind(&self) -> impl std::fmt::Debug {
@@ -121,7 +125,7 @@ impl crate::platform::Arch for MachOAArch64 {
                     4,
                 )
             }
-            object::macho::ARM64_RELOC_PAGE21 => {
+            object::macho::ARM64_RELOC_PAGE21 | object::macho::ARM64_RELOC_TLVP_LOAD_PAGE21 => {
                 debug_assert_eq!(rel_size, RelocationSize::ByteSize(4));
                 (
                     rel_kind,
@@ -131,7 +135,8 @@ impl crate::platform::Arch for MachOAArch64 {
                     1,
                 )
             }
-            object::macho::ARM64_RELOC_PAGEOFF12 => {
+            object::macho::ARM64_RELOC_PAGEOFF12
+            | object::macho::ARM64_RELOC_TLVP_LOAD_PAGEOFF12 => {
                 debug_assert_eq!(rel_size, RelocationSize::ByteSize(4));
                 (
                     RelocationKind::AbsoluteLowPart,
@@ -222,6 +227,22 @@ impl crate::platform::Arch for MachOAArch64 {
         _rel_addend: i64,
         _previous_relocation: Option<PreviousRelocationInfo<object::macho::RelocationInfo>>,
     ) -> Option<Self::Relaxation> {
-        todo!()
+        let interposable = flags.is_interposable();
+
+        match relocation_kind.r_type {
+            object::macho::ARM64_RELOC_TLVP_LOAD_PAGEOFF12
+                if output_kind.is_executable()
+                    && flags.has_link_time_address()
+                    && !interposable =>
+            {
+                let relocation = MachOAArch64::relocation_from_raw(relocation_kind)
+                    .expect("TLVP_LOAD_PAGEOFF12 must have relocation information");
+                Some(Relaxation {
+                    kind: RelaxationKind::LdrToAdd,
+                    rel_info: relocation,
+                })
+            }
+            _ => None,
+        }
     }
 }

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -43,6 +43,7 @@ use crate::macho::MAX_SEGMENT_COUNT;
 use crate::macho::MachO;
 use crate::macho::PLT_ENTRY_SIZE;
 use crate::macho::SectionEntry;
+use crate::macho::SectionFlags;
 use crate::macho::SegmentCommand;
 use crate::macho::SegmentName;
 use crate::macho::SymtabCommand;
@@ -63,6 +64,7 @@ use crate::output_trace::TraceOutput;
 use crate::platform::Arch;
 use crate::platform::Args;
 use crate::platform::ObjectFile;
+use crate::platform::Relaxation;
 use crate::platform::Symbol;
 use crate::resolution::SectionSlot;
 use crate::symbol_db::SymbolId;
@@ -79,6 +81,7 @@ use object::U16;
 use object::U32;
 use object::from_bytes_mut;
 use object::macho;
+use object::macho::ARM64_RELOC_TLVP_LOAD_PAGEOFF12;
 use object::macho::CPU_SUBTYPE_ARM64_ALL;
 use object::macho::CPU_TYPE_ARM64;
 use object::macho::CS_ADHOC;
@@ -608,8 +611,17 @@ fn write_object_section<'data, A: Arch<Platform = MachO>>(
         .address()
         .context("Attempted to apply relocations to a section that we didn't load")?;
 
+    let section_flags = object_layout.object.section(section_index)?.flags.get(LE);
+
     for rel in object_layout.relocations(section_index)?.relocations {
-        apply_relocation::<A>(object_layout, section_address, rel.info(LE), layout, out)?;
+        apply_relocation::<A>(
+            object_layout,
+            section_address,
+            section_flags,
+            rel.info(LE),
+            layout,
+            out,
+        )?;
     }
 
     Ok(())
@@ -619,11 +631,12 @@ fn write_object_section<'data, A: Arch<Platform = MachO>>(
 fn apply_relocation<'data, A: Arch<Platform = MachO>>(
     object_layout: &ObjectLayout<'data, MachO>,
     section_address: u64,
+    section_flags: SectionFlags,
     rel: RelocationInfo,
     layout: &MachOLayout<'data>,
     out: &mut [u8],
 ) -> Result {
-    let offset_in_section = u64::from(rel.r_address);
+    let mut offset_in_section = u64::from(rel.r_address);
     let place = section_address + offset_in_section;
 
     let _span = tracing::trace_span!(
@@ -633,9 +646,38 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
     )
     .entered();
 
-    let rel_info = A::relocation_from_raw(rel)?;
     let (resolution, _symbol_index, local_symbol_id) = get_resolution(rel, object_layout, layout)?;
     let flags = layout.flags_for_symbol(local_symbol_id);
+    let output_kind = layout.symbol_db.output_kind;
+
+    // TODO: We don't support addends, relaxation deltas, or previous relocations yet.
+    let relaxation = A::new_relaxation(
+        rel,
+        out,
+        offset_in_section,
+        flags,
+        output_kind,
+        section_flags,
+        None,
+        resolution.raw_value,
+        section_address,
+        0,
+        None,
+    );
+
+    let rel_info = match relaxation.as_ref() {
+        Some(relaxation) => {
+            relaxation.apply(out, &mut offset_in_section, &mut 0);
+            relaxation.rel_info()
+        }
+        None if rel.r_type == ARM64_RELOC_TLVP_LOAD_PAGEOFF12 => {
+            bail!(
+                "TLV relocations are currently only supported for locally-defined, strong, and \
+                non-interposable symbols in executables"
+            )
+        }
+        None => A::relocation_from_raw(rel)?,
+    };
 
     let mask = get_page_mask(rel_info.mask);
     let value = match rel_info.kind {

--- a/linker-utils/src/aarch64.rs
+++ b/linker-utils/src/aarch64.rs
@@ -44,6 +44,10 @@ pub enum RelaxationKind {
     /// Replace add with adr. We don't apply this, but lld does, so this is used by linker-diff.
     AddToAdr,
     LdrToAdr,
+
+    /// Replace ldr with add
+    LdrToAdd,
+
     /// Relax ADRP+ADD pair to NOP+ADR. Applied at the ADD instruction position.
     /// Writes NOP at ADRP position (offset-4) and ADR base at current position.
     AdrpAddToNopAdr,
@@ -97,6 +101,16 @@ impl RelaxationKind {
             }
             RelaxationKind::LdrToAdr => {
                 section_bytes[offset + 3] &= !0x89;
+            }
+            RelaxationKind::LdrToAdd => {
+                let mut insn = u32_from_slice(&section_bytes[offset..offset + 4]);
+                debug_assert_eq!(
+                    insn & 0xffc0_0000,
+                    0xf940_0000,
+                    "64-bit unsigned-immediate `ldr` is required"
+                );
+                insn = (insn & 0x001f_ffff) | 0x9100_0000;
+                section_bytes[offset..offset + 4].copy_from_slice(&insn.to_le_bytes());
             }
             RelaxationKind::AdrpAddToNopAdr => {
                 let adrp_dest_reg = u64::from(u32_from_slice(&section_bytes[offset - 4..offset]))

--- a/wild/tests/sources/macho/tlv-reloc-relax/tlv-reloc-relax.s
+++ b/wild/tests/sources/macho/tlv-reloc-relax/tlv-reloc-relax.s
@@ -1,0 +1,34 @@
+//#Arch:aarch64
+//#RunEnabled:false
+//#DiffEnabled:false
+//#ExpectSection:__thread_vars
+//#ExpectSectionBytes:__text=0x00600091 4..8
+
+.section __DATA,__thread_data,thread_local_regular
+.p2align 2
+_first$tlv$init:
+    .long 1
+_second$tlv$init:
+    .long 2
+
+.section __DATA,__thread_vars,thread_local_variables
+.p2align 3
+.globl _first
+_first:
+    .quad __tlv_bootstrap
+    .quad 0
+    .quad _first$tlv$init
+
+.globl _second
+_second:
+    .quad __tlv_bootstrap
+    .quad 0
+    .quad _second$tlv$init
+
+.text
+.p2align 2
+.globl _main
+_main:
+    adrp x0, _second@TLVPPAGE
+    ldr x0, [x0, _second@TLVPPAGEOFF]
+    ret


### PR DESCRIPTION
For an `ARM64_RELOC_TLVP_PAGEOFF12` relocation against a locally-defined, strong, and non-interposable TLV symbol in an executable, `ldr` is relaxed to `add` in the second instruction:

```
// Before
adrp x0, _second@TLVPPAGE
ldr	x0, [x0, _second@TLVPPAGEOFF]
ldr	x8, [x0]
blr	x8

// After
adrp x0, _second@TLVPPAGE
add	x0, x0, _second@TLVPPAGEOFF
ldr	x8, [x0]
blr	x8
```

This is because the TLV descriptor's address is known at link time, meaning that we can use an `adrp`/`add` pair instead of having to use a descriptor pointer in `__thread_ptrs`, as is the usual case for symbols requiring runtime binding. This also semantically matches [ld](https://github.com/apple-oss-distributions/ld64/blob/f60a74eaa2c99585de1dc0f2820e7a9f8aaf522c/src/ld/OutputFile.cpp#L2177-L2190) and [lld](https://github.com/llvm/llvm-project/blob/main/lld/MachO/Arch/ARM64Common.cpp#L94-L111) behavior, although I modified the mask to support only 64 bit unsigned-immediate `ldr` when performing the check for now. 

We still need support for `is_interposable`, correct descriptor offsets, and binding `__tlv_bootstrap` in each descriptor, which I plan to implement in the following diffs.

Part of #2071