### PR TITLE
chore: address cargo clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ resolver = "2"
 repository = "https://github.com/wild-linker/wild"
 license = "MIT OR Apache-2.0"
 version = "0.10.0"
-readme = "README.md"
 rust-version = "1.97.1"
 edition = "2024"
 

--- a/benchmarks/runner/Cargo.toml
+++ b/benchmarks/runner/Cargo.toml
@@ -13,3 +13,6 @@ postcard.workspace = true
 serde.workspace = true
 toml.workspace = true
 wait4.workspace = true
+
+[lints]
+workspace = true

--- a/benchmarks/runner/src/benchmarking.rs
+++ b/benchmarks/runner/src/benchmarking.rs
@@ -50,7 +50,7 @@ pub(crate) fn run_bench(args: &BenchArgs, config: &Config) -> Result {
 
     let results = run(&bins, &benchmarks, args)?;
 
-    let output_path = crate::default_result_path(config, &args.output);
+    let output_path = crate::default_result_path(config, args.output.as_ref());
 
     std::fs::write(&output_path, postcard::to_stdvec(&results)?)
         .with_context(|| format!("Failed to write `{}`", output_path.display()))?;
@@ -95,9 +95,9 @@ fn run(bins: &[Bin], benchmarks: &[Benchmark], args: &BenchArgs) -> Result<Bench
             benchmarks.len()
         );
 
-        let progress_bar = indicatif::ProgressBar::new(
-            (args.num_batches * args.batch_size * bins.len() as u32) as u64,
-        )
+        let progress_bar = indicatif::ProgressBar::new(u64::from(
+            args.num_batches * args.batch_size * bins.len() as u32,
+        ))
         .with_style(indicatif::ProgressStyle::with_template(
             "{msg} {spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}]",
         )?)
@@ -126,7 +126,7 @@ fn run(bins: &[Bin], benchmarks: &[Benchmark], args: &BenchArgs) -> Result<Bench
                 bench_results.push(BatchResult {
                     bin: bin.clone(),
                     runs: bin_results,
-                })
+                });
             }
         }
         bench_results.sort_by_key(|b| b.bin.index);
@@ -215,7 +215,7 @@ fn run_once(
     let elapsed = start.elapsed();
 
     if !res_use.status.success() {
-        bail!("Error returned from {command:?}\n{text_out}",)
+        bail!("Error returned from {command:?}\n{text_out}")
     }
 
     // Make sure that the linker runs without warning. Specifically what we care about is that the
@@ -254,7 +254,7 @@ fn find_benchmarks(args: &BenchArgs, config: &Config) -> Result<Vec<Benchmark>> 
     for (name, config) in &config.benches {
         available.remove(name);
         if !config.skip {
-            benchmarks.push(Benchmark::new(dir.join(name), config.clone())?);
+            benchmarks.push(Benchmark::new(&dir.join(name), config.clone())?);
         }
     }
 
@@ -288,12 +288,11 @@ fn filter_benchmarks_by_wild_version(benchmarks: Vec<Benchmark>, bins: &[Bin]) -
     benchmarks
         .into_iter()
         .filter(|bench| {
-            if !bench.supports_wild_version(maximum_wild_version) {
+            let supported = bench.supports_wild_version(maximum_wild_version);
+            if !supported {
                 println!("Skipping benchmark {bench} due to minimum version requirement");
-                false
-            } else {
-                true
             }
+            supported
         })
         .collect()
 }

--- a/benchmarks/runner/src/main.rs
+++ b/benchmarks/runner/src/main.rs
@@ -145,7 +145,7 @@ fn main() -> Result {
         Subcommand::Report(report_args) => {
             for config_path in &report_args.configs()? {
                 let config = config::Config::load(config_path)?;
-                reporting::run_report(&report_args, &config)?
+                reporting::run_report(&report_args, &config)?;
             }
             Ok(())
         }
@@ -228,7 +228,7 @@ impl LinkerKind {
         }
     }
 
-    fn supports_arg(&self, arg: &str) -> bool {
+    fn supports_arg(self, arg: &str) -> bool {
         match arg {
             "--no-fork" => matches!(self, LinkerKind::Wild | LinkerKind::Mold),
             _ => true,
@@ -270,7 +270,7 @@ impl Bin {
 }
 
 impl Benchmark {
-    fn new(bench_dir: PathBuf, bench_config: BenchConfig) -> Result<Benchmark> {
+    fn new(bench_dir: &Path, bench_config: BenchConfig) -> Result<Benchmark> {
         let name = bench_dir
             .file_name()
             .context("Invalid filename")?
@@ -325,32 +325,32 @@ impl LinkerIdentifier {
             if let Some(r) = rest.strip_prefix("version ") {
                 rest = r;
             }
-            version = take_word(&mut rest)?.to_owned();
+            version = take_word(&mut rest).to_owned();
             if !bin_path.to_string_lossy().contains(&version) {
                 // For wild, we only consider the version to be true if the path to the linker
                 // contains the version number, otherwise we use the git hash.
-                hash = take_word(&mut rest).map(|w| w.replace(['(', ')'], ""));
+                hash = Some(take_word(&mut rest).replace(['(', ')'], ""));
             }
 
             kind = LinkerKind::Wild;
         } else if let Some(mut rest) = version_line.strip_prefix("LLD ") {
             kind = LinkerKind::Lld;
-            version = take_word(&mut rest)?.to_owned();
+            version = take_word(&mut rest).to_owned();
         } else if let Some(mut rest) = version_line.strip_prefix("Ubuntu LLD ") {
             kind = LinkerKind::Lld;
-            version = take_word(&mut rest)?.to_owned();
+            version = take_word(&mut rest).to_owned();
             variant = Some("Ubuntu".to_owned());
         } else if let Some(mut rest) = version_line.strip_prefix("Debian LLD ") {
             kind = LinkerKind::Lld;
-            version = take_word(&mut rest)?.to_owned();
+            version = take_word(&mut rest).to_owned();
             variant = Some("Debian".to_owned());
         } else if let Some(mut rest) = version_line.strip_prefix("mold ") {
             kind = LinkerKind::Mold;
-            version = take_word(&mut rest)?.to_owned();
+            version = take_word(&mut rest).to_owned();
         } else {
             let mut rest = version_line.strip_prefix("GNU ld (GNU Binutils for Ubuntu) ")?;
             kind = LinkerKind::Bfd;
-            version = take_word(&mut rest)?.to_owned();
+            version = take_word(&mut rest).to_owned();
             variant = Some("Ubuntu".to_owned());
         }
 
@@ -386,12 +386,12 @@ impl LinkerIdentifier {
     }
 }
 
-fn take_word<'a>(input: &mut &'a str) -> Option<&'a str> {
+fn take_word<'a>(input: &mut &'a str) -> &'a str {
     *input = input.trim();
     let i = input.find(' ').unwrap_or(input.len());
     let (word, rest) = input.split_at(i);
     *input = rest;
-    Some(word)
+    word
 }
 
 impl Display for Bin {
@@ -431,7 +431,7 @@ impl Display for Benchmark {
 }
 
 fn parse_version_number(v: &str) -> Result<Vec<u32>> {
-    v.split(".")
+    v.split('.')
         .map(|p| {
             p.parse()
                 .with_context(|| format!("Failed to parse version `{v}`"))
@@ -439,8 +439,8 @@ fn parse_version_number(v: &str) -> Result<Vec<u32>> {
         .collect()
 }
 
-fn default_result_path(config: &Config, path_buf: &Option<PathBuf>) -> PathBuf {
-    path_buf.clone().unwrap_or_else(|| {
+fn default_result_path(config: &Config, path_buf: Option<&PathBuf>) -> PathBuf {
+    path_buf.cloned().unwrap_or_else(|| {
         PathBuf::from("benchmarks").join(format!("{}.bench-results", config.name))
     })
 }

--- a/benchmarks/runner/src/reporting.rs
+++ b/benchmarks/runner/src/reporting.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 const IMAGES_SUBDIR_NAME: &str = "images";
 
 pub(crate) fn run_report(args: &ReportArgs, config: &Config) -> Result {
-    let input_path = crate::default_result_path(config, &args.input);
+    let input_path = crate::default_result_path(config, args.input.as_ref());
     let report_dir = &args.dir;
     let target_subdir = report_dir.join(IMAGES_SUBDIR_NAME).join(&config.name);
     std::fs::create_dir_all(&target_subdir)
@@ -116,8 +116,8 @@ impl ReportMode {
         benchmark
     }
 
-    fn should_keep_run(&self, run: &crate::Run) -> bool {
-        run.extra_flags.iter().any(|f| f == "--no-fork") == (self == &ReportMode::Memory)
+    fn should_keep_run(self, run: &crate::Run) -> bool {
+        run.extra_flags.iter().any(|f| f == "--no-fork") == (self == ReportMode::Memory)
     }
 
     fn unit_name(self) -> &'static str {
@@ -130,7 +130,7 @@ impl ReportMode {
     fn unit_multiplier(self) -> f64 {
         match self {
             ReportMode::Time => 1000_f64,
-            ReportMode::Memory => 1_f64 / (1024 * 1024) as f64,
+            ReportMode::Memory => 1_f64 / f64::from(1024 * 1024),
         }
     }
 
@@ -139,6 +139,7 @@ impl ReportMode {
         mean(b, self) * self.unit_multiplier()
     }
 
+    #[allow(clippy::cast_precision_loss)]
     fn raw_value(self, r: &crate::Run) -> f64 {
         match self {
             ReportMode::Time => r.elapsed.as_secs_f64(),
@@ -154,11 +155,13 @@ fn alt_text(mode: ReportMode, benchmark: &BenchmarkResult) -> String {
     }
 }
 
+#[allow(clippy::cast_precision_loss)]
 fn mean(batch_result: &BatchResult, mode: ReportMode) -> f64 {
     let total: f64 = batch_result.runs.iter().map(|r| mode.raw_value(r)).sum();
     total / batch_result.runs.len() as f64
 }
 
+#[allow(clippy::cast_precision_loss)]
 fn std_def(batch_result: &BatchResult, mode: ReportMode) -> f64 {
     let mean = mean(batch_result, mode);
     let sum: f64 = batch_result
@@ -172,6 +175,7 @@ fn std_def(batch_result: &BatchResult, mode: ReportMode) -> f64 {
     (sum / batch_result.runs.len() as f64).sqrt()
 }
 
+#[allow(clippy::cast_precision_loss)]
 fn std_err(batch_result: &BatchResult, mode: ReportMode) -> f64 {
     std_def(batch_result, mode) / (batch_result.runs.len() as f64).sqrt()
 }
@@ -257,12 +261,12 @@ font-size="16" fill="{fg}" transform="rotate(270, 5, 288)">{unit}</text>"#
 
     let unit_label_x = left - 10;
 
-    let value_to_y = |v: f64| bottom - (v / chart_max as f64 * (bottom - top) as f64) as u32;
+    let value_to_y = |v: f64| bottom - (v / f64::from(chart_max) * f64::from(bottom - top)) as u32;
 
     for val in (0..=chart_max).step_by(step as usize) {
         // Draw horizontal lines.
         let val_str = format_number(val);
-        let y = value_to_y(val as f64);
+        let y = value_to_y(f64::from(val));
         writeln!(
             &mut svg,
             r#"<line x1="{left}" y1="{y}" x2="{right}" y2="{y}" stroke="{fg}" />"#
@@ -315,11 +319,7 @@ font-size="16" fill="{fg}" transform="rotate(270, 5, 288)">{unit}</text>"#
 
         // Draw the percent change relative to the baseline (the last linker).
         let y = chart_height - 20;
-        let baseline = benchmark
-            .batches
-            .last()
-            .map(|b| mode.get_value(b))
-            .unwrap_or(0.0);
+        let baseline = benchmark.batches.last().map_or(0.0, |b| mode.get_value(b));
         let extra = ((value / baseline) * 100_f64).round() as i32 - 100;
         writeln!(
             &mut svg,
@@ -327,7 +327,7 @@ font-size="16" fill="{fg}" transform="rotate(270, 5, 288)">{unit}</text>"#
         )?;
     }
 
-    writeln!(&mut svg, r#"</svg>"#)?;
+    writeln!(&mut svg, r"</svg>")?;
 
     std::fs::write(&svg_path, &svg)
         .with_context(|| format!("Failed to write `{}`", svg_path.display()))?;
@@ -389,12 +389,12 @@ fn merge_batches(benchmark: &mut BenchmarkResult) {
         .unwrap_or(0) as usize;
 
     let mut by_bin: Vec<Option<BatchResult>> = vec![None; num_bins];
-    std::mem::take(&mut benchmark.batches)
-        .into_iter()
-        .for_each(|mut b| match &mut by_bin[b.bin.index as usize] {
+    for mut b in std::mem::take(&mut benchmark.batches) {
+        match &mut by_bin[b.bin.index as usize] {
             Some(existing) => existing.runs.append(&mut b.runs),
             n => *n = Some(b),
-        });
+        }
+    }
 
     benchmark.batches = by_bin.into_iter().flatten().collect();
 }

--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -554,10 +554,9 @@ mod tests {
                 .extra_features,
             ["b"]
         );
-        assert!(
-            parse_args(["--extra-features=", "-o", "out.wasm"])
-                .extra_features
-                .is_empty()
+        assert_eq!(
+            parse_args(["--extra-features=", "-o", "out.wasm"]).extra_features,
+            Vec::<String>::new()
         );
     }
 }

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -201,7 +201,7 @@ impl<T: Default + PartialEq> OutputSectionPartMap<T> {
             let part_id_range = section_id.part_id_range::<P>();
             let max_alignment = self.max_alignment(part_id_range.clone(), output_sections);
 
-            for (part_id, input) in self.in_range(part_id_range.clone()) {
+            for (part_id, input) in self.in_range(part_id_range) {
                 let alignment = part_id.alignment(output_sections).min(max_alignment);
                 *output.get_mut(part_id) = cb(part_id, alignment, input);
             }

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -74,3 +74,6 @@ macho = ["libwild/macho"]
 external_tests = ["mold_tests", "lld_tests"]
 mold_tests = []
 lld_tests = []
+
+[lints]
+workspace = true

--- a/wild/build.rs
+++ b/wild/build.rs
@@ -51,8 +51,7 @@ fn has_changes_relative_to(version_ref: &str) -> bool {
         .arg("--quiet")
         .arg(version_ref)
         .output()
-        .map(|output| !output.status.success())
-        .unwrap_or(true)
+        .map_or(true, |output| !output.status.success())
 }
 
 /// Returns the hash of the merge-point with origin/main.

--- a/wild/tests/external_tests/lld_tests.rs
+++ b/wild/tests/external_tests/lld_tests.rs
@@ -157,8 +157,8 @@ fn run_lit_for_arch(
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
-    print!("{}", stdout);
-    eprint!("{}", stderr);
+    print!("{stdout}");
+    eprint!("{stderr}");
 
     if !output.status.success() {
         return Err(format!("lit exited with status: {}", output.status).into());

--- a/wild/tests/external_tests/mold_tests.rs
+++ b/wild/tests/external_tests/mold_tests.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::path::Path;
-use std::path::PathBuf;
 use std::process::Output;
 use std::str::FromStr;
 use std::sync::OnceLock;
@@ -91,14 +90,14 @@ pub(crate) fn collect_tests(
 
             if !should_skip_mold_test(&path) && !should_skip_by_local_config(&path, test_config) {
                 tests.push(Trial::test(name, move || {
-                    check_mold_tests_regression(path).map_err(|e| Failed::from(e.to_string()))
+                    check_mold_tests_regression(&path).map_err(|e| Failed::from(e.to_string()))
                 }));
             } else if should_skip_mold_test_by_toml(&path)
                 && !should_skip_mold_test_by_arch(&path)
                 && !should_skip_by_local_config(&path, test_config)
             {
                 tests.push(Trial::test(format!("{name}/expect_failure"), move || {
-                    verify_skipped_mold_tests_still_fail(path)
+                    verify_skipped_mold_tests_still_fail(&path)
                         .map_err(|e| Failed::from(e.to_string()))
                 }));
             }
@@ -107,8 +106,8 @@ pub(crate) fn collect_tests(
     Ok(())
 }
 
-fn check_mold_tests_regression(mold_test: PathBuf) -> Result {
-    let output = run_mold_test(&mold_test)?;
+fn check_mold_tests_regression(mold_test: &Path) -> Result {
+    let output = run_mold_test(mold_test)?;
     if !output.status.success() {
         let error_message = format!(
             "Mold test `{}` failed with status: {}\nOutput:\n{}",
@@ -122,8 +121,8 @@ fn check_mold_tests_regression(mold_test: PathBuf) -> Result {
     Ok(())
 }
 
-fn verify_skipped_mold_tests_still_fail(mold_test: PathBuf) -> Result {
-    let output = run_mold_test(&mold_test)?;
+fn verify_skipped_mold_tests_still_fail(mold_test: &Path) -> Result {
+    let output = run_mold_test(mold_test)?;
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
         if stdout.lines().any(|line| line.trim() == "skipped") {
@@ -152,26 +151,28 @@ fn verify_skipped_mold_tests_still_fail(mold_test: PathBuf) -> Result {
     Ok(())
 }
 
-fn load_skip_tests_config() -> &'static Option<Vec<String>> {
-    SKIP_TESTS_NAME.get_or_init(|| {
-        let skip_tests_path = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests")
-            .join("external_tests")
-            .join("mold_skip_tests.toml");
+fn load_skip_tests_config() -> Option<&'static Vec<String>> {
+    SKIP_TESTS_NAME
+        .get_or_init(|| {
+            let skip_tests_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests")
+                .join("external_tests")
+                .join("mold_skip_tests.toml");
 
-        fs::read_to_string(&skip_tests_path)
-            .map(|content| {
-                let config: Config =
-                    toml::from_str(&content).expect("Failed to parse skip_tests.toml");
+            fs::read_to_string(&skip_tests_path)
+                .map(|content| {
+                    let config: Config =
+                        toml::from_str(&content).expect("Failed to parse skip_tests.toml");
 
-                config
-                    .skipped_groups
-                    .into_values()
-                    .flat_map(|group| group.tests)
-                    .collect()
-            })
-            .ok()
-    })
+                    config
+                        .skipped_groups
+                        .into_values()
+                        .flat_map(|group| group.tests)
+                        .collect()
+                })
+                .ok()
+        })
+        .as_ref()
 }
 
 fn should_skip_mold_test(path: &Path) -> bool {

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -472,7 +472,7 @@ fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter, test_config: &TestConf
                     ),
                 )?;
 
-                let program_inputs = ProgramInputs::new(primary_source_file.clone())?;
+                let program_inputs = ProgramInputs::new(primary_source_file);
 
                 for config in configs {
                     if config.should_skip(arch) {
@@ -556,7 +556,7 @@ struct WasmModuleInfo {
     memories: Vec<wasmparser::MemoryType>,
 }
 
-fn i32_const_from_expr(expr: wasmparser::ConstExpr<'_>) -> Option<i32> {
+fn i32_const_from_expr(expr: &wasmparser::ConstExpr<'_>) -> Option<i32> {
     let mut reader = expr.get_operators_reader();
     match reader.read().ok()? {
         wasmparser::Operator::I32Const { value } => Some(value),
@@ -638,7 +638,7 @@ impl WasmModuleInfo {
                         let global = global.with_context(|| {
                             format!("Invalid global entry in {}", path.display())
                         })?;
-                        defined_global_i32.push(i32_const_from_expr(global.init_expr));
+                        defined_global_i32.push(i32_const_from_expr(&global.init_expr));
                     }
                 }
                 Payload::ExportSection(section) => {
@@ -1146,7 +1146,7 @@ const ALL_ARCHITECTURES: &[Architecture] = &[
 ];
 
 impl Architecture {
-    fn emulation_name(&self) -> &'static str {
+    fn emulation_name(self) -> &'static str {
         match self {
             Architecture::X86_64 => "elf_x86_64",
             Architecture::AArch64 => "aarch64elf",
@@ -1159,21 +1159,21 @@ impl Architecture {
 
     /// The architecture prefix used in target triples / cross-toolchain names. This differs from
     /// the short name (`Display`) for ppc64le, whose triple prefix is `powerpc64le`.
-    fn triple_arch(&self) -> String {
+    fn triple_arch(self) -> String {
         match self {
             Architecture::Ppc64 => "powerpc64le".to_owned(),
             _ => self.to_string(),
         }
     }
 
-    fn darwin_arch_name(&self) -> &'static str {
+    fn darwin_arch_name(self) -> &'static str {
         match self {
             Architecture::AArch64 => "arm64",
             _ => panic!("Unsupported architecture {self} for darwin"),
         }
     }
 
-    fn default_target_triple(&self, platform: PlatformKind) -> String {
+    fn default_target_triple(self, platform: PlatformKind) -> String {
         match platform {
             PlatformKind::Elf => {
                 if cfg!(target_os = "freebsd") {
@@ -1187,7 +1187,7 @@ impl Architecture {
         }
     }
 
-    fn default_target_triple_rustc(&self, platform: PlatformKind) -> String {
+    fn default_target_triple_rustc(self, platform: PlatformKind) -> String {
         match (platform, self) {
             (PlatformKind::Elf, Architecture::RiscV64) => "riscv64gc-unknown-linux-gnu".to_string(),
             (PlatformKind::Wasm, _) => "wasm32-wasip1".to_string(),
@@ -1195,7 +1195,7 @@ impl Architecture {
         }
     }
 
-    fn cross_triplet(&self) -> String {
+    fn cross_triplet(self) -> String {
         let arch = self.triple_arch();
         let suse_triplet = format!("{arch}-suse-linux");
         if std::path::Path::new(&format!("/usr/{suse_triplet}/sys-root")).exists() {
@@ -1204,7 +1204,7 @@ impl Architecture {
         format!("{arch}-linux-gnu")
     }
 
-    fn get_cross_sysroot_path(&self) -> String {
+    fn get_cross_sysroot_path(self) -> String {
         let triplet = self.cross_triplet();
         if triplet.ends_with("-suse-linux") {
             format!("/usr/{triplet}/sys-root")
@@ -1215,7 +1215,7 @@ impl Architecture {
 
     /// Returns extra library directories that should be added to `LD_LIBRARY_PATH` when running
     /// binaries under qemu.
-    fn qemu_extra_lib_paths(&self) -> Vec<String> {
+    fn qemu_extra_lib_paths(self) -> Vec<String> {
         let triplet = self.cross_triplet();
         let gcc_base = format!("/usr/lib64/gcc/{triplet}");
         let Ok(entries) = std::fs::read_dir(&gcc_base) else {
@@ -1290,7 +1290,7 @@ fn get_dynamic_linker(path: impl AsRef<Path>) -> Option<String> {
     // Remove null terminator.
     interp_data.pop();
 
-    String::from_utf8(interp_data.to_owned()).ok()
+    String::from_utf8(interp_data.clone()).ok()
 }
 
 #[allow(unreachable_code)]
@@ -1645,15 +1645,14 @@ fn check_sframe_support_for_arch(arch: Architecture) -> bool {
 ///
 /// TODO: This should be unnecessary once more various distributions have updated glibc.
 fn run_sframe_backtrace_test(arch: Architecture) -> bool {
-    let temp_dir = match tempfile::tempdir() {
-        Ok(d) => d,
-        Err(_) => return false,
+    let Ok(temp_dir) = tempfile::tempdir() else {
+        return false;
     };
 
     let source_path = temp_dir.path().join("sframe_test.c");
     let obj_path = temp_dir.path().join("sframe_test.o");
     let binary_path = temp_dir.path().join("sframe_test");
-    let test_code = r#"
+    let test_code = r"
 #define _GNU_SOURCE
 #include <execinfo.h>
 #include <stdlib.h>
@@ -1675,7 +1674,7 @@ __attribute__((noinline)) int inner(void) {
 int main(void) {
     return inner();
 }
-"#;
+";
 
     if std::fs::write(&source_path, test_code).is_err() {
         return false;
@@ -1703,14 +1702,10 @@ int main(void) {
         .arg(&obj_path);
 
     if let Some(ref sysroot) = sysroot {
-        compile_cmd.arg(format!("--sysroot={}", sysroot));
+        compile_cmd.arg(format!("--sysroot={sysroot}"));
     }
 
-    if !compile_cmd
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-    {
+    if !compile_cmd.output().is_ok_and(|o| o.status.success()) {
         return false;
     }
 
@@ -1718,20 +1713,16 @@ int main(void) {
     link_cmd.arg(&obj_path).arg("-o").arg(&binary_path);
 
     if let Some(ref sysroot) = sysroot {
-        link_cmd.arg(format!("--sysroot={}", sysroot));
+        link_cmd.arg(format!("--sysroot={sysroot}"));
     }
 
-    if !link_cmd
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-    {
+    if !link_cmd.output().is_ok_and(|o| o.status.success()) {
         return false;
     }
 
     // Remove .eh_frame and .eh_frame_hdr sections to force SFrame-only unwinding
     let objcopy = if is_cross {
-        format!("{}-linux-gnu-objcopy", arch)
+        format!("{arch}-linux-gnu-objcopy")
     } else {
         "objcopy".to_string()
     };
@@ -1742,7 +1733,7 @@ int main(void) {
         .arg(&binary_path)
         .output();
 
-    if !objcopy_result.map(|o| o.status.success()).unwrap_or(false) {
+    if !objcopy_result.is_ok_and(|o| o.status.success()) {
         return false;
     }
 
@@ -2089,14 +2080,14 @@ struct ArgumentSet {
 }
 
 impl ArgumentSet {
-    fn parse(s: &str) -> Result<ArgumentSet> {
-        Ok(ArgumentSet {
+    fn parse(s: &str) -> ArgumentSet {
+        ArgumentSet {
             args: s
                 .split(' ')
                 .map(str::to_owned)
                 .filter(|s| !s.is_empty())
                 .collect(),
-        })
+        }
     }
 
     fn default_for_compiling() -> Self {
@@ -2218,7 +2209,7 @@ fn parse_configs(src_filename: &Path, default_config: &Config) -> Result<Vec<Con
                 &mut configs,
                 is_rust,
             )
-            .with_context(|| format!("problematic directive line: '{}'", rest))
+            .with_context(|| format!("problematic directive line: '{rest}'"))
             .with_context(|| {
                 format!(
                     "Failed to process test directive {}:{}",
@@ -2382,7 +2373,7 @@ fn process_directive(
             if config.variant_num.is_some() {
                 bail!("Variant can only be specified once per config");
             }
-            config.variant_num = Some(arg.parse()?)
+            config.variant_num = Some(arg.parse()?);
         }
         "LinkArgs" => {
             if is_rust {
@@ -2395,9 +2386,9 @@ fn process_directive(
                 config.tracked_files.push(src_path.clone());
                 let with_replaced_path =
                     arg.replace(&format!("./{filename}"), &src_path.display().to_string());
-                config.linker_args = ArgumentSet::parse(&with_replaced_path)?
+                config.linker_args = ArgumentSet::parse(&with_replaced_path);
             } else {
-                config.linker_args = ArgumentSet::parse(&arg)?
+                config.linker_args = ArgumentSet::parse(&arg);
             }
         }
         "PostLinkArgs" => {
@@ -2405,13 +2396,13 @@ fn process_directive(
                 bail!("PostLinkArgs is not used when building Rust code");
             }
             let arg = expand_test_arg_placeholders(arg, config);
-            config.post_linker_args = ArgumentSet::parse(&arg)?
+            config.post_linker_args = ArgumentSet::parse(&arg);
         }
         "LinkSoArgs" => {
             if is_rust {
                 bail!("LinkSoArgs is not used when building Rust code");
             }
-            config.linker_so_args = ArgumentSet::parse(arg)?
+            config.linker_so_args = ArgumentSet::parse(arg);
         }
         "SoSingleLinker" => {
             config.so_single_linker = Some(
@@ -2426,14 +2417,14 @@ fn process_directive(
         "LinkerDriver" => {
             config.linker_driver = LinkerDriver::parse(arg)?;
         }
-        "WildExtraLinkArgs" => config.wild_extra_linker_args = ArgumentSet::parse(arg)?,
+        "WildExtraLinkArgs" => config.wild_extra_linker_args = ArgumentSet::parse(arg),
         "CompArgs" => {
             let arg = expand_test_arg_placeholders(arg, config);
-            config.compiler_args = ArgumentSet::parse(&arg)?
+            config.compiler_args = ArgumentSet::parse(&arg);
         }
         "CompSoArgs" => {
             let arg = expand_test_arg_placeholders(arg, config);
-            config.compiler_so_args = ArgumentSet::parse(&arg)?
+            config.compiler_so_args = ArgumentSet::parse(&arg);
         }
         "ExpectSym" => config
             .assertions
@@ -2550,7 +2541,7 @@ fn process_directive(
             .absent_dynamic_entries
             .push(arg.to_owned()),
         "ExpectLoadAlignment" => {
-            let alignment_strs = arg.split(" ").map(str::trim);
+            let alignment_strs = arg.split(' ').map(str::trim);
             let alignments = alignment_strs.map(parse_number);
             config.assertions.expected_load_alignments =
                 alignments.collect::<Result<Vec<u64>>>()?;
@@ -2620,7 +2611,7 @@ fn process_directive(
         }
         "Cross" => config.cross_enabled = arg.parse()?,
         "SkipOverlapSegmentsCheck" => {
-            config.assertions.skip_overlap_segments_check = arg.parse()?
+            config.assertions.skip_overlap_segments_check = arg.parse()?;
         }
         "ExpectError" => {
             config.expect_stderr.push(ErrorMatcher::new(arg)?);
@@ -2688,12 +2679,12 @@ fn process_directive(
             }
 
             let files = arg
-                .split(",")
+                .split(',')
                 .map(|arg| {
-                    let (filename, comp_args) = arg.split_once(":").unwrap_or((arg, ""));
+                    let (filename, comp_args) = arg.split_once(':').unwrap_or((arg, ""));
                     Ok(FilenameArgumentPair::new(
                         &config.source_path(filename),
-                        ArgumentSet::parse(comp_args)?,
+                        ArgumentSet::parse(comp_args),
                     ))
                 })
                 .collect::<Result<Vec<_>>>()?;
@@ -2704,7 +2695,7 @@ fn process_directive(
                 template,
                 output_path,
                 auto_add,
-            })
+            });
         }
         "RemoveSection" => config.remove_sections.push(arg.to_owned()),
         "AssertOutputFileMatches" => {
@@ -2717,14 +2708,14 @@ fn process_directive(
         "Arch" => {
             config.support_architectures = arg
                 .trim()
-                .split(",")
+                .split(',')
                 .map(|arch| Architecture::parse(arch.trim()))
                 .collect::<Result<Vec<_>, _>>()?;
         }
         "SkipArch" => {
             let skipped = arg
                 .trim()
-                .split(",")
+                .split(',')
                 .map(|arch| Architecture::parse(arch.trim()))
                 .collect::<Result<Vec<_>, _>>()?;
             config.support_architectures = ALL_ARCHITECTURES
@@ -2736,7 +2727,7 @@ fn process_directive(
         "RequiresGlibc" => config.requires_glibc = arg.parse()?,
         "RequiresGlibcVersion" => {
             config.requires_glibc = true;
-            config.requires_glibc_version = Some(arg.to_owned())
+            config.requires_glibc_version = Some(arg.to_owned());
         }
         "RequiresSFrameBacktrace" => {
             config.requires_sframe_backtrace = arg.parse()?;
@@ -2790,8 +2781,8 @@ fn process_directive(
 }
 
 impl ProgramInputs {
-    fn new(source_file: PathBuf) -> Result<Self> {
-        Ok(Self { source_file })
+    fn new(source_file: PathBuf) -> Self {
+        Self { source_file }
     }
 
     fn build<'a>(
@@ -2966,7 +2957,7 @@ fn remove_sections(
     cross_arch: Option<Architecture>,
 ) -> Result {
     let objcopy = match cross_arch {
-        Some(arch) => format!("{}-linux-gnu-objcopy", arch),
+        Some(arch) => format!("{arch}-linux-gnu-objcopy"),
         None => "objcopy".to_owned(),
     };
 
@@ -3119,12 +3110,11 @@ impl LinkOutput {
                 let _ = recv.read_to_end(&mut output);
             });
 
-            match child.wait_timeout(TEST_BINARY_TIMEOUT)? {
-                Some(s) => Ok(s),
-                None => {
-                    child.kill()?;
-                    bail!("Binary ran for too long");
-                }
+            if let Some(s) = child.wait_timeout(TEST_BINARY_TIMEOUT)? {
+                Ok(s)
+            } else {
+                child.kill()?;
+                bail!("Binary ran for too long");
             }
         })?;
 
@@ -3380,10 +3370,10 @@ fn build_linker_input(
 
                 match fat_kind {
                     FatKind::Bit32 => {
-                        make_macho_fat_file::<object::read::macho::FatArch32>(&fat_path, &path)?
+                        make_macho_fat_file::<object::read::macho::FatArch32>(&fat_path, &path)?;
                     }
                     FatKind::Bit64 => {
-                        make_macho_fat_file::<object::read::macho::FatArch64>(&fat_path, &path)?
+                        make_macho_fat_file::<object::read::macho::FatArch64>(&fat_path, &path)?;
                     }
                 }
 
@@ -3429,10 +3419,14 @@ fn build_linker_input(
 
                 match fat_kind {
                     FatKind::Bit32 => {
-                        make_macho_fat_file::<object::read::macho::FatArch32>(&fat_path, &obj_path)?
+                        make_macho_fat_file::<object::read::macho::FatArch32>(
+                            &fat_path, &obj_path,
+                        )?;
                     }
                     FatKind::Bit64 => {
-                        make_macho_fat_file::<object::read::macho::FatArch64>(&fat_path, &obj_path)?
+                        make_macho_fat_file::<object::read::macho::FatArch64>(
+                            &fat_path, &obj_path,
+                        )?;
                     }
                 }
 
@@ -3667,7 +3661,7 @@ fn build_obj(
                         "--target={}",
                         arch.default_target_triple_rustc(config.platform)
                     ));
-                    arch.default_target_triple(config.platform).to_owned()
+                    arch.default_target_triple(config.platform)
                 });
                 if config.platform != PlatformKind::Wasm {
                     let target_underscore = target.replace('-', "_");
@@ -3699,7 +3693,7 @@ fn build_obj(
 
     // If we haven't run previously or we're compiling rust code, there won't be a deps file. In
     // that case, our deps is just the source file.
-    let deps = parse_deps_file(&deps_path).unwrap_or_else(|_| vec![src_path.to_owned()]);
+    let deps = parse_deps_file(&deps_path).unwrap_or_else(|_| vec![src_path.clone()]);
 
     command.arg(&src_path);
 
@@ -3843,8 +3837,8 @@ fn add_cross_args(
 
     if !platform.is_host() || cross_arch.is_some() {
         let arch = cross_arch.unwrap_or_else(get_host_architecture);
-        let target = get_target(compiler_args)
-            .unwrap_or_else(|_| arch.default_target_triple(platform).to_owned());
+        let target =
+            get_target(compiler_args).unwrap_or_else(|_| arch.default_target_triple(platform));
         command.arg(format!("--target={target}"));
 
         // Debian sets sysroot to `/` and uses real paths for libraries in linker scripts.
@@ -3856,7 +3850,7 @@ fn add_cross_args(
 }
 
 impl RustcChannel {
-    fn as_arg(&self) -> Option<&'static str> {
+    fn as_arg(self) -> Option<&'static str> {
         match self {
             RustcChannel::Stable => Some("+stable"),
             RustcChannel::Beta => Some("+beta"),
@@ -4066,15 +4060,13 @@ fn parse_deps_file(depfile: &Path) -> std::io::Result<Vec<PathBuf>> {
         }
         let line = buf.trim_end_matches(['\r', '\n']);
 
-        let frag = if !started {
-            if let Some(i) = line.find(':') {
-                started = true;
-                &line[i + 1..]
-            } else {
-                continue;
-            }
-        } else {
+        let frag = if started {
             line
+        } else if let Some(i) = line.find(':') {
+            started = true;
+            &line[i + 1..]
+        } else {
+            continue;
         };
 
         let (frag, cont) = if frag.ends_with('\\') {
@@ -4399,7 +4391,7 @@ impl LinkCommand {
             inputs: inputs.to_vec(),
             input_commands: inputs
                 .iter()
-                .filter_map(|input| input.command.as_ref().cloned())
+                .filter_map(|input| input.command.clone())
                 .collect(),
             linker: linker.clone(),
             config: config.clone(),
@@ -4876,11 +4868,11 @@ impl Assertions {
             "dynsym",
         )?;
         self.verify_elf_entry(&obj)?;
-        self.verify_symbols_absent(&self.no_sym, obj.symbols(), "symtab")?;
+        Self::verify_symbols_absent(&self.no_sym, obj.symbols(), "symtab")?;
         self.verify_expected_sections(&obj)?;
         self.verify_absent_sections(&obj)?;
         self.verify_section_bytes(&obj)?;
-        self.verify_eh_frame_terminator(&obj, linker_used)?;
+        Self::verify_eh_frame_terminator(&obj, linker_used)?;
         self.verify_relr_count(&obj)?;
         self.verify_gdb_index_cu_count(&obj)?;
         self.verify_gdb_index_symbols(&obj)?;
@@ -4896,8 +4888,8 @@ impl Assertions {
                 self.verify_comment_section(&elf_obj, linker_used)?;
                 self.verify_load_alignment(&elf_obj)?;
                 self.verify_dynamic_entries(&elf_obj)?;
-                self.verify_symbols_absent(&self.no_sym, elf_obj.dynamic_symbols(), "dynsym")?;
-                self.verify_symbols_absent(&self.no_dynsym, elf_obj.dynamic_symbols(), "dynsym")?;
+                Self::verify_symbols_absent(&self.no_sym, elf_obj.dynamic_symbols(), "dynsym")?;
+                Self::verify_symbols_absent(&self.no_dynsym, elf_obj.dynamic_symbols(), "dynsym")?;
                 self.verify_program_headers(&elf_obj)?;
                 self.verify_section_max_entries(&elf_obj)?;
             }
@@ -4952,7 +4944,7 @@ impl Assertions {
         }
 
         self.verify_macho_entry(obj)?;
-        self.verify_symbols_absent(&self.no_sym, obj.symbols(), "symtab")?;
+        Self::verify_symbols_absent(&self.no_sym, obj.symbols(), "symtab")?;
         self.verify_expected_sections(obj)?;
         self.verify_absent_sections(obj)?;
         self.verify_section_bytes(obj)?;
@@ -5245,7 +5237,7 @@ impl Assertions {
             distinct_cus.len(),
             {
                 let mut v: Vec<_> = distinct_cus.iter().copied().collect();
-                v.sort();
+                v.sort_unstable();
                 v
             }
         );
@@ -5273,7 +5265,7 @@ impl Assertions {
         Ok(())
     }
 
-    fn verify_eh_frame_terminator(&self, obj: &object::File, linker: &Linker) -> Result {
+    fn verify_eh_frame_terminator(obj: &object::File, linker: &Linker) -> Result {
         // BFD fails this check for at least one of our tests.
         if linker.is_bfd() {
             return Ok(());
@@ -5323,7 +5315,7 @@ impl Assertions {
                 count += 1;
             } else {
                 // Bitmap entry — count set bits excluding LSB marker.
-                count += (val >> 1).count_ones() as u64;
+                count += u64::from((val >> 1).count_ones());
             }
             i += 8;
         }
@@ -5421,7 +5413,7 @@ impl Assertions {
             return Ok(());
         }
         let actual_comments = read_comments(obj)?;
-        for expected in self.expected_comments.iter() {
+        for expected in &self.expected_comments {
             if let Some(expected) = expected.strip_suffix('*') {
                 if !actual_comments
                     .iter()
@@ -5479,7 +5471,6 @@ impl Assertions {
     }
 
     fn verify_symbols_absent<'a, I>(
-        &self,
         absent_syms: &HashSet<String>,
         symbols: I,
         table_name: &str,
@@ -5584,7 +5575,7 @@ impl Assertions {
         let mut header_sections = Vec::with_capacity(headers.len());
         let mut header_types = HashSet::new();
         for header in headers {
-            header_sections.push(self.get_sections_in_segment(obj, header));
+            header_sections.push(Self::get_sections_in_segment(obj, header));
             header_types.insert(header.p_type(endian).0);
         }
 
@@ -5631,7 +5622,10 @@ impl Assertions {
                         continue;
                     }
 
-                    if !expected_sections.is_empty() {
+                    if expected_sections.is_empty() {
+                        found = true;
+                        break;
+                    } else {
                         let mut has_wildcard = false;
                         let mut sections_found = 0;
 
@@ -5652,9 +5646,6 @@ impl Assertions {
                             found = true;
                             break;
                         }
-                    } else {
-                        found = true;
-                        break;
                     }
                 }
             }
@@ -5682,7 +5673,6 @@ impl Assertions {
     }
 
     fn get_sections_in_segment<'data>(
-        &self,
         obj: &object::read::elf::ElfFile64<'data, object::Endianness>,
         header: &object::elf::ProgramHeader64<object::Endianness>,
     ) -> HashSet<&'data str> {
@@ -6071,8 +6061,7 @@ fn verify_macho_tlv_template_layout(obj: &object::File) -> Result {
     ensure!(
         matches!(
             types.as_slice(),
-            [S_THREAD_LOCAL_REGULAR]
-                | [S_THREAD_LOCAL_ZEROFILL]
+            [S_THREAD_LOCAL_REGULAR | S_THREAD_LOCAL_ZEROFILL]
                 | [S_THREAD_LOCAL_REGULAR, S_THREAD_LOCAL_ZEROFILL]
         ),
         "Mach-O TLV template sections must be contiguous: {}",
@@ -6261,6 +6250,7 @@ fn verify_uuid(obj: &object::File, bytes: &[u8]) -> Result {
     Ok(())
 }
 
+#[allow(clippy::wildcard_imports)]
 fn dynamic_tag_name(tag: object::elf::DynamicTag) -> Option<&'static str> {
     use object::elf::*;
     Some(match tag {
@@ -6321,7 +6311,7 @@ fn lookup_line_for_symbol(obj: &object::File, sym_address: u64) -> Result<Option
         match obj.section_by_name(id.name()) {
             Some(section) => section
                 .uncompressed_data()
-                .map_err(|e| libwild::error::Error::from(format!("Failed to read section: {}", e))),
+                .map_err(|e| libwild::error::Error::from(format!("Failed to read section: {e}"))),
             None => Ok(std::borrow::Cow::Borrowed(&[])),
         }
     };
@@ -6546,7 +6536,7 @@ where
             "Missing expected symbol(s) in {context_name}: {}",
             missing.join(", ")
         );
-    };
+    }
 
     Ok(())
 }
@@ -6609,9 +6599,9 @@ impl Compiler {
         }
     }
 
-    fn c_language(&self) -> CLanguage {
+    fn c_language(self) -> CLanguage {
         match self {
-            Compiler::Gcc(lang) | Compiler::Clang(lang) => *lang,
+            Compiler::Gcc(lang) | Compiler::Clang(lang) => lang,
         }
     }
 }
@@ -6749,7 +6739,7 @@ impl Clone for LinkCommand {
     fn clone(&self) -> Self {
         Self {
             command: clone_command(&self.command),
-            input_commands: self.input_commands.to_vec(),
+            input_commands: self.input_commands.clone(),
             linker: self.linker.clone(),
             invocation_mode: self.invocation_mode,
             opt_save_dir: self.opt_save_dir.clone(),
@@ -6935,7 +6925,7 @@ fn create_diff_config(config: &Config, files: Vec<PathBuf>) -> Result<linker_dif
         .equiv
         .extend(config.section_equiv.iter().cloned());
     diff_config.match_any = config.diff_match_any;
-    diff_config.references = files.clone();
+    diff_config.references = files;
     diff_config.file = diff_config
         .references
         .pop()
@@ -6971,7 +6961,7 @@ fn setup_wild_ld_symlink() -> Result {
                 wild_ld_path.display(),
                 wild.display()
             )
-        })?
+        })?;
     }
     Ok(())
 }
@@ -7066,7 +7056,7 @@ fn should_print_timing() -> bool {
 }
 
 impl LinkerInvocationMode {
-    fn format_arg(&self, arg: &str) -> String {
+    fn format_arg(self, arg: &str) -> String {
         match self {
             LinkerInvocationMode::Direct | LinkerInvocationMode::Script => arg.to_owned(),
             LinkerInvocationMode::Cc => {
@@ -7194,7 +7184,7 @@ fn available_linkers_for_mac() -> Result<LinkerCatalog> {
     })
 }
 
-fn available_linkers_for_wasm() -> Result<Vec<Linker>> {
+fn available_linkers_for_wasm() -> Vec<Linker> {
     let mut linkers = Vec::new();
 
     if let Ok(path) = find_bin(&["wasm-ld"]) {
@@ -7210,7 +7200,7 @@ fn available_linkers_for_wasm() -> Result<Vec<Linker>> {
 
     linkers.push(Linker::Wild);
 
-    Ok(linkers)
+    linkers
 }
 
 fn run_with_config(
@@ -7652,7 +7642,7 @@ fn verify_linker_plugin_requirements(
                     .output()
                     .context("Can't execute compiler with -dumpversion")?;
                 let compiler_version = String::from_utf8_lossy(&output.stdout)
-                    .split_once(".")
+                    .split_once('.')
                     .and_then(|version| version.0.parse::<u64>().ok())
                     .context("Can't parse compiler version")?;
 
@@ -7722,9 +7712,10 @@ fn get_wild_test_cross() -> Result<Option<Vec<Architecture>>> {
 fn read_test_config() -> Result<TestConfig> {
     let config_default_path = base_dir().parent().unwrap().join("test-config.toml");
 
-    let config_path = std::env::var("WILD_TEST_CONFIG")
-        .map(|config_path| base_dir().parent().unwrap().join(config_path))
-        .unwrap_or_else(|_| config_default_path.clone());
+    let config_path = std::env::var("WILD_TEST_CONFIG").map_or_else(
+        |_| config_default_path.clone(),
+        |config_path| base_dir().parent().unwrap().join(config_path),
+    );
 
     let mut config = if config_path.exists() {
         let config_content = std::fs::read_to_string(&config_path).with_context(|| {
@@ -7735,7 +7726,7 @@ fn read_test_config() -> Result<TestConfig> {
         })?;
 
         toml::from_str(&config_content)
-            .with_context(|| format!("Unable to load config from {config_path:?}"))?
+            .with_context(|| format!("Unable to load config from `{}`", config_path.display()))?
     } else if config_path == config_default_path {
         TestConfig::default()
     } else {
@@ -7800,7 +7791,7 @@ impl PlatformKind {
             }),
             PlatformKind::MachO => available_linkers_for_mac(),
             PlatformKind::Wasm => Ok(LinkerCatalog {
-                available: available_linkers_for_wasm()?,
+                available: available_linkers_for_wasm(),
                 unavailable: Vec::new(),
             }),
         }
@@ -7840,7 +7831,7 @@ impl PlatformKind {
         })
     }
 
-    fn intermediate_extension(&self, kind: IntermediateKind) -> Result<&'static str> {
+    fn intermediate_extension(self, kind: IntermediateKind) -> Result<&'static str> {
         Ok(match (self, kind) {
             (PlatformKind::Elf, IntermediateKind::Shared) => "so",
             (PlatformKind::Elf, IntermediateKind::Partial) => "o",


### PR DESCRIPTION
Apparently, the latest nightly of the cargo noticed we don't inherit the linting configuration in some crates:
`warning: missing `[lints]` to inherit `[workspace.lints]``

Doing so, a bunch of new warnings popped up and I'm going to address them.