### PR TITLE
port(wasm): Support `--demangle` and `--no-demangle`

### DIFF
--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -431,6 +431,15 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
 
     parser
         .declare()
+        .long("demangle")
+        .help("Demangle symbol names (default)")
+        .execute(|args, _modifier_stack| {
+            args.common_mut().demangle = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
         .long("no-demangle")
         .help("Disable symbol demangling")
         .execute(|args, _modifier_stack| {

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1636,12 +1636,21 @@ fn encode_wasm_section(section: &impl wasm_encoder::Section) -> Vec<u8> {
     bytes
 }
 
+fn demangle_symbol_name(name: &str, demangle: bool) -> Cow<'_, str> {
+    if demangle {
+        symbolic_demangle::demangle(name)
+    } else {
+        Cow::Borrowed(name)
+    }
+}
+
 fn build_name_section<'data>(
     layout: &WasmLayout<'data>,
     layout_inputs: &[WasmObjectLayoutInput<'data>],
     indices: &LinkerDefinedIndices,
     got_mem: &GotMem,
     got_func: &GotFunc,
+    demangle: bool,
 ) -> Option<wasm_encoder::NameSection> {
     let (n_func_imports, n_global_imports) = count_output_imports(layout);
     let n_funcs = n_func_imports + layout.function_type_indices.len();
@@ -1700,7 +1709,7 @@ fn build_name_section<'data>(
                     })
                     .map_or_else(
                         || format!("GOT.data.internal.{i}"),
-                        |sym| format!("GOT.data.internal.{sym}"),
+                        |sym| format!("GOT.data.internal.{}", demangle_symbol_name(sym, demangle)),
                     ),
                 GotMemDef::LinkerDefined(known) => {
                     let sym = std::str::from_utf8(known.name()).unwrap_or("?");
@@ -1716,7 +1725,7 @@ fn build_name_section<'data>(
     if let Some(got_base) = indices.got_func_global_base {
         got_func_names.reserve(got_func.entries.len());
         for (i, entry) in got_func.entries.iter().enumerate() {
-            got_func_names.push(got_func_debug_name(layout_inputs, entry, i));
+            got_func_names.push(got_func_debug_name(layout_inputs, entry, i, demangle));
         }
         for (i, name) in got_func_names.iter().enumerate() {
             set_name_first_wins(&mut global_names, got_base + i as u32, name.as_str());
@@ -1778,8 +1787,8 @@ fn build_name_section<'data>(
         }
     }
 
-    let function_map = name_map_from_dense(&function_names);
-    let global_map = name_map_from_dense(&global_names);
+    let function_map = name_map_from_dense(&function_names, demangle);
+    let global_map = name_map_from_dense(&global_names, demangle);
     if function_map.is_none() && global_map.is_none() {
         return None;
     }
@@ -1816,14 +1825,15 @@ fn set_name_first_wins<'a>(names: &mut Vec<Option<&'a str>>, index: u32, name: &
     }
 }
 
-fn name_map_from_dense(names: &[Option<&str>]) -> Option<NameMap> {
+fn name_map_from_dense(names: &[Option<&str>], demangle: bool) -> Option<NameMap> {
     if names.iter().all(Option::is_none) {
         return None;
     }
     let mut map = NameMap::new();
     for (idx, name) in names.iter().enumerate() {
         if let Some(name) = name {
-            map.append(idx as u32, name);
+            let name = demangle_symbol_name(name, demangle);
+            map.append(idx as u32, &name);
         }
     }
     Some(map)
@@ -1968,6 +1978,7 @@ impl<'data> WasmLayout<'data> {
         symbol_db: &SymbolDb<'data, Wasm>,
     ) -> Result {
         timing_phase!("Encode Wasm metadata sections");
+        let demangle = symbol_db.args.common().demangle;
 
         {
             timing_phase!("Encode Wasm type section");
@@ -2034,7 +2045,7 @@ impl<'data> WasmLayout<'data> {
         {
             timing_phase!("Encode Wasm name section");
             if let Some(name_section) =
-                build_name_section(self, layout_inputs, indices, got_mem, got_func)
+                build_name_section(self, layout_inputs, indices, got_mem, got_func, demangle)
             {
                 self.encoded_sections.name = Some(encode_wasm_section(&name_section));
             }
@@ -3522,6 +3533,7 @@ fn report_disallowed_unresolved_imports<'data>(
             if !seen.insert((file_display.clone(), name.to_owned())) {
                 continue;
             }
+            let name = demangle_symbol_name(name, symbol_db.args.common().demangle);
             errors.push(format!("{file_display}: undefined symbol: {name}"));
         }
     }
@@ -4468,7 +4480,8 @@ fn scan_layout_relocations(
         needs_table |= scan.needs_table;
         for key in scan.undefined_data_errors {
             if seen_undefined_data.insert(key.clone()) {
-                undefined_data_errors.push(format!("{}: undefined symbol: {}", key.0, key.1));
+                let name = demangle_symbol_name(&key.1, symbol_db.args.common().demangle);
+                undefined_data_errors.push(format!("{}: undefined symbol: {name}", key.0));
             }
         }
         table_index_symbol_indices[obj_idx] = scan.table_syms;
@@ -4643,6 +4656,7 @@ fn got_func_debug_name(
     layout_inputs: &[WasmObjectLayoutInput<'_>],
     entry: &GotFuncEntry,
     index: usize,
+    demangle: bool,
 ) -> String {
     let sym_name = layout_inputs.get(entry.object_index).and_then(|input| {
         input
@@ -4651,7 +4665,7 @@ fn got_func_debug_name(
             .and_then(|sym| wasm_symbol_name_str(input.data, sym))
     });
     match sym_name {
-        Some(name) => format!("GOT.func.internal.{name}"),
+        Some(name) => format!("GOT.func.internal.{}", demangle_symbol_name(name, demangle)),
         None => format!("GOT.func.internal.{index}"),
     }
 }

--- a/wild/tests/sources/wasm/demangle-got/demangle-got.cc
+++ b/wild/tests/sources/wasm/demangle-got/demangle-got.cc
@@ -1,0 +1,28 @@
+//#AbstractConfig:base
+//#CompArgs: -fPIC
+//#Object:demangle-got2.cc
+//#ExpectSection: name
+
+//#Config:default:base
+//#Contains: GOT.data.internal.Foo::value
+//#DoesNotContain: GOT.data.internal._ZN3Foo5valueE
+
+//#Config:no-demangle:base
+//#LinkArgs: --no-demangle
+//#Contains: GOT.data.internal._ZN3Foo5valueE
+//#DoesNotContain: GOT.data.internal.Foo::value
+
+//#Config:demangle:base
+//#LinkArgs: --no-demangle --demangle
+//#Contains: GOT.data.internal.Foo::value
+//#DoesNotContain: GOT.data.internal._ZN3Foo5valueE
+
+struct Foo {
+  static int value;
+};
+
+extern "C" void _start() {
+  if (Foo::value != 7) {
+    __builtin_trap();
+  }
+}

--- a/wild/tests/sources/wasm/demangle-got/demangle-got2.cc
+++ b/wild/tests/sources/wasm/demangle-got/demangle-got2.cc
@@ -1,0 +1,5 @@
+struct Foo {
+  static int value;
+};
+
+int Foo::value = 7;

--- a/wild/tests/sources/wasm/demangle-undefined-data/demangle-undefined-data.cc
+++ b/wild/tests/sources/wasm/demangle-undefined-data/demangle-undefined-data.cc
@@ -1,0 +1,18 @@
+//#AbstractConfig:base
+
+//#Config:default:base
+//#ExpectError: undefined symbol: Foo::missing_data
+
+//#Config:no-demangle:base
+//#LinkArgs: --no-demangle
+//#ExpectError: undefined symbol: _ZN3Foo12missing_dataE
+
+//#Config:demangle:base
+//#LinkArgs: --no-demangle --demangle
+//#ExpectError: undefined symbol: Foo::missing_data
+
+struct Foo {
+  static int missing_data;
+};
+
+extern "C" void _start() { Foo::missing_data = 1; }

--- a/wild/tests/sources/wasm/demangle-undefined/demangle-undefined.cc
+++ b/wild/tests/sources/wasm/demangle-undefined/demangle-undefined.cc
@@ -1,0 +1,21 @@
+//#AbstractConfig:base
+
+//#Config:default:base
+//#ExpectError: undefined symbol: Foo::missing\(\)
+
+//#Config:no-demangle:base
+//#LinkArgs: --no-demangle
+//#ExpectError: undefined symbol: _ZN3Foo7missingEv
+
+//#Config:demangle:base
+//#LinkArgs: --no-demangle --demangle
+//#ExpectError: undefined symbol: Foo::missing\(\)
+
+struct Foo {
+  void missing();
+};
+
+extern "C" void _start() {
+  Foo foo;
+  foo.missing();
+}

--- a/wild/tests/sources/wasm/demangle/demangle.cc
+++ b/wild/tests/sources/wasm/demangle/demangle.cc
@@ -22,24 +22,9 @@
 //#Contains: _ZN3Foo3barEv
 //#DoesNotContain: Foo::bar()
 
-//#Config:undefined:base
-//#CompArgs: -DUNDEFINED
-//#ExpectError: undefined symbol: Foo::missing\(\)
-
-//#Config:undefined-no-demangle:base
-//#CompArgs: -DUNDEFINED
-//#LinkArgs: --no-demangle
-//#ExpectError: undefined symbol: _ZN3Foo7missingEv
-
-//#Config:undefined-demangle:base
-//#CompArgs: -DUNDEFINED
-//#LinkArgs: --no-demangle --demangle
-//#ExpectError: undefined symbol: Foo::missing\(\)
-
 struct Foo {
   Foo();
   void bar();
-  void missing();
 };
 
 Foo::Foo() {}
@@ -48,9 +33,5 @@ void Foo::bar() {}
 
 extern "C" void _start() {
   Foo foo;
-#ifdef UNDEFINED
-  foo.missing();
-#else
   foo.bar();
-#endif
 }

--- a/wild/tests/sources/wasm/demangle/demangle.cc
+++ b/wild/tests/sources/wasm/demangle/demangle.cc
@@ -1,0 +1,56 @@
+//#AbstractConfig:base
+//#ExpectSection: name
+
+// Default is `--demangle`.
+//#Config:default:base
+//#Contains: Foo::bar()
+//#DoesNotContain: _ZN3Foo3barEv
+
+//#Config:no-demangle:base
+//#LinkArgs: --no-demangle
+//#Contains: _ZN3Foo3barEv
+//#DoesNotContain: Foo::bar()
+
+//#Config:demangle:base
+//#LinkArgs: --no-demangle --demangle
+//#Contains: Foo::bar()
+//#DoesNotContain: _ZN3Foo3barEv
+
+// Single-dash form used by `clang -Wl,-no-demangle`.
+//#Config:single-dash-no-demangle:base
+//#LinkArgs: -no-demangle
+//#Contains: _ZN3Foo3barEv
+//#DoesNotContain: Foo::bar()
+
+//#Config:undefined:base
+//#CompArgs: -DUNDEFINED
+//#ExpectError: undefined symbol: Foo::missing\(\)
+
+//#Config:undefined-no-demangle:base
+//#CompArgs: -DUNDEFINED
+//#LinkArgs: --no-demangle
+//#ExpectError: undefined symbol: _ZN3Foo7missingEv
+
+//#Config:undefined-demangle:base
+//#CompArgs: -DUNDEFINED
+//#LinkArgs: --no-demangle --demangle
+//#ExpectError: undefined symbol: Foo::missing\(\)
+
+struct Foo {
+  Foo();
+  void bar();
+  void missing();
+};
+
+Foo::Foo() {}
+
+void Foo::bar() {}
+
+extern "C" void _start() {
+  Foo foo;
+#ifdef UNDEFINED
+  foo.missing();
+#else
+  foo.bar();
+#endif
+}


### PR DESCRIPTION
As mentioned in the original issue, when demangling occurs, the contents of the name section also follow suit.

Close #2339 
Part of #1431 