### PR TITLE
chore: Model ELF emulations explicitly

### DIFF
--- a/libwild/src/arch.rs
+++ b/libwild/src/arch.rs
@@ -65,5 +65,3 @@ impl Architecture {
 
 pub(crate) const SUPPORTED_TARGETS: &str =
     "elf64-x86-64 elf64-littleaarch64 elf64-littleriscv elf64-loongarch elf64-powerpcle";
-pub(crate) const SUPPORTED_EMULATIONS: &str =
-    "elf_x86_64 aarch64elf elf64lriscv elf64loongarch elf64lppc";

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -221,7 +221,7 @@ impl Args {
                 writeln!(
                     stdout,
                     "supported emulations: {}",
-                    crate::arch::SUPPORTED_EMULATIONS
+                    elf::supported_emulations()
                 )?;
             }
             Args::Coff(_) | Args::MachO(_) | Args::Wasm(_) => (),
@@ -868,7 +868,7 @@ impl<T: platform::Args> ArgumentParser<T> {
                     // Value has '=', look up key with trailing '='
                     if let Some(sub) = handler.sub_options.get(format!("{key}=").as_str()) {
                         match sub.handler {
-                            SubOptionHandler::NoValue(_) => {
+                            SubOptionHandler::NoValue(_) | SubOptionHandler::WithName(_) => {
                                 (handler.handler)(args, modifier_stack, &value)?;
                             }
                             SubOptionHandler::WithValue(f) => f(args, modifier_stack, param_value)?,
@@ -882,6 +882,7 @@ impl<T: platform::Args> ArgumentParser<T> {
                     if let Some(sub) = handler.sub_options.get(value.as_str()) {
                         match sub.handler {
                             SubOptionHandler::NoValue(f) => f(args, modifier_stack)?,
+                            SubOptionHandler::WithName(f) => f(args, modifier_stack, &value),
                             SubOptionHandler::WithValue(_) => {
                                 bail!("Option -{prefix} {value} requires a value");
                             }
@@ -1183,6 +1184,8 @@ struct WithOptionalParam;
 enum SubOptionHandler<T> {
     /// Handler without value parameter (exact match)
     NoValue(fn(&mut T, &mut Vec<Modifiers>) -> Result<()>),
+    /// Handler that receives the name of the matched sub-option.
+    WithName(fn(&mut T, &mut Vec<Modifiers>, &str)),
     /// Handler with value parameter (prefix match)
     WithValue(fn(&mut T, &mut Vec<Modifiers>, &str) -> Result<()>),
 }
@@ -1250,6 +1253,23 @@ impl<'a, T, S> OptionDeclaration<'a, T, S> {
             SubOption {
                 help,
                 handler: SubOptionHandler::NoValue(handler),
+            },
+        );
+        self
+    }
+
+    #[must_use]
+    fn sub_option_with_name(
+        mut self,
+        name: &'static str,
+        help: &'static str,
+        handler: fn(&mut T, &mut Vec<Modifiers>, &str),
+    ) -> Self {
+        self.sub_options.insert(
+            name,
+            SubOption {
+                help,
+                handler: SubOptionHandler::WithName(handler),
             },
         );
         self

--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -7,7 +7,6 @@ use super::Input;
 use super::InputSpec;
 use crate::alignment::Alignment;
 use crate::arch::Architecture;
-use crate::arch::SUPPORTED_EMULATIONS;
 use crate::arch::SUPPORTED_TARGETS;
 use crate::args::CommonArgs;
 use crate::args::CopyRelocations;
@@ -44,14 +43,16 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicI64;
+use strum::EnumMessage as _;
+use strum::IntoEnumIterator as _;
 
 #[derive(Debug)]
 pub struct ElfArgs {
     pub(crate) common: super::CommonArgs,
 
-    pub(crate) arch: Architecture,
+    emulation: Emulation,
     pub(crate) lib_search_path: Vec<Box<Path>>,
-    pub(crate) dynamic_linker: Option<Box<Path>>,
+    dynamic_linker: DynamicLinker,
     pub(crate) strip: Strip,
     pub(crate) merge_sections: bool,
     pub(crate) version_script_path: Option<PathBuf>,
@@ -264,17 +265,67 @@ const DEFAULT_SHORT_FLAGS: &[&str] = &[
     "X", // alias for --discard-locals
 ];
 
+#[derive(Debug, Default)]
+enum DynamicLinker {
+    #[default]
+    EmulationDefault,
+    Omit,
+    Explicit(Box<Path>),
+}
+
+#[derive(Debug, Clone, Copy, strum::EnumIter, strum::EnumMessage, strum::EnumString)]
+enum Emulation {
+    #[strum(serialize = "elf_x86_64", message = "x86-64 ELF target")]
+    ElfX86_64,
+    #[strum(serialize = "elf_x86_64_sol2", message = "x86-64 ELF target (Solaris)")]
+    ElfX86_64Sol2,
+    #[strum(
+        serialize = "aarch64elf",
+        serialize = "aarch64linux",
+        message = "AArch64 ELF target"
+    )]
+    AArch64,
+    #[strum(serialize = "elf64lriscv", message = "RISC-V 64-bit ELF target")]
+    RiscV64,
+    #[strum(serialize = "elf64loongarch", message = "LoongArch 64-bit ELF target")]
+    LoongArch64,
+    #[strum(serialize = "elf64lppc", message = "PowerPC64 LE ELF target")]
+    Ppc64,
+    #[strum(disabled)]
+    Unsupported,
+}
+
+impl Emulation {
+    fn architecture(self) -> Architecture {
+        match self {
+            Emulation::ElfX86_64 | Emulation::ElfX86_64Sol2 => Architecture::X86_64,
+            Emulation::AArch64 => Architecture::AArch64,
+            Emulation::RiscV64 => Architecture::RiscV64,
+            Emulation::LoongArch64 => Architecture::LoongArch64,
+            Emulation::Ppc64 => Architecture::Ppc64,
+            Emulation::Unsupported => Architecture::Unsupported,
+        }
+    }
+
+    fn default_dynamic_linker(self) -> Option<&'static Path> {
+        match self {
+            Emulation::ElfX86_64Sol2 => Some(Path::new("/lib/amd64/ld.so.1")),
+            _ => None,
+        }
+    }
+}
+
 impl Default for ElfArgs {
     fn default() -> Self {
         Self {
             common: CommonArgs::default(),
 
-            arch: default_target_arch(),
+            emulation: default_emulation(),
 
             lib_search_path: Vec::new(),
             should_output_executable: true,
             should_output_partial_object: false,
-            dynamic_linker: None,
+            dynamic_linker: DynamicLinker::default(),
             strip: Strip::Nothing,
             // For now, we default to --gc-sections. This is different to other linkers, but other
             // than being different, there doesn't seem to be any downside to doing
@@ -349,32 +400,32 @@ impl Default for ElfArgs {
     }
 }
 
-const fn default_target_arch() -> Architecture {
+const fn default_emulation() -> Emulation {
     // We default to targeting the architecture that we're running on. We don't support running on
     // architectures that we can't target.
     #[cfg(target_arch = "x86_64")]
     {
-        return Architecture::X86_64;
+        return Emulation::ElfX86_64;
     }
     #[cfg(target_arch = "aarch64")]
     {
-        return Architecture::AArch64;
+        return Emulation::AArch64;
     }
     #[cfg(target_arch = "riscv64")]
     {
-        return Architecture::RiscV64;
+        return Emulation::RiscV64;
     }
     #[cfg(target_arch = "loongarch64")]
     {
-        return Architecture::LoongArch64;
+        return Emulation::LoongArch64;
     }
     #[cfg(all(target_arch = "powerpc64", target_endian = "little"))]
     {
-        return Architecture::Ppc64;
+        return Emulation::Ppc64;
     }
 
     #[allow(unreachable_code)]
-    Architecture::Unsupported
+    Emulation::Unsupported
 }
 
 impl ElfArgs {
@@ -389,6 +440,22 @@ impl ElfArgs {
         self.z_pack_relative_relocs
             || self.pack_dyn_relocs == PackDynRelocs::Relr
             || self.pack_dyn_relocs == PackDynRelocs::AndroidRelr
+    }
+
+    pub(crate) fn architecture(&self) -> Architecture {
+        self.emulation.architecture()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_architecture(&mut self, architecture: Architecture) {
+        self.emulation = match architecture {
+            Architecture::X86_64 => Emulation::ElfX86_64,
+            Architecture::AArch64 => Emulation::AArch64,
+            Architecture::RiscV64 => Emulation::RiscV64,
+            Architecture::LoongArch64 => Emulation::LoongArch64,
+            Architecture::Ppc64 => Emulation::Ppc64,
+            Architecture::Unsupported => Emulation::Unsupported,
+        };
     }
 }
 
@@ -445,6 +512,29 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(
     }
 
     Ok(())
+}
+
+fn set_command_line_emulation(
+    args: &mut ElfArgs,
+    _modifier_stack: &mut Vec<Modifiers>,
+    emulation: &str,
+) {
+    args.emulation = emulation
+        .parse()
+        .expect("registered emulation should always parse");
+}
+
+fn emulations() -> impl Iterator<Item = (Emulation, &'static str)> {
+    Emulation::iter().flat_map(|emulation| {
+        emulation
+            .get_serializations()
+            .iter()
+            .map(move |&name| (emulation, name))
+    })
+}
+
+pub(crate) fn supported_emulations() -> String {
+    emulations().map(|(_, name)| name).join(" ")
 }
 
 fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
@@ -522,52 +612,21 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
             Ok(())
         });
 
-    parser
+    let mut emulation_option = parser
         .declare_with_param()
         .prefix("m")
-        .help("Set target architecture")
-        .sub_option("elf_x86_64", "x86-64 ELF target", |args, _| {
-            args.arch = Architecture::X86_64;
-            Ok(())
-        })
-        .sub_option(
-            "elf_x86_64_sol2",
-            "x86-64 ELF target (Solaris)",
-            |args, _| {
-                if args.dynamic_linker.is_none() {
-                    args.dynamic_linker = Some(Path::new("/lib/amd64/ld.so.1").into());
-                }
-                args.arch = Architecture::X86_64;
-                Ok(())
-            },
-        )
-        .sub_option("aarch64elf", "AArch64 ELF target", |args, _| {
-            args.arch = Architecture::AArch64;
-            Ok(())
-        })
-        .sub_option("aarch64linux", "AArch64 ELF target (Linux)", |args, _| {
-            args.arch = Architecture::AArch64;
-            Ok(())
-        })
-        .sub_option("elf64lriscv", "RISC-V 64-bit ELF target", |args, _| {
-            args.arch = Architecture::RiscV64;
-            Ok(())
-        })
-        .sub_option(
-            "elf64loongarch",
-            "LoongArch 64-bit ELF target",
-            |args, _| {
-                args.arch = Architecture::LoongArch64;
-                Ok(())
-            },
-        )
-        .sub_option("elf64lppc", "PowerPC64 LE ELF target", |args, _| {
-            args.arch = Architecture::Ppc64;
-            Ok(())
-        })
-        .execute(|_args, _modifier_stack, value| {
-            bail!("-m {value} is not yet supported");
-        });
+        .help("Select linker emulation");
+
+    for (emulation, name) in emulations() {
+        emulation_option = emulation_option.sub_option_with_name(
+            name,
+            emulation.get_message().unwrap(),
+            set_command_line_emulation,
+        );
+    }
+
+    emulation_option
+        .execute(|_args, _modifier_stack, value| bail!("-m {value} is not yet supported"));
 
     parser
         .declare_with_param()
@@ -884,7 +943,11 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
 
             // The following listing is something autoconf detection relies on.
             writeln!(stdout, "wild: supported targets: {SUPPORTED_TARGETS}")?;
-            writeln!(stdout, "wild: supported emulations: {SUPPORTED_EMULATIONS}")?;
+            writeln!(
+                stdout,
+                "wild: supported emulations: {}",
+                supported_emulations()
+            )?;
 
             std::process::exit(0);
         });
@@ -939,7 +1002,7 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
         .long("dynamic-linker")
         .help("Set dynamic linker path")
         .execute(|args, _modifier_stack, value| {
-            args.dynamic_linker = Some(Box::from(Path::new(value)));
+            args.dynamic_linker = DynamicLinker::Explicit(Box::from(Path::new(value)));
             Ok(())
         });
 
@@ -948,7 +1011,7 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
         .long("no-dynamic-linker")
         .help("Omit the load-time dynamic linker request")
         .execute(|args, _modifier_stack| {
-            args.dynamic_linker = None;
+            args.dynamic_linker = DynamicLinker::Omit;
             Ok(())
         });
 
@@ -1989,7 +2052,11 @@ impl platform::Args for ElfArgs {
     }
 
     fn dynamic_linker(&self) -> Option<&Path> {
-        self.dynamic_linker.as_deref()
+        match &self.dynamic_linker {
+            DynamicLinker::EmulationDefault => self.emulation.default_dynamic_linker(),
+            DynamicLinker::Omit => None,
+            DynamicLinker::Explicit(path) => Some(path),
+        }
     }
 
     fn should_allow_object_undefined(&self, output_kind: OutputKind) -> bool {
@@ -2029,7 +2096,7 @@ impl platform::Args for ElfArgs {
             return max_page_size;
         }
 
-        match self.arch {
+        match self.architecture() {
             Architecture::X86_64 => Alignment { exponent: 12 },
             Architecture::AArch64 => Alignment { exponent: 16 },
             Architecture::RiscV64 => Alignment { exponent: 12 },
@@ -2060,7 +2127,7 @@ impl platform::Args for ElfArgs {
     }
 
     fn architecture(&self) -> Architecture {
-        self.arch
+        ElfArgs::architecture(self)
     }
 
     fn output_format_endian(&self) -> Option<Endianness> {

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -162,7 +162,7 @@ pub(crate) fn link_for_arch<'data, F: FileSystem>(
     linker: &'data crate::Linker<F>,
     args: &'data ElfArgs,
 ) -> Result<crate::LinkerOutput<'data>> {
-    match args.arch {
+    match args.architecture() {
         crate::arch::Architecture::X86_64 => {
             linker.link_for_arch::<Elf64, crate::elf_x86_64::ElfX86_64>(args)
         }
@@ -1273,7 +1273,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
                 *keep = !args.nmagic;
             }
             if segment_def.segment_type == pt::RISCV_ATTRIBUTES
-                && args.arch != Architecture::RiscV64
+                && args.architecture() != Architecture::RiscV64
             {
                 *keep = false;
             }
@@ -1408,14 +1408,14 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
             .set_hidden(hidden);
         symbols.section_end(output_section_id::BSS, "__end").hide();
 
-        if args.arch == Architecture::RiscV64 {
+        if args.architecture() == Architecture::RiscV64 {
             symbols.section_start(
                 output_section_id::DATA,
                 crate::elf::GLOBAL_POINTER_SYMBOL_NAME,
             );
         }
 
-        if args.arch == Architecture::Ppc64 {
+        if args.architecture() == Architecture::Ppc64 {
             symbols.section_start(output_section_id::GOT, crate::elf::TOC_SYMBOL_NAME);
         }
 
@@ -3102,12 +3102,12 @@ impl<'data, C: ElfClass> platform::ObjectFile<'data> for File<'data, C> {
 
         let file = Self::parse_bytes(input.data, is_dynamic)?;
 
-        if file.arch != args.arch {
+        if file.arch != args.architecture() {
             bail!(
                 "`{}` has incompatible architecture: {}, expecting {}",
                 input,
                 file.arch,
-                args.arch,
+                args.architecture(),
             )
         }
 

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -5519,12 +5519,18 @@ const EPILOGUE_DYNAMIC_ENTRY_WRITERS: &[DynamicEntryWriter] = &[
     ),
     DynamicEntryWriter::optional(
         object::elf::DT_AARCH64_VARIANT_PCS,
-        |inputs| inputs.has_variant_pcs && inputs.args.arch == crate::arch::Architecture::AArch64,
+        |inputs| {
+            inputs.has_variant_pcs
+                && inputs.args.architecture() == crate::arch::Architecture::AArch64
+        },
         |_inputs| 0,
     ),
     DynamicEntryWriter::optional(
         object::elf::DT_RISCV_VARIANT_CC,
-        |inputs| inputs.has_variant_pcs && inputs.args.arch == crate::arch::Architecture::RiscV64,
+        |inputs| {
+            inputs.has_variant_pcs
+                && inputs.args.architecture() == crate::arch::Architecture::RiscV64
+        },
         |_inputs| 0,
     ),
     DynamicEntryWriter::new(object::elf::DT_NULL, |_inputs| 0),

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -6174,8 +6174,8 @@ fn test_no_disallowed_overlaps() {
     let (output_order, program_segments) =
         output_sections.output_order(output_kind, &[], &[]).unwrap();
     let mut args = crate::args::elf::ElfArgs::default();
-    if args.arch == crate::arch::Architecture::Unsupported {
-        args.arch = crate::arch::Architecture::X86_64;
+    if args.architecture() == crate::arch::Architecture::Unsupported {
+        args.set_architecture(crate::arch::Architecture::X86_64);
     }
 
     let sections_to_output: hashbrown::HashSet<OutputSectionId> = output_order


### PR DESCRIPTION
This is mostly a refactoring to help support #2483, but in the process a few very minor behaviours changed.

`--no-dynamic-linker -m elf_x86_64_sol2` now honours the `--no-dynamic-linker` flag where before, the later flag would have overwritten it.

Even more obscure... `-m elf_x86_64_sol2 -m elf_x86_64` would previously have used the solaris interpreter, now it wouldn't.

elf_x86_64_sol2 and aarch64linux are added to the list of supported emulations emitted by `-V`.

The help text for `-m` was made more accurate (it previously referred to "target architecture" rather than "emulation".