### PR TITLE
fix: Reject CREL relocations when partial linking

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -1135,6 +1135,10 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
         scope: &Scope<'scope>,
     ) -> Result {
         if resources.symbol_db.args.should_output_partial_object() {
+            let header = state.object.section(section_index)?;
+            if header.sh_type(LittleEndian) == object::elf::SHT_CREL {
+                bail!("CREL with partial linking isn't yet supported: {state}");
+            }
             return Ok(());
         }
         match state.relocations(section_index)? {

--- a/wild/tests/sources/elf/partial-link-crel-unsupported/partial-link-crel-unsupported.s
+++ b/wild/tests/sources/elf/partial-link-crel-unsupported/partial-link-crel-unsupported.s
@@ -1,0 +1,10 @@
+//#Arch:x86_64
+//#Compiler:clang
+//#CompArgs:-Xassembler --crel -Xassembler --allow-experimental-crel
+//#RequiresCompilerFlags:-Xassembler --crel -Xassembler --allow-experimental-crel
+//#LinkArgs:-r
+//#ReferenceLinkers:
+//#ExpectErrorWild:CREL with partial linking isn't yet supported
+
+.data
+.quad undefined_symbol


### PR DESCRIPTION
We weren't properly handling CREL relocations when doing partial linking. This ensures that we error for now rather than producing an incorrect output.