### PR TITLE
port(MachO): Fix TLV descriptor offset

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1684,6 +1684,15 @@ impl<'data, P: Platform> Layout<'data, P> {
         })
     }
 
+    pub(crate) fn tlv_data_start_address(&self) -> u64 {
+        self.output_sections
+            .ids_with_info()
+            .filter(|(_, info)| info.section_attributes.is_tls())
+            .map(|(id, _)| self.section_layouts.get(id).mem_offset)
+            .min()
+            .unwrap_or(0)
+    }
+
     pub(crate) fn layout_data(&self) -> linker_layout::Layout {
         let thunk_count = self.thunk_count();
 

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -109,6 +109,9 @@ use object::macho::N_ABS;
 use object::macho::N_SECT;
 use object::macho::PLATFORM_MACOS;
 use object::macho::RelocationInfo;
+use object::macho::S_THREAD_LOCAL_REGULAR;
+use object::macho::S_THREAD_LOCAL_VARIABLES;
+use object::macho::S_THREAD_LOCAL_ZEROFILL;
 use object::macho::SegmentFlags;
 use object::slice_from_bytes_mut;
 use object::write::macho::CodeDirectory;
@@ -681,6 +684,17 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
 
     let mask = get_page_mask(rel_info.mask);
     let value = match rel_info.kind {
+        RelocationKind::Absolute
+            if section_flags.typ() == S_THREAD_LOCAL_VARIABLES
+                && flags.has_link_time_address()
+                && is_tlv_template_referent(layout, local_symbol_id) =>
+        {
+            // TODO: Once addends are supported, remember to change this to S + A -
+            // tlv_data_start_address().
+            resolution
+                .raw_value
+                .wrapping_sub(layout.tlv_data_start_address())
+        }
         RelocationKind::Absolute => resolution.raw_value.bitand(mask.symbol_plus_addend),
         RelocationKind::AbsoluteLowPart => resolution.raw_value.bitand(mask.symbol_plus_addend),
         RelocationKind::Relative => resolution
@@ -715,6 +729,19 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
         })?;
 
     Ok(())
+}
+
+fn is_tlv_template_referent(layout: &MachOLayout<'_>, symbol_id: SymbolId) -> bool {
+    layout
+        .symbol_db
+        .output_section_id(layout.symbol_db.definition(symbol_id))
+        .map(|id| layout.output_sections.primary_output_section(id))
+        .is_some_and(|id| {
+            matches!(
+                layout.output_sections.section_flags(id).typ(),
+                S_THREAD_LOCAL_REGULAR | S_THREAD_LOCAL_ZEROFILL
+            )
+        })
 }
 
 fn write_section_raw<'out, 'data>(

--- a/wild/tests/sources/macho/tlv-reloc-relax/tlv-reloc-relax.s
+++ b/wild/tests/sources/macho/tlv-reloc-relax/tlv-reloc-relax.s
@@ -2,6 +2,7 @@
 //#RunEnabled:false
 //#DiffEnabled:false
 //#ExpectSection:__thread_vars
+//#ExpectSectionBytes:__thread_vars=0x0400000000000000 40..48
 //#ExpectSectionBytes:__text=0x00600091 4..8
 
 .section __DATA,__thread_data,thread_local_regular


### PR DESCRIPTION
Currently in the `ARM64_RELOC_UNSIGNED`/`RelocationKind::Absolute` case, the full address is being written into the TLV descriptor offset when it should actually be calculated by the `S + A - first TLV data section address` when handling this relocation for TLV descriptors. See [ld](https://github.com/apple-oss-distributions/ld64/blob/f60a74eaa2c99585de1dc0f2820e7a9f8aaf522c/src/ld/OutputFile.cpp#L540-L543) and [lld](https://github.com/llvm/llvm-project/blob/main/lld/MachO/InputSection.cpp#L262C1-L271C8).

Part of #2071