### PR TITLE
port(wasm): Wrap all defined exports with `__wasm_call_ctors`

### DIFF
--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1576,6 +1576,8 @@ pub(crate) struct WasmLayout<'data> {
     pub(crate) encoded_sections: WasmEncodedSections,
     pub(crate) code_section_size: u64,
     pub(crate) data_section_size: u64,
+    /// Linker-synthesized `{export}.command_export` wrappers and their name-section names.
+    command_export_wrapper_names: Vec<(u32, String)>,
 }
 
 #[derive(Debug, Default)]
@@ -1773,6 +1775,12 @@ fn build_name_section<'data>(
         for (out_idx, name) in entries.globals {
             set_name_first_wins(&mut global_names, out_idx, name);
         }
+    }
+
+    // Named after object symbols so first-wins keeps `{export}.command_export` rather than the
+    // export name that is retargeted onto the wrapper.
+    for (idx, name) in &layout.command_export_wrapper_names {
+        set_name_first_wins(&mut function_names, *idx, name.as_str());
     }
 
     for export in &layout.exports {
@@ -3940,7 +3948,6 @@ struct LinkerDefinedIndices {
     /// `emit_reserved_linker_definitions` (not the Wasm module global index).
     stack_pointer_defined_slot: Option<u32>,
     call_ctors_func: Option<u32>,
-    entry_wrapper_func: Option<u32>,
     weak_undef_stubs: Vec<WeakUndefFunctionStub>,
     /// Linker-defined globals including GOT.mem.
     num_defined_globals: u32,
@@ -4033,7 +4040,6 @@ fn setup_got_mem_and_indices<'data>(
     symbol_db: &SymbolDb<'data, Wasm>,
     file_id_to_index: &HashMap<crate::input_data::FileId, usize>,
     has_init_funcs: bool,
-    wrap_entry: bool,
 ) -> Result<(
     LinkerDefinedIndices,
     LayoutRelocScan,
@@ -4083,7 +4089,6 @@ fn setup_got_mem_and_indices<'data>(
                     export_symbols: requested_linker_export_symbols(symbol_db.args),
                     // Executables always get a defined linear memory.
                     has_memory: true,
-                    wrap_entry,
                     got_mem_count: scan.got_mem.len(),
                     got_func_count: scan.got_func.len(),
                     needs_memory_base: scan.needs_memory_base,
@@ -4877,34 +4882,11 @@ fn call_ctors_used_in_objects(inputs: &[WasmObjectLayoutInput<'_>]) -> bool {
     })
 }
 
-fn entry_is_defined_function(
-    layout_inputs: &[WasmObjectLayoutInput<'_>],
-    symbol_db: &SymbolDb<'_, Wasm>,
-    file_id_to_index: &HashMap<crate::input_data::FileId, usize>,
-) -> bool {
-    let Some(entry_name) = symbol_db.entry_symbol_name() else {
-        return false;
-    };
-    let Some(symbol_id) = symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(entry_name))
-    else {
-        return false;
-    };
-    let def_id = symbol_db.definition(symbol_id);
-    let def_file_id = symbol_db.file_id_for_symbol(def_id);
-    let Some(&obj_idx) = file_id_to_index.get(&def_file_id) else {
-        return false;
-    };
-    let input = &layout_inputs[obj_idx];
-    let sym = &input.symbols[input.symbol_id_range.id_to_offset(def_id)];
-    !sym.is_undefined() && sym.kind == WasmSymbolKind::Func
-}
-
 struct LinkerDefinedIndexRequest {
     has_init_funcs: bool,
     // Linker symbols named by `--export` / `--export-if-defined`.
     export_symbols: Vec<WasmLinkerSymbol>,
     has_memory: bool,
-    wrap_entry: bool,
     got_mem_count: u32,
     got_func_count: u32,
     needs_memory_base: bool,
@@ -5021,11 +5003,6 @@ impl LinkerDefinedIndices {
             next_func += 1;
             idx
         });
-        let entry_wrapper_func = request.wrap_entry.then(|| {
-            let idx = next_func;
-            next_func += 1;
-            idx
-        });
         for stub in &mut weak_undef_stubs {
             stub.function_index = next_func;
             next_func = next_func
@@ -5041,7 +5018,6 @@ impl LinkerDefinedIndices {
             tls_base_global,
             stack_pointer_defined_slot,
             call_ctors_func,
-            entry_wrapper_func,
             weak_undef_stubs,
             num_defined_globals,
             num_defined_functions,
@@ -5204,6 +5180,114 @@ fn encode_call_sequence_body(calls: &[(u32, usize)]) -> Vec<u8> {
     bytes
 }
 
+fn encode_command_export_wrapper_body(call_ctors: u32, original: u32, n_params: usize) -> Vec<u8> {
+    let mut bytes = vec![0x00]; // 0 locals
+    bytes.push(0x10); // call
+    leb128::write::unsigned(&mut bytes, u64::from(call_ctors))
+        .expect("leb128 write to Vec cannot fail");
+    for i in 0..n_params {
+        bytes.push(0x20); // local.get
+        leb128::write::unsigned(&mut bytes, i as u64).expect("leb128 write to Vec cannot fail");
+    }
+    bytes.push(0x10); // call
+    leb128::write::unsigned(&mut bytes, u64::from(original))
+        .expect("leb128 write to Vec cannot fail");
+    bytes.push(0x0b); // end
+    bytes
+}
+
+/// Like wasm-ld, wrap defined function exports when InitFuncs exist and crt / `--export` does not
+/// already take care of `__wasm_call_ctors`.
+fn should_wrap_command_exports(
+    has_init_funcs: bool,
+    layout_inputs: &[WasmObjectLayoutInput<'_>],
+    exports: &[OutputExport<'_>],
+) -> bool {
+    has_init_funcs
+        && !call_ctors_used_in_objects(layout_inputs)
+        && !export_name_exists(exports, "__wasm_call_ctors")
+}
+
+fn wrap_command_exports(layout: &mut WasmLayout<'_>, call_ctors: u32) -> Result<()> {
+    let (n_func_imports, _) = count_output_imports(layout);
+    let n_func_imports = u32::try_from(n_func_imports).context("too many Wasm function imports")?;
+
+    struct PendingWrap {
+        export_index: usize,
+        original: u32,
+        type_index: u32,
+        n_params: usize,
+        export_name: String,
+    }
+
+    let mut pending = Vec::new();
+    for (export_index, export) in layout.exports.iter().enumerate() {
+        if !matches!(
+            export.kind,
+            wasmparser::ExternalKind::Func | wasmparser::ExternalKind::FuncExact
+        ) {
+            continue;
+        }
+        if export.name == "__wasm_call_ctors" {
+            continue;
+        }
+        if export.index < n_func_imports {
+            continue;
+        }
+        let defined_idx = (export.index - n_func_imports) as usize;
+        let type_index = *layout
+            .function_type_indices
+            .get(defined_idx)
+            .ok_or_else(|| {
+                crate::error!(
+                    "export `{}` function index {} has no type",
+                    export.name,
+                    export.index
+                )
+            })?;
+        let n_params = layout
+            .output_types
+            .get(type_index as usize)
+            .ok_or_else(|| crate::error!("missing Wasm type {type_index}"))?
+            .params()
+            .len();
+        pending.push(PendingWrap {
+            export_index,
+            original: export.index,
+            type_index,
+            n_params,
+            export_name: export.name.to_owned(),
+        });
+    }
+
+    if pending.is_empty() {
+        return Ok(());
+    }
+
+    layout.function_type_indices.reserve(pending.len());
+    layout.function_bodies.reserve(pending.len());
+    layout.command_export_wrapper_names.reserve(pending.len());
+
+    for wrap in pending {
+        let wrapper_index = n_func_imports
+            .checked_add(
+                u32::try_from(layout.function_type_indices.len())
+                    .context("too many Wasm functions")?,
+            )
+            .ok_or_else(|| crate::error!("Wasm function index overflow"))?;
+        layout.function_type_indices.push(wrap.type_index);
+        layout.function_bodies.push(owned_linker_function_body(
+            encode_command_export_wrapper_body(call_ctors, wrap.original, wrap.n_params),
+        ));
+        layout.command_export_wrapper_names.push((
+            wrapper_index,
+            format!("{}.command_export", wrap.export_name),
+        ));
+        layout.exports[wrap.export_index].index = wrapper_index;
+    }
+    Ok(())
+}
+
 fn function_type_for_symbol<'a>(
     input: &'a WasmObjectLayoutInput<'_>,
     sym: &WasmSymbol,
@@ -5288,7 +5372,6 @@ fn emit_reserved_linker_definitions(
     layout: &mut WasmLayout<'_>,
     indices: &LinkerDefinedIndices,
     call_ctors_body: Option<Vec<u8>>,
-    entry_wrapper_body: Option<Vec<u8>>,
 ) {
     let mut linker_globals = Vec::with_capacity(indices.num_defined_globals as usize);
     if indices.memory_base_global.is_some() {
@@ -5356,13 +5439,6 @@ fn emit_reserved_linker_definitions(
         if indices.call_ctors_func.is_some() {
             type_indices.push(void_ty);
             bodies.push(match call_ctors_body {
-                Some(bytes) => owned_linker_function_body(bytes),
-                None => empty_linker_function_body(),
-            });
-        }
-        if indices.entry_wrapper_func.is_some() {
-            type_indices.push(void_ty);
-            bodies.push(match entry_wrapper_body {
                 Some(bytes) => owned_linker_function_body(bytes),
                 None => empty_linker_function_body(),
             });
@@ -5586,30 +5662,21 @@ fn resolve_entry_function<'data>(
     }))
 }
 
-/// Export the command entry (default `_start`). With a wrapper, retarget any existing export.
+/// Export the command entry (default `_start`).
 fn ensure_entry_export<'data>(
     exports: &mut Vec<OutputExport<'data>>,
     entry: Option<&ResolvedEntry<'data>>,
-    entry_wrapper_func: Option<u32>,
 ) {
     let Some(entry) = entry else {
         return;
     };
-    let index = entry_wrapper_func.unwrap_or(entry.function_index);
-    if let Some(existing) = exports
-        .iter_mut()
-        .find(|export| export.name == entry.export_name)
-    {
-        if entry_wrapper_func.is_some() {
-            existing.kind = wasmparser::ExternalKind::Func;
-            existing.index = index;
-        }
+    if export_name_exists(exports, entry.export_name) {
         return;
     }
     exports.push(OutputExport {
         name: entry.export_name,
         kind: wasmparser::ExternalKind::Func,
-        index,
+        index: entry.function_index,
     });
 }
 
@@ -5656,7 +5723,6 @@ fn ensure_force_exports<'data>(
     layout_inputs: &[WasmObjectLayoutInput<'data>],
     object_index_maps: &[WasmObjectIndexMap],
     symbol_db: &SymbolDb<'data, Wasm>,
-    entry: Option<&ResolvedEntry<'data>>,
     indices: &LinkerDefinedIndices,
     file_id_to_index: &HashMap<crate::input_data::FileId, usize>,
 ) -> Result<()> {
@@ -5714,14 +5780,8 @@ fn ensure_force_exports<'data>(
 
         match def_sym.kind {
             WasmSymbolKind::Func => {
-                let mut index =
+                let index =
                     remap_wasm_index(&index_map.function_indices, def_sym.index, "function")?;
-                // If this is the entry and we wrap it, export the wrapper.
-                if let (Some(entry), Some(wrapper)) = (entry, indices.entry_wrapper_func)
-                    && export_name == entry.export_name
-                {
-                    index = wrapper;
-                }
                 push_export(exports, export_name, wasmparser::ExternalKind::Func, index);
             }
             WasmSymbolKind::Global => {
@@ -5792,11 +5852,6 @@ where
     let has_init_funcs = layout_inputs
         .iter()
         .any(|input| !input.init_funcs.is_empty());
-    // Like wasm-ld, wrap only when InitFuncs exist and crt does not already call
-    // `__wasm_call_ctors`.
-    let wrap_entry = has_init_funcs
-        && !call_ctors_used_in_objects(&layout_inputs)
-        && entry_is_defined_function(&layout_inputs, symbol_db, &file_id_to_index);
 
     let (indices, reloc_scan, shared_imports) = setup_got_mem_and_indices(
         &layout_inputs,
@@ -5804,7 +5859,6 @@ where
         symbol_db,
         &file_id_to_index,
         has_init_funcs,
-        wrap_entry,
     )?;
     let got_mem = &reloc_scan.got_mem;
     let got_func = &reloc_scan.got_func;
@@ -5960,22 +6014,10 @@ where
         symbol_db,
         &file_id_to_index,
     )?;
-    let entry_wrapper_body = match (indices.entry_wrapper_func, indices.call_ctors_func, &entry) {
-        (Some(_), Some(ctors), Some(entry)) => Some(encode_call_sequence_body(&[
-            (ctors, 0),
-            (entry.function_index, 0),
-        ])),
-        _ => None,
-    };
 
     {
         timing_phase!("Wasm linker-defined symbols and data addresses");
-        emit_reserved_linker_definitions(
-            &mut layout,
-            &indices,
-            call_ctors_body,
-            entry_wrapper_body,
-        );
+        emit_reserved_linker_definitions(&mut layout, &indices, call_ctors_body);
         deduplicate_output_types(&mut layout);
 
         // wasm-ld always defines a linear memory for executables.
@@ -6036,20 +6078,20 @@ where
             stack_first,
         )?;
         fill_stack_pointer_init(&mut layout, &indices, stack_size, stack_first)?;
-        ensure_entry_export(
-            &mut layout.exports,
-            entry.as_ref(),
-            indices.entry_wrapper_func,
-        );
+        ensure_entry_export(&mut layout.exports, entry.as_ref());
         ensure_force_exports(
             &mut layout.exports,
             &layout_inputs,
             &layout.object_index_maps,
             symbol_db,
-            entry.as_ref(),
             &indices,
             &file_id_to_index,
         )?;
+        if should_wrap_command_exports(has_init_funcs, &layout_inputs, &layout.exports)
+            && let Some(ctors) = indices.call_ctors_func
+        {
+            wrap_command_exports(&mut layout, ctors)?;
+        }
     }
     {
         timing_phase!("Finalize Wasm indirect function table");

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -130,7 +130,8 @@
 //! RunDynSym:{string} If set and RunEnabled:true, then, instead of executing the binary normally,
 //! the binary is loaded as a shared library and the function specified by the string is called. The
 //! function must return an integer to indicate status (status != 42 is an error). Such run is
-//! currently skipped if the shared library is cross compiled.
+//! currently skipped if the shared library is cross compiled. For Wasm, wasmtime is invoked with
+//! `--invoke` on the named export.
 //!
 //! ReferenceLinkers:{linker-names} List of reference linkers to run this test with.
 //!
@@ -876,10 +877,14 @@ fn validate_wasm(wasm_file: &Path, linker_name: &str) -> Result {
     Ok(())
 }
 
-fn run_wasm_with_wasmtime(wasm_file: &Path, linker_name: &str) -> Result {
-    let output = Command::new("wasmtime")
-        .arg("run")
-        .args(["-W", "threads,shared-memory"])
+fn run_wasm_with_wasmtime(wasm_file: &Path, linker_name: &str, invoke: Option<&str>) -> Result {
+    let mut command = Command::new("wasmtime");
+    command.arg("run");
+    command.args(["-W", "threads,shared-memory"]);
+    if let Some(func) = invoke {
+        command.arg("--invoke").arg(func);
+    }
+    let output = command
         .arg(wasm_file)
         .output()
         .context("Failed to run wasmtime")?;
@@ -3081,7 +3086,11 @@ const EXIT_SUCCESS: i32 = 42;
 impl LinkOutput {
     fn run(&self, cross_arch: Option<Architecture>) -> Result {
         if self.command.config.platform == PlatformKind::Wasm {
-            return run_wasm_with_wasmtime(&self.binary, self.linker_used.name());
+            return run_wasm_with_wasmtime(
+                &self.binary,
+                self.linker_used.name(),
+                self.command.config.run_dyn_sym.as_deref(),
+            );
         }
 
         let mut command = if let Some(arch) = cross_arch {
@@ -7305,14 +7314,20 @@ fn run_with_config(
             // If RunDynSym is set, execute our binary by loading it dynamically and calling the
             // configured function.
             if let Some(func) = config.run_dyn_sym.as_ref() {
-                // As we are loading the library directly into our process, our binary cannot be
-                // cross compiled. Also, if we are on a musl libc system, we cannot
-                // use dlopen() as the integration test is a statically linked binary.
-                // In those cases test execution is skipped.
+                // Wasm: `run` already passes `--invoke` to wasmtime.
+                if config.platform == PlatformKind::Wasm {
+                    program
+                        .link_output
+                        .run(cross_arch)
+                        .with_context(|| format!("Failed to run program. {program}"))?;
+                } else if cross_arch.is_none() && !is_musl_used() {
+                    // As we are loading the library directly into our process, our binary cannot be
+                    // cross compiled. Also, if we are on a musl libc system, we cannot
+                    // use dlopen() as the integration test is a statically linked binary.
+                    // In those cases test execution is skipped.
 
-                // TODO: To support those other cases: a small "wrapper executable" can be cross
-                // compiled and dynamically linked to load the shared library instead.
-                if cross_arch.is_none() && !is_musl_used() {
+                    // TODO: To support those other cases: a small "wrapper executable" can be cross
+                    // compiled and dynamically linked to load the shared library instead.
                     program
                         .link_output
                         .run_as_dynlib(func)

--- a/wild/tests/sources/wasm/command-export-wrap/command-export-wrap.c
+++ b/wild/tests/sources/wasm/command-export-wrap/command-export-wrap.c
@@ -1,0 +1,43 @@
+//#Config:with-entry
+//#LinkArgs: --export=foo --export=add
+//#Contains: foo.command_export
+//#Contains: add.command_export
+//#Contains: _start.command_export
+//#ExpectSym: foo
+//#ExpectSym: add
+//#ExpectSym: _start
+
+//#Config:no-entry
+//#LinkArgs: --no-entry --export=foo
+//#RunDynSym: foo
+//#Contains: foo.command_export
+//#DoesNotContain: _start.command_export
+//#ExpectSym: foo
+//#NoSym: _start
+
+//#Config:export-ctors
+//#LinkArgs: --export=__wasm_call_ctors --export=foo
+//#RunEnabled: false
+//#DoesNotContain: .command_export
+//#ExpectSym: __wasm_call_ctors
+//#ExpectSym: foo
+//#ExpectSym: _start
+
+static int x;
+
+__attribute__((constructor(100))) static void init(void) { x = 42; }
+
+void foo(void) {
+  if (x != 42) {
+    __builtin_trap();
+  }
+}
+
+int add(int a, int b) { return a + b; }
+
+void _start(void) {
+  foo();
+  if (add(1, 2) != 3) {
+    __builtin_trap();
+  }
+}

--- a/wild/tests/sources/wasm/constructors-manual/constructors-manual.c
+++ b/wild/tests/sources/wasm/constructors-manual/constructors-manual.c
@@ -1,5 +1,6 @@
-// When the program imports and calls __wasm_call_ctors, do not wrap the entry (wrapping would run
+// When the program imports and calls __wasm_call_ctors, do not wrap exports (wrapping would run
 // constructors twice).
+//#DoesNotContain: .command_export
 
 static int x;
 

--- a/wild/tests/sources/wasm/constructors/constructors.c
+++ b/wild/tests/sources/wasm/constructors/constructors.c
@@ -2,6 +2,7 @@
 //#ExpectSection: Global
 //#ExpectSym: memory
 //#Contains: __stack_pointer
+//#Contains: _start.command_export
 
 static int x;
 

--- a/wild/tests/sources/wasm/export/export.c
+++ b/wild/tests/sources/wasm/export/export.c
@@ -5,6 +5,7 @@
 //#ExpectSym: _start
 //#ExpectSym: memory
 //#NoSym: not_exported
+//#DoesNotContain: .command_export
 
 //#Config:missing-export
 //#LinkArgs: --export does_not_exist

--- a/wild/tests/sources/wasm/no-entry/no-entry.c
+++ b/wild/tests/sources/wasm/no-entry/no-entry.c
@@ -5,6 +5,7 @@
 //#ExpectSym: memory
 //#NoSym: _start
 //#NoSym: custom_entry
+//#DoesNotContain: .command_export
 
 //#Config:custom-entry
 //#LinkArgs: --entry=custom_entry


### PR DESCRIPTION
Match wasm-ld by wrapping all defined function exports with `__wasm_call_ctors`, not just `_start`. Each export is retargeted to a synthetic `{name}.command_export` that runs constructors then the original function. Wrapping is skipped when inputs already use `__wasm_call_ctors` or it is exported explicitly.

Fixes #2395
Part of #1431