### PR TITLE
port(MachO): support `__init_offsets` and `__dso_handle` symbol

### DIFF
--- a/libwild/src/args/macho.rs
+++ b/libwild/src/args/macho.rs
@@ -65,6 +65,8 @@ const SILENTLY_IGNORED_FLAGS: &[&str] = &[
     // Mach-O appears to always demangle symbols.
     "demangle",
     "dynamic",
+    // __init_offsets is emitted by default
+    "init_offsets",
 ];
 
 const IGNORED_FLAGS: &[&str] = &[];

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -4152,6 +4152,7 @@ impl<'data, P: Platform<GcUnit = SectionGcUnit>> ObjectLayoutState<'data, P> {
         let mut frame_section_indices = SmallVec::<[SectionIndex; 2]>::new();
         let mut note_gnu_property_section = None;
         let mut riscv_attributes_section = None;
+        let mut init_func_section = None;
 
         let no_gc = !resources.symbol_db.args.should_gc_sections();
 
@@ -4186,6 +4187,9 @@ impl<'data, P: Platform<GcUnit = SectionGcUnit>> ObjectLayoutState<'data, P> {
                 SectionSlot::RiscvVAttributes(index) => {
                     riscv_attributes_section = Some(*index);
                 }
+                SectionSlot::InitFunc(index) => {
+                    init_func_section = Some(*index);
+                }
                 _ => (),
             }
         }
@@ -4213,6 +4217,17 @@ impl<'data, P: Platform<GcUnit = SectionGcUnit>> ObjectLayoutState<'data, P> {
                 riscv_attributes_index,
             )
             .context("Cannot parse .riscv.attributes section")?;
+        }
+
+        if let Some(init_function_section_index) = init_func_section {
+            <A::Platform as Platform>::process_init_func_section::<A>(
+                self,
+                common,
+                init_function_section_index,
+                resources,
+                queue,
+                scope,
+            )?;
         }
 
         Ok(())
@@ -4248,7 +4263,8 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
             | SectionSlot::FrameData(..)
             | SectionSlot::LoadedDebugInfo(..)
             | SectionSlot::NoteGnuProperty(..)
-            | SectionSlot::RiscvVAttributes(..) => {}
+            | SectionSlot::RiscvVAttributes(..)
+            | SectionSlot::InitFunc(..) => {}
             SectionSlot::MergeStrings(_) => {
                 // We currently always load everything in merge-string sections. i.e. we don't GC
                 // unreferenced data. So the only thing we need to do here is propagate section
@@ -4456,6 +4472,7 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
                     let address = P::frame_data_base_address(memory_offsets);
                     SectionResolution { address }
                 }
+                SectionSlot::InitFunc(..) => SectionResolution::none(),
                 _ => SectionResolution::none(),
             };
             section_resolutions.push(resolution);

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -4152,7 +4152,7 @@ impl<'data, P: Platform<GcUnit = SectionGcUnit>> ObjectLayoutState<'data, P> {
         let mut frame_section_indices = SmallVec::<[SectionIndex; 2]>::new();
         let mut note_gnu_property_section = None;
         let mut riscv_attributes_section = None;
-        let mut init_func_section = None;
+        let mut init_func_section_indices = SmallVec::<[SectionIndex; 1]>::new();
 
         let no_gc = !resources.symbol_db.args.should_gc_sections();
 
@@ -4188,7 +4188,7 @@ impl<'data, P: Platform<GcUnit = SectionGcUnit>> ObjectLayoutState<'data, P> {
                     riscv_attributes_section = Some(*index);
                 }
                 SectionSlot::InitFunc(index) => {
-                    init_func_section = Some(*index);
+                    init_func_section_indices.push(*index);
                 }
                 _ => (),
             }
@@ -4219,7 +4219,7 @@ impl<'data, P: Platform<GcUnit = SectionGcUnit>> ObjectLayoutState<'data, P> {
             .context("Cannot parse .riscv.attributes section")?;
         }
 
-        if let Some(init_function_section_index) = init_func_section {
+        for init_function_section_index in init_func_section_indices {
             <A::Platform as Platform>::process_init_func_section::<A>(
                 self,
                 common,

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -111,6 +111,7 @@ pub(crate) enum SectionRuleOutcome {
     DebugIndex,
     RiscVAttribute,
     SortedSection(SectionOutputInfo),
+    InitFunc,
 }
 
 impl SectionRuleOutcome {

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -22,6 +22,7 @@ use crate::layout::SymbolCopyInfo;
 use crate::layout::SymbolResolutions;
 use crate::layout_rules::SectionKind;
 use crate::layout_rules::SectionRule;
+use crate::layout_rules::SectionRuleOutcome;
 use crate::macho::output_section_id::CHAINED_FIXUP_TABLE;
 use crate::macho::output_section_id::CODE_SIGNATURE;
 use crate::macho::output_section_id::EXPORTS_TRIE;
@@ -109,6 +110,7 @@ enum SinglePartSectionId {
     CodeSignature,
     ChainedFixupTable,
     ExportsTrie,
+    InitOffsets,
 
     // Must be last.
     Count,
@@ -126,6 +128,7 @@ pub(crate) mod part_id {
     pub(crate) const CODE_SIGNATURE: PartId = SinglePartSectionId::CodeSignature.part_id();
     pub(crate) const CHAINED_FIXUP_TABLE: PartId = SinglePartSectionId::ChainedFixupTable.part_id();
     pub(crate) const EXPORTS_TRIE: PartId = SinglePartSectionId::ExportsTrie.part_id();
+    pub(crate) const INIT_OFFSETS: PartId = SinglePartSectionId::InitOffsets.part_id();
 }
 
 pub(crate) mod output_section_id {
@@ -147,6 +150,8 @@ pub(crate) mod output_section_id {
         SinglePartSectionId::ChainedFixupTable.output_section_id();
     pub(crate) const EXPORTS_TRIE: OutputSectionId =
         SinglePartSectionId::ExportsTrie.output_section_id();
+    pub(crate) const INIT_OFFSETS: OutputSectionId =
+        SinglePartSectionId::InitOffsets.output_section_id();
 }
 
 const LE: Endianness = Endianness::Little;
@@ -172,6 +177,7 @@ pub(crate) const CHAINED_FIXUP_IMPORT_SIZE: u64 = size_of::<u32>() as u64;
 pub(crate) const CHAINED_FIXUP_PAGE_START_SIZE: u64 = size_of::<u16>() as u64;
 pub(crate) const GOT_ENTRY_SIZE: u64 = 8;
 pub(crate) const PLT_ENTRY_SIZE: u64 = 12;
+pub(crate) const INIT_OFFSET_ENTRY_SIZE: u64 = size_of::<u32>() as u64;
 
 type SectionHeader = Section64<crate::macho::Endianness>;
 type SectionTable<'data> = &'data [Section64<crate::macho::Endianness>];
@@ -262,12 +268,20 @@ impl std::fmt::Display for SegmentName {
 pub(crate) struct LayoutExt {
     /// Imported STUB library symbols, sorted by GOT.
     pub(crate) imported_symbols: Vec<ImportedSymbolWithResolution>,
+    /// Final addresses of initializer functions, in input relocation order.
+    pub(crate) init_function_addresses: Vec<u64>,
 }
 
 #[derive(Debug, Default)]
 pub(crate) struct FinaliseSizesExt {
     imported_libraries: Vec<FileId>,
     imported_symbols: Vec<SymbolId>,
+    init_functions: Vec<SymbolId>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ObjectLayoutStateExt {
+    init_functions: Vec<SymbolId>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -563,7 +577,7 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
 
     fn process_gnu_note_section(
         &self,
-        _state: &mut (),
+        _state: &mut ObjectLayoutStateExt,
         _section_index: object::SectionIndex,
     ) -> Result {
         todo!()
@@ -1075,7 +1089,7 @@ impl platform::Platform for MachO {
     type LayoutResourcesExt<'data> = ();
     type PreludeLayoutStateExt = PreludeLayoutExt;
     type PreludeLayoutExt = PreludeLayoutExt;
-    type ObjectLayoutStateExt<'data> = ();
+    type ObjectLayoutStateExt<'data> = ObjectLayoutStateExt;
     type RawSymbolName<'data> = RawSymbolName<'data>;
     type VersionNames<'data> = ();
     type VerneedTable<'data> = VerneedTable<'data>;
@@ -1312,10 +1326,14 @@ impl platform::Platform for MachO {
     }
 
     fn create_linker_defined_symbols(
-        _symbols: &mut crate::parsing::InternalSymbolsBuilder<Self>,
+        symbols: &mut crate::parsing::InternalSymbolsBuilder<Self>,
         _output_kind: crate::output_kind::OutputKind,
         _args: &Self::Args,
     ) {
+        // Mach-O object symbol names include the C ABI's leading underscore.
+        symbols
+            .section_start(crate::output_section_id::FILE_HEADER, "___dso_handle")
+            .hide();
     }
 
     fn built_in_section_infos<'data>()
@@ -1352,10 +1370,14 @@ impl platform::Platform for MachO {
     {
         let mut imported_libraries = Vec::new();
         let mut imported_symbols = Vec::new();
+        let mut init_functions = Vec::new();
 
         for group in groups {
             for file in &group.files {
                 match file {
+                    layout::FileLayoutState::Object(state) => {
+                        init_functions.extend_from_slice(&state.format_specific.init_functions);
+                    }
                     layout::FileLayoutState::StubLibrary(state) => {
                         if state.format_specific.loaded {
                             imported_libraries.push(state.file_id());
@@ -1378,6 +1400,7 @@ impl platform::Platform for MachO {
         Ok(FinaliseSizesExt {
             imported_libraries,
             imported_symbols,
+            init_functions,
         })
     }
 
@@ -1412,6 +1435,18 @@ impl platform::Platform for MachO {
             .into_iter()
             .sorted_by_key(|symbol| symbol.got_address)
             .collect();
+        layout_ext.init_function_addresses = finalise_sizes_ext
+            .init_functions
+            .iter()
+            .map(|&symbol_id| {
+                resolutions
+                    .get(symbol_id)
+                    .map(|resolution| resolution.raw_value)
+                    .ok_or_else(|| {
+                        error!("missing resolution for Mach-O initializer {symbol_id:?}")
+                    })
+            })
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(layout_ext)
     }
@@ -1425,6 +1460,45 @@ impl platform::Platform for MachO {
         _scope: &rayon::Scope<'scope>,
     ) -> Result {
         todo!()
+    }
+
+    fn process_init_func_section<'data, 'scope, A: platform::Arch<Platform = Self>>(
+        object: &mut crate::layout::ObjectLayoutState<'data, Self>,
+        _common: &mut crate::layout::CommonGroupState<'data, Self>,
+        section_index: object::SectionIndex,
+        resources: &'scope crate::layout::GraphResources<'data, '_, Self>,
+        queue: &mut crate::layout::LocalWorkQueue<Self>,
+        scope: &rayon::Scope<'scope>,
+    ) -> Result {
+        let header = object.object.section(section_index)?;
+        ensure!(
+            header.flags.get(LE).typ() == macho::S_MOD_INIT_FUNC_POINTERS,
+            "Mach-O __mod_init_func section has an unexpected section type"
+        );
+
+        for rel in object
+            .relocations(section_index)?
+            .relocations
+            .iter()
+            .sorted_unstable_by_key(|rel| rel.info(LE).r_address)
+        {
+            let info = rel.info(LE);
+            ensure!(
+                info.r_extern
+                    && !info.r_pcrel
+                    && info.r_length == 3
+                    && info.r_type == macho::ARM64_RELOC_UNSIGNED,
+                "unsupported Mach-O initializer relocation"
+            );
+            object.format_specific.init_functions.push(
+                object
+                    .symbol_id_range
+                    .input_to_id(SymbolIndex(info.r_symbolnum as usize)),
+            );
+            process_relocation::<A>(object, rel, section_index, resources, queue, scope)?;
+        }
+
+        Ok(())
     }
 
     fn non_empty_section_loaded<'data, 'scope, A: platform::Arch<Platform = Self>>(
@@ -1484,7 +1558,7 @@ impl platform::Platform for MachO {
         state: &mut Self::EpilogueLayoutExt,
         mem_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         dynamic_symbol_definitions: &[crate::layout::DynamicSymbolDefinition<'data, Self>],
-        _format_specific: &Self::FinaliseSizesExt<'data>,
+        format_specific: &Self::FinaliseSizesExt<'data>,
         symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
     ) {
         let mut fixup_table_size = CHAINED_FIXUP_TABLE_BASE_SIZE;
@@ -1529,6 +1603,11 @@ impl platform::Platform for MachO {
             part_id::EXPORTS_TRIE,
             crate::trie::build(&mut exports).len() as u64,
         );
+
+        mem_sizes.increment(
+            part_id::INIT_OFFSETS,
+            format_specific.init_functions.len() as u64 * INIT_OFFSET_ENTRY_SIZE,
+        );
     }
 
     fn finalise_sizes_all<'data>(
@@ -1539,12 +1618,16 @@ impl platform::Platform for MachO {
 
     fn finalise_layout_epilogue<'data>(
         _epilogue_state: &mut Self::EpilogueLayoutExt,
-        _memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
+        memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         _symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
-        _format_specific: &Self::FinaliseSizesExt<'data>,
+        format_specific: &Self::FinaliseSizesExt<'data>,
         _dynsym_start_index: u32,
         _dynamic_symbol_defs: &[crate::layout::DynamicSymbolDefinition<Self>],
     ) -> Result {
+        memory_offsets.increment(
+            part_id::INIT_OFFSETS,
+            format_specific.init_functions.len() as u64 * INIT_OFFSET_ENTRY_SIZE,
+        );
         Ok(())
     }
 
@@ -1841,6 +1924,7 @@ impl platform::Platform for MachO {
             &custom.exec,
             SegmentName::TEXT,
         );
+        builder.add_section(output_section_id::INIT_OFFSETS);
 
         builder.add_section(output_section_id::PLT_GOT);
         add_sections_in_segment(&mut builder, output_sections, &custom.ro, SegmentName::TEXT);
@@ -2068,6 +2152,14 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         min_alignment: Alignment { exponent: 2 },
         ..DEFAULT_DEFS
     };
+    defs[output_section_id::INIT_OFFSETS.as_usize()] = BuiltInSectionDetails {
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(b"__init_offsets"),
+            Some(SegmentName::TEXT),
+        )),
+        section_flags: macho::S_INIT_FUNC_OFFSETS.to_flags(),
+        min_alignment: Alignment { exponent: 2 },
+    };
 
     defs
 };
@@ -2107,6 +2199,7 @@ fn allocate_plt(memory_offsets: &mut OutputSectionPartMap<u64>) -> NonZeroU64 {
 }
 
 const DEFAULT_SECTION_RULES: &[SectionRule<'static>] = &[
+    SectionRule::exact(b"__mod_init_func", SectionRuleOutcome::InitFunc),
     // TODO: Add a Mach-O output section ID and rule for `__compact_unwind`.
 ];
 

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1362,7 +1362,7 @@ impl platform::Platform for MachO {
     fn create_finalise_sizes_ext<'data, 'states, 'files, A: platform::Arch<Platform = Self>>(
         _args: &Self::Args,
         groups: &'files mut [layout::GroupState<'data, Self>],
-        _symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
+        symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
     ) -> Result<Self::FinaliseSizesExt<'data>>
     where
         'data: 'files,
@@ -1376,7 +1376,13 @@ impl platform::Platform for MachO {
             for file in &group.files {
                 match file {
                     layout::FileLayoutState::Object(state) => {
-                        init_functions.extend_from_slice(&state.format_specific.init_functions);
+                        init_functions.extend(
+                            state
+                                .format_specific
+                                .init_functions
+                                .iter()
+                                .map(|local_symbol_id| symbol_db.definition(*local_symbol_id)),
+                        );
                     }
                     layout::FileLayoutState::StubLibrary(state) => {
                         if state.format_specific.loaded {

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -18,6 +18,7 @@ use crate::layout::OutputRecordLayout;
 use crate::layout::PreludeLayout;
 use crate::layout::Resolution;
 use crate::layout::Section;
+use crate::layout::SegmentLayout;
 use crate::layout::SymbolCopyInfo;
 use crate::macho::BuildVersionCommand;
 use crate::macho::CHAINED_FIXUP_PAGE_START_SIZE;
@@ -282,6 +283,7 @@ fn write_epilogue(
 ) -> Result {
     verbose_timing_phase!("Write epilogue");
     write_chained_fixup_table(layout, buffers.get_mut(part_id::CHAINED_FIXUP_TABLE))?;
+    write_init_offsets(layout, buffers.get_mut(part_id::INIT_OFFSETS))?;
     let out = buffers.get_mut(part_id::EXPORTS_TRIE);
     ensure!(
         exports_trie.len() <= out.len(),
@@ -293,18 +295,35 @@ fn write_epilogue(
     Ok(())
 }
 
+fn write_init_offsets(layout: &MachOLayout<'_>, out: &mut [u8]) -> Result {
+    let text_segment = get_text_segment_layout(layout)?.sizes.mem_offset;
+
+    let chunks = out.as_chunks_mut::<4>();
+    ensure!(
+        chunks.1.is_empty(),
+        "Mach-O initializer must be a multiple of 4"
+    );
+    for (&address, slot) in layout
+        .format_specific
+        .init_function_addresses
+        .iter()
+        .zip(chunks.0)
+    {
+        let offset = address
+            .checked_sub(text_segment)
+            .context("Mach-O initializer is before the __TEXT segment")?;
+        let offset = u32::try_from(offset).context("Mach-O initializer offset exceeds 32 bits")?;
+        slot.copy_from_slice(&offset.to_le_bytes());
+    }
+    Ok(())
+}
+
 fn build_exports_trie(layout: &MachOLayout<'_>) -> Result<Vec<u8>> {
     if !layout.symbol_db.output_kind.needs_dynsym() {
         return Ok(Vec::new());
     }
 
-    let text_segment = layout
-        .segment_layouts
-        .segments
-        .iter()
-        .find(|segment| layout.program_segments.segment_def(segment.id).name == SegmentName::TEXT)
-        .context("Missing Mach-O __TEXT segment")?;
-
+    let text_segment = get_text_segment_layout(layout)?;
     let image_base = text_segment.sizes.mem_offset;
 
     let mut symbols = layout
@@ -1141,12 +1160,7 @@ fn write_code_signature_metadata(
         "Unexpected code directory size"
     );
 
-    let text_segment = layout
-        .segment_layouts
-        .segments
-        .iter()
-        .find(|segment| layout.program_segments.segment_def(segment.id).name == SegmentName::TEXT)
-        .ok_or_else(|| error!("__TEXT segment is mandatory"))?;
+    let text_segment = get_text_segment_layout(layout)?;
 
     let code_directory = CodeDirectory {
         length: (code_signature_section.file_size - CS_BLOB_HEADERS_SIZE as usize) as u32,
@@ -1363,4 +1377,13 @@ fn macho_section_index(layout: &MachOLayout<'_>, section_id: OutputSectionId) ->
     }
 
     bail!("cannot find the output section")
+}
+
+fn get_text_segment_layout<'a>(layout: &'a MachOLayout<'_>) -> Result<&'a SegmentLayout> {
+    layout
+        .segment_layouts
+        .segments
+        .iter()
+        .find(|segment| layout.program_segments.segment_def(segment.id).name == SegmentName::TEXT)
+        .context("Missing Mach-O __TEXT segment")
 }

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -676,6 +676,18 @@ pub(crate) trait Platform:
         scope: &Scope<'scope>,
     ) -> Result;
 
+    /// Processes an input section containing initializer function pointers (Mach-O specific).
+    fn process_init_func_section<'data, 'scope, A: Arch<Platform = Self>>(
+        _object: &mut ObjectLayoutState<'data, Self>,
+        _common: &mut layout::CommonGroupState<'data, Self>,
+        _section_index: object::SectionIndex,
+        _resources: &'scope layout::GraphResources<'data, '_, Self>,
+        _queue: &mut layout::LocalWorkQueue<Self>,
+        _scope: &Scope<'scope>,
+    ) -> Result {
+        Ok(())
+    }
+
     /// Called when a section is loaded (not GCed). Implementations should process any exception
     /// frame data related to the loaded section.
     fn non_empty_section_loaded<'data, 'scope, A: Arch<Platform = Self>>(

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -717,6 +717,9 @@ pub(crate) enum SectionSlot {
     /// The section contains frame data, e.g. .eh_frame or equivalent.
     FrameData(object::SectionIndex),
 
+    /// The section contains initializer function pointers that are processed by the platform.
+    InitFunc(object::SectionIndex),
+
     /// The section is a string-merge section.
     MergeStrings(StringMergeSectionSlot),
 
@@ -1465,6 +1468,12 @@ fn resolve_section<'data, P: Platform>(
                 crate::part_id::UNMAPPED,
             ));
         }
+        SectionRuleOutcome::InitFunc => {
+            return Ok((
+                SectionSlot::InitFunc(input_section_index),
+                crate::part_id::UNMAPPED,
+            ));
+        }
         SectionRuleOutcome::NoteGnuProperty => {
             return Ok((
                 SectionSlot::NoteGnuProperty(input_section_index),
@@ -1759,7 +1768,10 @@ impl SectionSlot {
     pub(crate) fn is_loaded(&self) -> bool {
         !matches!(
             self,
-            SectionSlot::Discard | SectionSlot::Unloaded(..) | SectionSlot::NoteGnuProperty(..)
+            SectionSlot::Discard
+                | SectionSlot::Unloaded(..)
+                | SectionSlot::InitFunc(..)
+                | SectionSlot::NoteGnuProperty(..)
         )
     }
 

--- a/wild/tests/sources/macho/ctor-dtor/ctor-dtor.cc
+++ b/wild/tests/sources/macho/ctor-dtor/ctor-dtor.cc
@@ -1,0 +1,31 @@
+//#LinkerDriver:clang++
+//#ExpectSection:__init_offsets
+//#NoSection:__mod_init_func
+//#DiffIgnore:section.__unwind_info
+//#DiffIgnore:section.__gcc_except_tab
+
+#include <iostream>
+
+int v = 0;
+
+namespace {
+
+class Tracer {
+ public:
+  Tracer() {
+    v = 42;
+    std::cout << "new\n";
+  }
+  ~Tracer() { std::cout << "destroy\n"; }
+};
+
+}  // namespace
+
+Tracer globalA;
+
+Tracer& functionStatic() {
+  static Tracer object{};
+  return object;
+}
+
+int main() { return v; }

--- a/wild/tests/sources/macho/init-offsets/init-offsets.c
+++ b/wild/tests/sources/macho/init-offsets/init-offsets.c
@@ -1,0 +1,10 @@
+//#LinkerDriver:clang
+//#ExpectSection:__init_offsets
+//#NoSection:__mod_init_func
+
+static int state;
+
+__attribute__((constructor)) static void first(void) { state = 1; }
+__attribute__((constructor)) static void second(void) { state = state * 40 + 2; }
+
+int main(void) { return state; }

--- a/wild/tests/sources/macho/init-offsets/init-offsets.c
+++ b/wild/tests/sources/macho/init-offsets/init-offsets.c
@@ -1,6 +1,7 @@
 //#LinkerDriver:clang
 //#ExpectSection:__init_offsets
 //#NoSection:__mod_init_func
+//#DiffIgnore:section.__unwind_info
 
 static int state;
 


### PR DESCRIPTION
The PR adds support for constructors in a form of function points in the `__mod_init_func` section. We could just concatenate the section to the output file, but as Mach-O is PIC by default, we would have to emit also chained fix-ups. Rather than that, we can use a more modern `__init_offsets` section, which contains relative (to __TEXT segment) 32-bit offsets and thus the fixup are unnecessary. On top of that, I'm also adding a synthetic symbol `___dso_handle` used as part of C++ ABI function `__cxa_atexit`.

Part of #757
Resolves: #2379