### PR TITLE
fix: Preserve function identity with canonical PLT entries

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -1020,12 +1020,15 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
             let address;
             let dynamic_symbol_index;
 
-            if flags.needs_copy_relocation() {
-                let input_address = local_symbol.value();
-
-                address = *copy_relocation_addresses
-                    .get(&input_address)
-                    .context("Internal error: Missing copy relocation address")?;
+            if flags.needs_copy_relocation() || flags.needs_canonical_plt() {
+                address = if flags.needs_copy_relocation() {
+                    let input_address = local_symbol.value();
+                    *copy_relocation_addresses
+                        .get(&input_address)
+                        .context("Internal error: Missing copy relocation address")?
+                } else {
+                    0
+                };
 
                 // Since this is a definition, the dynamic symbol index will be determined by the
                 // epilogue and set by `update_dynamic_symbol_resolutions`.
@@ -1958,7 +1961,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
                 // need to deal with the symtab entry here.
                 common.allocate(part_id::SYMTAB_GLOBAL, C::SYMTAB_ENTRY_SIZE);
                 common.allocate(part_id::STRTAB, name.len() as u64 + 1);
-            } else {
+            } else if !flags.needs_canonical_plt() {
                 common.allocate(part_id::DYNSTR, name.len() as u64 + 1);
                 common.allocate(part_id::DYNSYM, C::SYMTAB_ENTRY_SIZE);
             }
@@ -2001,7 +2004,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
             if flags.needs_plt() {
                 mem_sizes.increment(part_id::PLT_GOT, PLT_ENTRY_SIZE);
             }
-            if flags.is_ifunc() {
+            if flags.is_ifunc() || flags.needs_canonical_plt() {
                 mem_sizes.increment(part_id::RELA_PLT, C::RELA_ENTRY_SIZE);
             } else if has_dynamic_symbol {
                 mem_sizes.increment(part_id::RELA_DYN_GENERAL, C::RELA_ENTRY_SIZE);
@@ -2013,6 +2016,11 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
                     mem_sizes.increment(part_id::RELA_DYN_RELATIVE, C::RELA_ENTRY_SIZE);
                 }
                 // is_got_relr=true: RELR entries counted by post_compute_sizes
+            }
+
+            if flags.needs_canonical_plt_got_for_address() {
+                mem_sizes.increment(part_id::GOT, C::GOT_ENTRY_SIZE);
+                mem_sizes.increment(part_id::RELA_DYN_GENERAL, C::RELA_ENTRY_SIZE);
             }
         }
 
@@ -2213,10 +2221,12 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
             if flags.is_dynamic() {
                 resolution.raw_value = plt_address.get();
             }
-            // For ifunc with address equality needs, allocate 2 GOT entries
+            // For functions with address equality needs, allocate 2 GOT entries
             // - First entry: Used by PLT
             // - Second entry: Used by GOT-relative references
-            let num_got_entries = if flags.needs_ifunc_got_for_address() {
+            let num_got_entries = if flags.needs_ifunc_got_for_address()
+                || flags.needs_canonical_plt_got_for_address()
+            {
                 2
             } else {
                 1
@@ -6193,7 +6203,7 @@ fn materialize_relocation_requirements<
         } else if flags.is_function() {
             // Create a PLT entry for the function and refer to that instead.
             flags_to_add.remove(ValueFlags::DIRECT);
-            *flags_to_add |= ValueFlags::PLT | ValueFlags::GOT;
+            *flags_to_add |= ValueFlags::PLT | ValueFlags::GOT | ValueFlags::CANONICAL_PLT;
         } else if !flags.is_absolute() {
             match args.copy_relocations_enabled() {
                 crate::args::CopyRelocations::Allowed => {
@@ -6249,6 +6259,11 @@ fn materialize_relocation_requirements<
     // that all references to the ifunc return the same address.
 
     let relocation_needs_got = flags_to_add.needs_got();
+    let relocation_needs_got_for_address = relocation_needs_got && !flags_to_add.needs_plt();
+
+    if flags.is_function() && relocation_needs_got_for_address {
+        *flags_to_add |= ValueFlags::GOT_FOR_PLT_ENTRY;
+    }
 
     if flags.is_ifunc() && !symbol_db.output_kind.is_static_executable() {
         *flags_to_add |= ValueFlags::GOT | ValueFlags::PLT;
@@ -6378,7 +6393,9 @@ impl<C: ElfClass> Resolution<Elf<C>> {
 
     pub(crate) fn got_address_for_relocation(&self) -> Result<u64> {
         let mut got_address = self.got_address()?;
-        if self.flags.needs_ifunc_got_for_address() {
+        if self.flags.needs_ifunc_got_for_address()
+            || self.flags.needs_canonical_plt_got_for_address()
+        {
             got_address += C::GOT_ENTRY_SIZE;
         }
         Ok(got_address)

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -784,7 +784,10 @@ impl<'layout, 'out, C: ElfClass> TableWriter<'layout, 'out, C> {
         } else {
             self.take_next_got_entry()?
         };
-        if res.flags.is_dynamic()
+        if res.flags.needs_canonical_plt() {
+            *got_entry = elf::Word::<C>::from_u64(0)?;
+            self.write_jump_slot_relocation::<A>(got_address, res.dynamic_symbol_index()?)?;
+        } else if res.flags.is_dynamic()
             || (flags.needs_export_dynamic() && res.flags.is_interposable())
                 && !res.flags.is_ifunc()
         {
@@ -836,6 +839,18 @@ impl<'layout, 'out, C: ElfClass> TableWriter<'layout, 'out, C> {
                 plt_address
             };
             *got_entry = elf::Word::<C>::from_u64(value)?;
+        }
+
+        if res.flags.needs_canonical_plt_got_for_address() {
+            let address_got_address = got_address + C::GOT_ENTRY_SIZE;
+            *self.take_next_got_entry()? = elf::Word::<C>::from_u64(0)?;
+
+            self.write_dynamic_symbol_relocation::<A>(
+                address_got_address,
+                0,
+                res.dynamic_symbol_index()?,
+                DynamicRelocationKind::GotEntry,
+            )?;
         }
 
         Ok(())
@@ -1109,6 +1124,27 @@ impl<'layout, 'out, C: ElfClass> TableWriter<'layout, 'out, C> {
             0,
             A::get_dynamic_relocation_type(DynamicRelocationKind::Irelative),
         )?;
+        Ok(())
+    }
+
+    fn write_jump_slot_relocation<A: Arch<Platform = elf::Elf<C>>>(
+        &mut self,
+        got_address: u64,
+        dynamic_symbol_index: u32,
+    ) -> Result {
+        let out = self
+            .rela_plt
+            .split_off_first_mut()
+            .ok_or_else(|| insufficient_allocation(".rela.plt"))?;
+
+        out.set_addend(0)?;
+        out.set_offset(got_address)?;
+
+        out.set_info(
+            dynamic_symbol_index,
+            A::get_dynamic_relocation_type(DynamicRelocationKind::JumpSlot),
+        )?;
+
         Ok(())
     }
 
@@ -4640,12 +4676,24 @@ fn write_dynamic_symbol_definitions<C: ElfClass>(
                         }
                     }
                     FileLayout::Dynamic(object) => {
-                        write_copy_relocation_dynamic_symbol_definition(
-                            sym_def,
-                            object,
-                            layout,
-                            &mut table_writer.dynsym_writer,
-                        )?;
+                        if layout
+                            .flags_for_symbol(sym_def.symbol_id)
+                            .needs_canonical_plt()
+                        {
+                            write_canonical_plt_dynamic_symbol_definition(
+                                sym_def,
+                                object,
+                                layout,
+                                &mut table_writer.dynsym_writer,
+                            )?;
+                        } else {
+                            write_copy_relocation_dynamic_symbol_definition(
+                                sym_def,
+                                object,
+                                layout,
+                                &mut table_writer.dynsym_writer,
+                            )?;
+                        }
 
                         if let Some(versym) = table_writer.versym.as_mut() {
                             copy_symbol_version(
@@ -4955,6 +5003,26 @@ fn write_copy_relocation_dynamic_symbol_definition<'data, C: ElfClass>(
                 layout.symbol_debug(sym_def.symbol_id)
             )
         })?;
+    Ok(())
+}
+
+fn write_canonical_plt_dynamic_symbol_definition<'data, C: ElfClass>(
+    sym_def: &crate::layout::DynamicSymbolDefinition<elf::Elf<C>>,
+    object: &DynamicLayout<'data, elf::Elf<C>>,
+    layout: &ElfLayout<C>,
+    dynamic_symbol_writer: &mut SymbolTableWriter<'_, '_, C>,
+) -> Result {
+    let sym_index = sym_def.symbol_id.to_input(object.symbol_id_range);
+    let sym = object.object.symbol(sym_index)?;
+
+    let resolution = layout
+        .local_symbol_resolution(sym_def.symbol_id)
+        .context("Canonical PLT symbol has no resolution")?;
+
+    let entry = dynamic_symbol_writer.undefined_symbol(false, sym_def.name)?;
+    entry.set_value(resolution.plt_address()?)?;
+    entry.set_binding_and_type(sym.st_bind(), object::elf::STT_FUNC);
+
     Ok(())
 }
 
@@ -5839,13 +5907,18 @@ fn write_dynamic_file<'data, C: ElfClass, A: Arch<Platform = elf::Elf<C>>>(
                     res.value(),
                     ValueFlags::empty(),
                 )?;
-            } else {
+            } else if !res.flags.needs_canonical_plt() {
                 let entry = table_writer.dynsym_writer.undefined_symbol(false, name)?;
 
-                // Note, we copy st_info, but not st_other since we don't want to copy the
-                // visibility. We want to emit the symbol with default visibility, otherwise the
-                // runtime loader may ignore dynamic relocations that reference the symbol.
-                entry.set_info(symbol.st_info());
+                let symbol_type = if symbol.st_type() == object::elf::STT_GNU_IFUNC {
+                    // An undefined reference to an IFUNC needs to be emitted as type FUNC.
+                    object::elf::STT_FUNC
+                } else {
+                    symbol.st_type()
+                };
+
+                // Note, for undefined symbols, we always use default visibility.
+                entry.set_binding_and_type(symbol.st_bind(), symbol_type);
 
                 if let Some(versym) = table_writer.version_writer.versym.as_mut() {
                     copy_symbol_version(

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -163,6 +163,13 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>, F: FileSystem>(
     let mut dynamic_symbol_definitions =
         merge_dynamic_symbol_definitions(&group_states, &symbol_db)?;
 
+    create_canonical_plt_entries(
+        &group_states,
+        &symbol_db,
+        &atomic_per_symbol_flags,
+        &mut dynamic_symbol_definitions,
+    )?;
+
     let mut script_sorted_sections = harvest_and_sort_script_sections(
         &mut group_states,
         &output_sections,
@@ -687,6 +694,37 @@ fn merge_dynamic_symbol_definitions<'data, P: Platform>(
     )?;
 
     Ok(dynamic_symbol_definitions)
+}
+
+fn create_canonical_plt_entries<'data, P: Platform>(
+    group_states: &[GroupState<'data, P>],
+    symbol_db: &SymbolDb<'data, P>,
+    per_symbol_flags: &AtomicPerSymbolFlags<'_>,
+    dynamic_symbol_definitions: &mut Vec<DynamicSymbolDefinition<'data, P>>,
+) -> Result {
+    timing_phase!("Create canonical PLT entries");
+
+    for group in group_states {
+        for file in &group.files {
+            let FileLayoutState::Dynamic(dynamic) = file else {
+                continue;
+            };
+
+            for symbol_id in dynamic.symbol_id_range {
+                if symbol_db.is_canonical(symbol_id)
+                    && per_symbol_flags
+                        .get_atomic(symbol_id)
+                        .get()
+                        .needs_canonical_plt()
+                {
+                    dynamic_symbol_definitions
+                        .push(P::create_dynamic_symbol_definition(symbol_db, symbol_id)?);
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 fn append_prelude_defsym_dynamic_symbols<'data, P: Platform>(

--- a/libwild/src/value_flags.rs
+++ b/libwild/src/value_flags.rs
@@ -106,6 +106,13 @@ bitflags! {
 
         /// Whether the symbol has a reference from non-IR code.
         const HAS_NON_IR_REF = 1 << 16;
+
+        /// Symbol needs a canonical PLT in order to preserve address identity.
+        const CANONICAL_PLT = 1 << 17;
+
+        /// We need a second GOT entry. i.e GOT->PLT->GOT. This is only used in conjunction with
+        /// canonical PLT entries.
+        const GOT_FOR_PLT_ENTRY = 1 << 18;
     }
 }
 
@@ -135,7 +142,9 @@ impl ValueFlags {
                 | ValueFlags::GOT_TLS_DESCRIPTOR
                 | ValueFlags::EXPORT_DYNAMIC
                 | ValueFlags::COPY_RELOCATION
-                | ValueFlags::IFUNC_GOT_FOR_ADDRESS,
+                | ValueFlags::IFUNC_GOT_FOR_ADDRESS
+                | ValueFlags::CANONICAL_PLT
+                | ValueFlags::GOT_FOR_PLT_ENTRY,
         )
     }
 
@@ -233,6 +242,16 @@ impl ValueFlags {
     #[must_use]
     pub(crate) fn needs_ifunc_got_for_address(self) -> bool {
         self.contains(ValueFlags::IFUNC_GOT_FOR_ADDRESS)
+    }
+
+    #[must_use]
+    pub(crate) fn needs_canonical_plt(self) -> bool {
+        self.contains(ValueFlags::CANONICAL_PLT)
+    }
+
+    #[must_use]
+    pub(crate) fn needs_canonical_plt_got_for_address(self) -> bool {
+        self.contains(ValueFlags::CANONICAL_PLT | ValueFlags::GOT_FOR_PLT_ENTRY)
     }
 
     #[must_use]

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -76,7 +76,6 @@ tests = [
 [skipped_groups.arch_x86_64]
 reason = "x86_64 specific tests"
 tests = [
-  "arch-x86_64-address-equality.sh",
   "arch-x86_64-comdat-signatures.sh",
   "arch-x86_64-empty-mergeable-section.sh",
   "arch-x86_64-execstack-if-needed.sh",
@@ -232,8 +231,6 @@ tests = [
 reason = "Not grouped yet"
 tests = [
   "as-needed-gc.sh",
-  "bno-symbolic.sh",
-  "canonical-plt.sh",
   "common-archive.sh",
   "common-ref.sh",
   "common-symbols.sh",

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -314,6 +314,9 @@
 //! binding=local|global|weak: Type: string. Asserts the binding of the symbol (STB_LOCAL,
 //! STB_GLOBAL or STB_WEAK).
 //!
+//! type=notype|object|func|section|file|common|tls|ifunc: Type: string. Asserts the ELF symbol
+//! type. This property is only supported for ELF symbols.
+//!
 //! line={num} Parses debug info to check that the symbol is on the line specified.
 //!
 //! ## Program Header properties
@@ -1989,6 +1992,9 @@ struct SymtabAssertions {
     size: Option<u64>,
 
     binding: Option<String>,
+
+    #[serde(rename = "type")]
+    symbol_type: Option<String>,
 
     line: Option<u64>,
 }
@@ -6476,6 +6482,40 @@ where
                 bail!(
                     "Expected symbol `{}` to have binding `{expected_binding}`, \
                      but it actually had binding `{actual_binding}`",
+                    exp.name
+                );
+            }
+        }
+
+        if let Some(expected_type) = exp.assertions.symbol_type.as_deref() {
+            let expected_type_value = match expected_type {
+                "notype" => object::elf::STT_NOTYPE,
+                "object" => object::elf::STT_OBJECT,
+                "func" => object::elf::STT_FUNC,
+                "section" => object::elf::STT_SECTION,
+                "file" => object::elf::STT_FILE,
+                "common" => object::elf::STT_COMMON,
+                "tls" => object::elf::STT_TLS,
+                "ifunc" => object::elf::STT_GNU_IFUNC,
+                _ => bail!(
+                    "Invalid type value `{expected_type}` for symbol `{}`. Must be one of: \
+                     notype, object, func, section, file, common, tls, ifunc",
+                    exp.name
+                ),
+            };
+
+            let object::SymbolFlags::Elf { st_info, .. } = sym.flags() else {
+                bail!(
+                    "Cannot assert ELF symbol type `{expected_type}` for non-ELF symbol `{}`",
+                    exp.name
+                );
+            };
+
+            let actual_type = st_info.st_type();
+            if actual_type != expected_type_value {
+                bail!(
+                    "Expected symbol `{}` to have type `{expected_type}`, but it actually had \
+                     type `{actual_type:?}`",
                     exp.name
                 );
             }

--- a/wild/tests/sources/elf/canonical-plt/canonical-plt-pic.c
+++ b/wild/tests/sources/elf/canonical-plt/canonical-plt-pic.c
@@ -1,0 +1,7 @@
+typedef void (*Func)(void);
+
+extern void foo(void);
+extern void imported_ifunc(void);
+
+Func get_foo_from_executable(void) { return foo; }
+Func get_imported_ifunc_from_executable(void) { return imported_ifunc; }

--- a/wild/tests/sources/elf/canonical-plt/canonical-plt-shared.c
+++ b/wild/tests/sources/elf/canonical-plt/canonical-plt-shared.c
@@ -1,0 +1,14 @@
+typedef void (*Func)(void);
+
+void foo(void) {}
+void called_only(void) {}
+
+static void imported_ifunc_impl(void) {}
+static Func imported_ifunc_resolver(void) { return imported_ifunc_impl; }
+__attribute__((ifunc("imported_ifunc_resolver"))) void imported_ifunc(void);
+
+static void called_ifunc_only_impl(void) {}
+static Func called_ifunc_only_resolver(void) { return called_ifunc_only_impl; }
+__attribute__((ifunc("called_ifunc_only_resolver"))) void called_ifunc_only(void);
+
+Func get_foo(void) { return foo; }

--- a/wild/tests/sources/elf/canonical-plt/canonical-plt.c
+++ b/wild/tests/sources/elf/canonical-plt/canonical-plt.c
@@ -1,0 +1,65 @@
+//#AbstractConfig:default
+//#RequiresGlibc:true
+//#CompArgs:-fno-pie
+//#Mode:dynamic
+//#Object:runtime.c
+//#Object:canonical-plt-pic.c:-fPIC
+//#ReferenceLinkers:bfd,lld
+//#Shared:canonical-plt-shared.c:-fPIC
+//#DiffIgnore:.dynamic.DT_NEEDED
+//#DiffIgnore:.dynamic.DT_RELA*
+
+//#Config:x86_64:default
+//#Arch:x86_64
+//#ExpectDynSym:called_only address=0
+//#ExpectDynSym:called_ifunc_only address=0,type=func
+//#ExpectDynSym:imported_ifunc type=func
+
+//#Config:other:default
+//#Arch:riscv64,loongarch64
+
+//#Config:aarch64:default
+//#Arch:aarch64
+//#DiffMatchAny:true
+
+#include "../common/runtime.h"
+
+typedef void (*Func)(void);
+
+extern void foo(void);
+extern void called_only(void);
+extern void called_ifunc_only(void);
+extern Func get_foo(void);
+extern Func get_foo_from_executable(void);
+extern Func get_imported_ifunc_from_executable(void);
+extern void imported_ifunc(void);
+
+void _start(void) {
+  runtime_init();
+
+  Func executable_address = foo;
+  Func shared_object_address = get_foo();
+  Func executable_pic_address = get_foo_from_executable();
+  Func imported_ifunc_address = imported_ifunc;
+
+  if (executable_address != shared_object_address) {
+    exit_syscall(100);
+  }
+
+  if (executable_address != executable_pic_address) {
+    exit_syscall(101);
+  }
+
+  if (imported_ifunc_address != get_imported_ifunc_from_executable()) {
+    exit_syscall(102);
+  }
+
+  executable_address();
+  shared_object_address();
+  executable_pic_address();
+  imported_ifunc_address();
+  called_only();
+  called_ifunc_only();
+
+  exit_syscall(42);
+}


### PR DESCRIPTION
Should fix #2469