### PR TITLE
fix(tests): require GCC 14+ for linker plug-in

### DIFF
--- a/libwild/src/linker_plugins.rs
+++ b/libwild/src/linker_plugins.rs
@@ -128,6 +128,7 @@ struct WrapSymbols<'data>(&'data [*const libc::c_char]);
 unsafe impl Send for WrapSymbols<'_> {}
 unsafe impl Sync for WrapSymbols<'_> {}
 
+// The API version got introduced in GCC 14.
 const API_VERSION: u32 = 1;
 
 #[derive(Debug)]

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -7594,6 +7594,33 @@ fn verify_linker_plugin_requirements(
 
             verify_command_success(&mut command)
                 .context("Can't use compiler with linker-plugin")?;
+
+            // Our linker plugin implementation requires at least GCC 14 (where the LAPI_V1 version
+            // got added).
+            let output = Command::new(&linker_driver_string)
+                .arg("--version")
+                .output()
+                .context("Can't execute compiler with --version")?;
+            let compiler_version = String::from_utf8_lossy(&output.stdout);
+            if compiler_version.contains("gcc") || compiler_version.contains("g++") {
+                let mut command = Command::new(&linker_driver_string);
+                let output = command
+                    .arg("-dumpfullversion")
+                    .output()
+                    .context("Can't execute compiler with -dumpversion")?;
+                let compiler_version = String::from_utf8_lossy(&output.stdout)
+                    .split_once(".")
+                    .context("expected comma in the compiler version")?
+                    .0
+                    .parse::<u64>()
+                    .context("Can't parse compiler version")?;
+
+                const MINIMAL_GCC_VERSION: u64 = 14;
+                ensure!(
+                    compiler_version >= MINIMAL_GCC_VERSION,
+                    "Expected GCC LTO plug-in version {MINIMAL_GCC_VERSION}, got: {compiler_version}"
+                );
+            }
         }
     }
 

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -7610,9 +7610,7 @@ fn verify_linker_plugin_requirements(
                     .context("Can't execute compiler with -dumpversion")?;
                 let compiler_version = String::from_utf8_lossy(&output.stdout)
                     .split_once(".")
-                    .context("expected comma in the compiler version")?
-                    .0
-                    .parse::<u64>()
+                    .and_then(|version| version.0.parse::<u64>().ok())
                     .context("Can't parse compiler version")?;
 
                 const MINIMAL_GCC_VERSION: u64 = 14;


### PR DESCRIPTION
Noticed while testing on my RISC-V board, where I didn't get recent enough version of the GCC compiler.