### PR TITLE
feat: implement ABSOLUTE in linker scripts

### DIFF
--- a/LINKER_SCRIPT_SUPPORT.md
+++ b/LINKER_SCRIPT_SUPPORT.md
@@ -89,6 +89,7 @@ end lists the features required to link the Linux kernel.
 | `DEFINED(sym)` | ✅ | |
 | `SIZEOF_HEADERS` | ✅ | |
 | `SEGMENT_START(segment, default)` | ✅ | Supports `"text"`, `"data"`, `"bss"`, `"rodata"`; returns `-Ttext`/`-Tdata`/`-Tbss` override if provided, otherwise `default`; unknown segment names always return `default` |
+| `ABSOLUTE(expr)` | ✅ | |
 
 ## MEMORY Command
 

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -4857,6 +4857,7 @@ fn get_symbol_attributes<C: ElfClass>(
             let def_info = &script.internal_symbols.symbol_definitions[local_index.0];
             let shndx = if let crate::parsing::SymbolPlacement::Redirect(redirect) =
                 &def_info.placement
+                && !redirect.expression.is_absolute()
                 && let SymbolLoc::SectionEnd(section_id) = redirect.loc
             {
                 let section_id = layout.output_sections.primary_output_section(section_id);
@@ -4918,6 +4919,9 @@ fn get_defsym_attributes<C: ElfClass>(
             Err(redirect.missing_target(target_name))
         }
     } else {
+        if redirect.expression.is_absolute() {
+            return Ok((object::elf::SHN_ABS.into(), object::elf::STT_NOTYPE));
+        }
         let shndx = match redirect.loc {
             SymbolLoc::SectionEnd(os) => {
                 let os = layout.output_sections.primary_output_section(os);

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -4857,7 +4857,7 @@ fn get_symbol_attributes<C: ElfClass>(
             let def_info = &script.internal_symbols.symbol_definitions[local_index.0];
             let shndx = if let crate::parsing::SymbolPlacement::Redirect(redirect) =
                 &def_info.placement
-                && !redirect.expression.is_absolute()
+                && !redirect.is_absolute
                 && let SymbolLoc::SectionEnd(section_id) = redirect.loc
             {
                 let section_id = layout.output_sections.primary_output_section(section_id);
@@ -4919,7 +4919,7 @@ fn get_defsym_attributes<C: ElfClass>(
             Err(redirect.missing_target(target_name))
         }
     } else {
-        if redirect.expression.is_absolute() {
+        if redirect.is_absolute {
             return Ok((object::elf::SHN_ABS.into(), object::elf::STT_NOTYPE));
         }
         let shndx = match redirect.loc {

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -384,9 +384,9 @@ fn evaluate_expression_value<'data, P: Platform>(
         Expression::BitwiseXor(l, r) => Ok(eval!(l)? ^ eval!(r)?),
         Expression::LeftShift(l, r) => Ok(eval!(l)?.wrapping_shl(eval!(r)? as u32)),
         Expression::RightShift(l, r) => Ok(eval!(l)?.wrapping_shr(eval!(r)? as u32)),
-        Expression::LogicalAnd(l, r) => Ok(u64::from(eval!(l)? != 0 && eval!(r)? != 0)),
-        Expression::LogicalOr(l, r) => Ok(u64::from(eval!(l)? != 0 || eval!(r)? != 0)),
-        Expression::LogicalNot(e) => Ok(u64::from(eval!(e)? == 0)),
+        Expression::LogicalAnd(l, r) => eval_cmp(l, r, false, |a, b| u64::from(a != 0 && b != 0)),
+        Expression::LogicalOr(l, r) => eval_cmp(l, r, false, |a, b| u64::from(a != 0 || b != 0)),
+        Expression::LogicalNot(e) => eval_cmp(e, e, false, |a, _| u64::from(a == 0)),
         Expression::BitwiseNot(e) => Ok(!eval!(e)?),
         Expression::Negate(e) => Ok(eval!(e)?.wrapping_neg()),
 

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -234,6 +234,9 @@ fn evaluate_expression_value<'data, P: Platform>(
 ) -> Result<u64> {
     macro_rules! eval {
         ($e:expr) => {
+            eval!($e, value_kind)
+        };
+        ($e:expr, $value_kind:expr) => {
             evaluate_expression_value(
                 $e,
                 expr_loc,
@@ -244,29 +247,35 @@ fn evaluate_expression_value<'data, P: Platform>(
                 symbol_db,
                 sizeof_headers,
                 resolved_location_counters,
-                value_kind,
+                $value_kind,
                 laid_out_mem_offsets,
                 symbol_resolution_callback,
             )
         };
     }
 
-    macro_rules! eval_abs {
-        ($e:expr) => {
-            evaluate_expression(
-                $e,
-                expr_loc,
-                input_ref,
-                section_layouts,
-                output_sections,
-                memory_regions,
-                symbol_db,
-                sizeof_headers,
-                resolved_location_counters,
-                laid_out_mem_offsets,
-                symbol_resolution_callback,
-            )
-        };
+    macro_rules! eval_cmp {
+        ($l:expr, $r:expr, $cmp:expr) => {{
+            let mut l_kind = ExpressionValueKind::default();
+            let mut r_kind = ExpressionValueKind::default();
+            let mut l_val = eval!($l, &mut l_kind)?;
+            let r_val = eval!($r, &mut r_kind)?;
+
+            if let Some(id) = expr_loc.relative_section_id() {
+                let primary_id = output_sections.primary_output_section(id);
+                let section_base = section_layouts.get(primary_id).mem_offset;
+
+                let l_needs_base = l_kind.contains_section_relative
+                    && !l_kind.contains_absolute
+                    && r_kind.contains_absolute;
+
+                if l_needs_base {
+                    l_val = l_val.wrapping_add(section_base);
+                }
+            }
+
+            Ok(u64::from($cmp(l_val, r_val)))
+        }};
     }
 
     match expr {
@@ -318,12 +327,12 @@ fn evaluate_expression_value<'data, P: Platform>(
         }
 
         // Comparisons return 1 (true) or 0 (false)
-        Expression::LessThan(l, r) => Ok(u64::from(eval_abs!(l)? < eval_abs!(r)?)),
-        Expression::GreaterThan(l, r) => Ok(u64::from(eval_abs!(l)? > eval_abs!(r)?)),
-        Expression::LessEqual(l, r) => Ok(u64::from(eval_abs!(l)? <= eval_abs!(r)?)),
-        Expression::GreaterEqual(l, r) => Ok(u64::from(eval_abs!(l)? >= eval_abs!(r)?)),
-        Expression::Equal(l, r) => Ok(u64::from(eval_abs!(l)? == eval_abs!(r)?)),
-        Expression::NotEqual(l, r) => Ok(u64::from(eval_abs!(l)? != eval_abs!(r)?)),
+        Expression::LessThan(l, r) => eval_cmp!(l, r, |a, b| a < b),
+        Expression::GreaterThan(l, r) => eval_cmp!(l, r, |a, b| a > b),
+        Expression::LessEqual(l, r) => eval_cmp!(l, r, |a, b| a <= b),
+        Expression::GreaterEqual(l, r) => eval_cmp!(l, r, |a, b| a >= b),
+        Expression::Equal(l, r) => eval_cmp!(l, r, |a, b| a == b),
+        Expression::NotEqual(l, r) => eval_cmp!(l, r, |a, b| a != b),
 
         Expression::Sizeof(name) => Ok(section_size(name, section_layouts, output_sections)),
         Expression::Alignof(name) => Ok(section_align(name, section_layouts, output_sections)),
@@ -420,13 +429,40 @@ fn evaluate_expression_value<'data, P: Platform>(
             }
             Ok(result)
         }
-        Expression::Absolute(expression) => todo!(),
+        Expression::Absolute(expression) => {
+            let mut inner_kind = ExpressionValueKind::default();
+            let val = evaluate_expression_value(
+                expression,
+                expr_loc,
+                input_ref,
+                section_layouts,
+                output_sections,
+                memory_regions,
+                symbol_db,
+                sizeof_headers,
+                resolved_location_counters,
+                &mut inner_kind,
+                laid_out_mem_offsets,
+                symbol_resolution_callback,
+            )?;
+            value_kind.contains_absolute = true;
+            value_kind.contains_section_relative = false;
+            if inner_kind.contains_section_relative
+                && let Some(id) = expr_loc.relative_section_id()
+            {
+                let primary_id = output_sections.primary_output_section(id);
+                let section_layout = section_layouts.get(primary_id);
+                return Ok(val.wrapping_add(section_layout.mem_offset));
+            }
+            Ok(val)
+        }
     }
 }
 
 pub(crate) fn evaluate_const<'data>(expr: &Expression<'data>) -> Result<u64> {
     match expr {
         Expression::Number(n) => Ok(*n),
+        Expression::Absolute(expression) => evaluate_const(expression),
         Expression::Add(l, r) => Ok(evaluate_const(l)?.wrapping_add(evaluate_const(r)?)),
         Expression::Subtract(l, r) => Ok(evaluate_const(l)?.wrapping_sub(evaluate_const(r)?)),
         Expression::Multiply(l, r) => Ok(evaluate_const(l)?.wrapping_mul(evaluate_const(r)?)),

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -257,7 +257,7 @@ fn evaluate_expression_value<'data, P: Platform>(
         };
     }
 
-    let mut eval_cmp = |l, r, cmp: fn(u64, u64) -> bool| {
+    let mut eval_cmp = |l, r, update_kind: bool, op: fn(u64, u64) -> u64| -> Result<u64> {
         let mut l_kind = ExpressionValueKind::default();
         let mut r_kind = ExpressionValueKind::default();
         let mut l_val = eval!(l, &mut l_kind)?;
@@ -282,7 +282,18 @@ fn evaluate_expression_value<'data, P: Platform>(
             }
         }
 
-        Ok(u64::from(cmp(l_val, r_val)))
+        if update_kind {
+            if l_kind.contains_absolute || r_kind.contains_absolute {
+                value_kind.contains_absolute = true;
+            }
+            if (l_kind.contains_section_relative || r_kind.contains_section_relative)
+                && !value_kind.contains_absolute
+            {
+                value_kind.contains_section_relative = true;
+            }
+        }
+
+        Ok(op(l_val, r_val))
     };
 
     match expr {
@@ -328,12 +339,12 @@ fn evaluate_expression_value<'data, P: Platform>(
         }
 
         // Comparisons return 1 (true) or 0 (false)
-        Expression::LessThan(l, r) => eval_cmp(l, r, |a, b| a < b),
-        Expression::GreaterThan(l, r) => eval_cmp(l, r, |a, b| a > b),
-        Expression::LessEqual(l, r) => eval_cmp(l, r, |a, b| a <= b),
-        Expression::GreaterEqual(l, r) => eval_cmp(l, r, |a, b| a >= b),
-        Expression::Equal(l, r) => eval_cmp(l, r, |a, b| a == b),
-        Expression::NotEqual(l, r) => eval_cmp(l, r, |a, b| a != b),
+        Expression::LessThan(l, r) => eval_cmp(l, r, false, |a, b| u64::from(a < b)),
+        Expression::GreaterThan(l, r) => eval_cmp(l, r, false, |a, b| u64::from(a > b)),
+        Expression::LessEqual(l, r) => eval_cmp(l, r, false, |a, b| u64::from(a <= b)),
+        Expression::GreaterEqual(l, r) => eval_cmp(l, r, false, |a, b| u64::from(a >= b)),
+        Expression::Equal(l, r) => eval_cmp(l, r, false, |a, b| u64::from(a == b)),
+        Expression::NotEqual(l, r) => eval_cmp(l, r, false, |a, b| u64::from(a != b)),
 
         Expression::Sizeof(name) => Ok(section_size(name, section_layouts, output_sections)),
         Expression::Alignof(name) => Ok(section_align(name, section_layouts, output_sections)),
@@ -366,8 +377,8 @@ fn evaluate_expression_value<'data, P: Platform>(
             Ok(value.next_multiple_of(align))
         }
 
-        Expression::Min(l, r) => Ok(eval!(l)?.min(eval!(r)?)),
-        Expression::Max(l, r) => Ok(eval!(l)?.max(eval!(r)?)),
+        Expression::Min(l, r) => eval_cmp(l, r, true, u64::min),
+        Expression::Max(l, r) => eval_cmp(l, r, true, u64::max),
         Expression::BitwiseAnd(l, r) => Ok(eval!(l)? & eval!(r)?),
         Expression::BitwiseOr(l, r) => Ok(eval!(l)? | eval!(r)?),
         Expression::BitwiseXor(l, r) => Ok(eval!(l)? ^ eval!(r)?),
@@ -408,7 +419,8 @@ fn evaluate_expression_value<'data, P: Platform>(
         }
         Expression::SizeofHeaders => Ok(sizeof_headers),
         Expression::Ternary(cond, if_true, if_false) => {
-            let cond = eval!(cond)?;
+            let mut cond_kind = ExpressionValueKind::default();
+            let cond = eval!(cond, &mut cond_kind)?;
             if cond != 0 {
                 eval!(if_true)
             } else {
@@ -433,14 +445,15 @@ fn evaluate_expression_value<'data, P: Platform>(
         Expression::Absolute(expression) => {
             let mut inner_kind = ExpressionValueKind::default();
             let val = eval!(expression, &mut inner_kind)?;
-            value_kind.contains_absolute = true;
             if inner_kind.contains_section_relative
                 && let Some(id) = expr_loc.relative_section_id()
             {
+                value_kind.contains_absolute = true;
                 let primary_id = output_sections.primary_output_section(id);
                 let section_layout = section_layouts.get(primary_id);
                 return Ok(val.wrapping_add(section_layout.mem_offset));
             }
+            value_kind.contains_absolute |= inner_kind.contains_absolute;
             Ok(val)
         }
     }

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -70,9 +70,7 @@ fn evaluate_symbol_value<P: Platform>(
         .relative_section_id()
         .map(|id| output_sections.primary_output_section(id));
     match symbol_value {
-        SymbolValue::Absolute(value) => {
-            Ok(*value)
-        }
+        SymbolValue::Absolute(value) => Ok(*value),
         SymbolValue::SectionRelative {
             section_id,
             address,

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -264,18 +264,24 @@ fn evaluate_expression_value<'data, P: Platform>(
         let mut l_kind = ExpressionValueKind::default();
         let mut r_kind = ExpressionValueKind::default();
         let mut l_val = eval!(l, &mut l_kind)?;
-        let r_val = eval!(r, &mut r_kind)?;
+        let mut r_val = eval!(r, &mut r_kind)?;
 
         if let Some(id) = expr_loc.relative_section_id() {
             let primary_id = output_sections.primary_output_section(id);
             let section_base = section_layouts.get(primary_id).mem_offset;
 
-            let l_needs_base = l_kind.contains_section_relative
+            if l_kind.contains_section_relative
                 && !l_kind.contains_absolute
-                && r_kind.contains_absolute;
-
-            if l_needs_base {
+                && r_kind.contains_absolute
+            {
                 l_val = l_val.wrapping_add(section_base);
+            }
+
+            if r_kind.contains_section_relative
+                && !r_kind.contains_absolute
+                && l_kind.contains_absolute
+            {
+                r_val = r_val.wrapping_add(section_base);
             }
         }
 

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -218,7 +218,7 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
         0
     };
 
-    Ok(value + offset)
+    Ok(value.wrapping_add(offset))
 }
 
 fn evaluate_expression_value<'data, P: Platform>(

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -254,29 +254,27 @@ fn evaluate_expression_value<'data, P: Platform>(
         };
     }
 
-    macro_rules! eval_cmp {
-        ($l:expr, $r:expr, $cmp:expr) => {{
-            let mut l_kind = ExpressionValueKind::default();
-            let mut r_kind = ExpressionValueKind::default();
-            let mut l_val = eval!($l, &mut l_kind)?;
-            let r_val = eval!($r, &mut r_kind)?;
+    let mut eval_cmp = |l, r, cmp: fn(u64, u64) -> bool| {
+        let mut l_kind = ExpressionValueKind::default();
+        let mut r_kind = ExpressionValueKind::default();
+        let mut l_val = eval!(l, &mut l_kind)?;
+        let r_val = eval!(r, &mut r_kind)?;
 
-            if let Some(id) = expr_loc.relative_section_id() {
-                let primary_id = output_sections.primary_output_section(id);
-                let section_base = section_layouts.get(primary_id).mem_offset;
+        if let Some(id) = expr_loc.relative_section_id() {
+            let primary_id = output_sections.primary_output_section(id);
+            let section_base = section_layouts.get(primary_id).mem_offset;
 
-                let l_needs_base = l_kind.contains_section_relative
-                    && !l_kind.contains_absolute
-                    && r_kind.contains_absolute;
+            let l_needs_base = l_kind.contains_section_relative
+                && !l_kind.contains_absolute
+                && r_kind.contains_absolute;
 
-                if l_needs_base {
-                    l_val = l_val.wrapping_add(section_base);
-                }
+            if l_needs_base {
+                l_val = l_val.wrapping_add(section_base);
             }
+        }
 
-            Ok(u64::from($cmp(l_val, r_val)))
-        }};
-    }
+        Ok(u64::from(cmp(l_val, r_val)))
+    };
 
     match expr {
         Expression::Number(n) => Ok(*n),
@@ -327,12 +325,12 @@ fn evaluate_expression_value<'data, P: Platform>(
         }
 
         // Comparisons return 1 (true) or 0 (false)
-        Expression::LessThan(l, r) => eval_cmp!(l, r, |a, b| a < b),
-        Expression::GreaterThan(l, r) => eval_cmp!(l, r, |a, b| a > b),
-        Expression::LessEqual(l, r) => eval_cmp!(l, r, |a, b| a <= b),
-        Expression::GreaterEqual(l, r) => eval_cmp!(l, r, |a, b| a >= b),
-        Expression::Equal(l, r) => eval_cmp!(l, r, |a, b| a == b),
-        Expression::NotEqual(l, r) => eval_cmp!(l, r, |a, b| a != b),
+        Expression::LessThan(l, r) => eval_cmp(l, r, |a, b| a < b),
+        Expression::GreaterThan(l, r) => eval_cmp(l, r, |a, b| a > b),
+        Expression::LessEqual(l, r) => eval_cmp(l, r, |a, b| a <= b),
+        Expression::GreaterEqual(l, r) => eval_cmp(l, r, |a, b| a >= b),
+        Expression::Equal(l, r) => eval_cmp(l, r, |a, b| a == b),
+        Expression::NotEqual(l, r) => eval_cmp(l, r, |a, b| a != b),
 
         Expression::Sizeof(name) => Ok(section_size(name, section_layouts, output_sections)),
         Expression::Alignof(name) => Ok(section_align(name, section_layouts, output_sections)),

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -71,7 +71,6 @@ fn evaluate_symbol_value<P: Platform>(
         .map(|id| output_sections.primary_output_section(id));
     match symbol_value {
         SymbolValue::Absolute(value) => {
-            value_kind.contains_absolute = true;
             Ok(*value)
         }
         SymbolValue::SectionRelative {
@@ -436,10 +435,10 @@ fn evaluate_expression_value<'data, P: Platform>(
         Expression::Absolute(expression) => {
             let mut inner_kind = ExpressionValueKind::default();
             let val = eval!(expression, &mut inner_kind)?;
+            value_kind.contains_absolute = true;
             if inner_kind.contains_section_relative
                 && let Some(id) = expr_loc.relative_section_id()
             {
-                value_kind.contains_absolute = true;
                 let primary_id = output_sections.primary_output_section(id);
                 let section_layout = section_layouts.get(primary_id);
                 return Ok(val.wrapping_add(section_layout.mem_offset));
@@ -1119,11 +1118,11 @@ mod tests {
                     .iter()
                     .map(|assertion| {
                         InternalSymDefInfo::new(
-                            SymbolPlacement::Redirect(Redirect {
-                                kind: RedirectKind::Script,
-                                expression: Expression::Assert(assertion.clone()),
-                                loc: SymbolLoc::None,
-                            }),
+                            SymbolPlacement::Redirect(Redirect::new(
+                                RedirectKind::Script,
+                                Expression::Assert(assertion.clone()),
+                                SymbolLoc::None,
+                            )),
                             b"",
                         )
                     })

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -143,7 +143,13 @@ fn evaluate_location<'data, P: Platform>(
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
     output_sections: &OutputSections<'data, P>,
     resolved_location_counters: &[ResolvedLocationCounter],
+    value_kind: &mut ExpressionValueKind,
 ) -> Result<u64> {
+    if expr_loc.relative_section_id().is_some() {
+        value_kind.contains_section_relative = true;
+    } else {
+        value_kind.contains_absolute = true;
+    }
     match expr_loc {
         SymbolLoc::SectionStartRelative(_) => Ok(0),
         SymbolLoc::SectionEndRelative(id) => {
@@ -203,7 +209,7 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
         symbol_resolution_callback,
     )?;
 
-    let offset = if value_kind.needs_section_base() {
+    let offset = if !expr.is_absolute() && value_kind.needs_section_base() {
         if let Some(id) = expr_loc.relative_section_id() {
             let primary_id = output_sections.primary_output_section(id);
             let section_layout = section_layouts.get(primary_id);
@@ -279,19 +285,13 @@ fn evaluate_expression_value<'data, P: Platform>(
     match expr {
         Expression::Number(n) => Ok(*n),
 
-        Expression::LocationCounter => {
-            if expr_loc.relative_section_id().is_some() {
-                value_kind.contains_section_relative = true;
-            } else {
-                value_kind.contains_absolute = true;
-            }
-            evaluate_location(
-                expr_loc,
-                section_layouts,
-                output_sections,
-                resolved_location_counters,
-            )
-        }
+        Expression::LocationCounter => evaluate_location(
+            expr_loc,
+            section_layouts,
+            output_sections,
+            resolved_location_counters,
+            value_kind,
+        ),
 
         Expression::Symbol(name) => {
             let value = symbol_resolution_callback(name)?;
@@ -349,18 +349,18 @@ fn evaluate_expression_value<'data, P: Platform>(
             if align == 0 {
                 bail!("ALIGN(0) is invalid");
             }
-            let expr = expr.as_ref().map_or_else(
-                || {
-                    evaluate_location(
-                        expr_loc,
-                        section_layouts,
-                        output_sections,
-                        resolved_location_counters,
-                    )
-                },
-                |e| eval!(e),
-            )?;
-            Ok(expr.next_multiple_of(align))
+            let value = if let Some(expr) = expr {
+                eval!(expr)?
+            } else {
+                evaluate_location(
+                    expr_loc,
+                    section_layouts,
+                    output_sections,
+                    resolved_location_counters,
+                    value_kind,
+                )?
+            };
+            Ok(value.next_multiple_of(align))
         }
 
         Expression::Min(l, r) => Ok(eval!(l)?.min(eval!(r)?)),
@@ -429,25 +429,11 @@ fn evaluate_expression_value<'data, P: Platform>(
         }
         Expression::Absolute(expression) => {
             let mut inner_kind = ExpressionValueKind::default();
-            let val = evaluate_expression_value(
-                expression,
-                expr_loc,
-                input_ref,
-                section_layouts,
-                output_sections,
-                memory_regions,
-                symbol_db,
-                sizeof_headers,
-                resolved_location_counters,
-                &mut inner_kind,
-                laid_out_mem_offsets,
-                symbol_resolution_callback,
-            )?;
-            value_kind.contains_absolute = true;
-            value_kind.contains_section_relative = false;
+            let val = eval!(expression, &mut inner_kind)?;
             if inner_kind.contains_section_relative
                 && let Some(id) = expr_loc.relative_section_id()
             {
+                value_kind.contains_absolute = true;
                 let primary_id = output_sections.primary_output_section(id);
                 let section_layout = section_layouts.get(primary_id);
                 return Ok(val.wrapping_add(section_layout.mem_offset));
@@ -665,9 +651,8 @@ fn evaluate_early_expression_internal_symbol<'data, P: Platform>(
             );
             visited_nodes.remove(&canonical_id);
             let value = value?;
-            let symbol_section = redirect
-                .loc
-                .relative_section_id()
+            let symbol_section = symbol_db
+                .output_section_id(canonical_id)
                 .map(|id| output_sections.primary_output_section(id));
             if let Some(symbol_section) = symbol_section {
                 Ok(SymbolValue::SectionRelative {

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -420,6 +420,7 @@ fn evaluate_expression_value<'data, P: Platform>(
             }
             Ok(result)
         }
+        Expression::Absolute(expression) => todo!(),
     }
 }
 

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -209,28 +209,28 @@ impl<'data> LayoutRulesBuilder<'data> {
 
         for cmd in &input.script.commands {
             if let linker_script::Command::Provide(provide) = cmd {
-                let placement = SymbolPlacement::Redirect(Redirect {
-                    kind: RedirectKind::Script,
-                    expression: provide.value.clone(),
-                    loc: loc_for_global_expr(&provide.value, current_section_id),
-                });
+                let placement = SymbolPlacement::Redirect(Redirect::new(
+                    RedirectKind::Script,
+                    provide.value.clone(),
+                    loc_for_global_expr(&provide.value, current_section_id),
+                ));
                 symbol_defs.push(
                     crate::parsing::InternalSymDefInfo::new(placement, provide.name)
                         .with_hidden(provide.hidden),
                 );
             } else if let linker_script::Command::SymbolDefinition { name, value } = cmd {
-                let placement = SymbolPlacement::Redirect(Redirect {
-                    kind: RedirectKind::Script,
-                    expression: value.to_owned(),
-                    loc: loc_for_global_expr(value, current_section_id),
-                });
+                let placement = SymbolPlacement::Redirect(Redirect::new(
+                    RedirectKind::Script,
+                    value.to_owned(),
+                    loc_for_global_expr(value, current_section_id),
+                ));
                 symbol_defs.push(crate::parsing::InternalSymDefInfo::new(placement, name));
             } else if let linker_script::Command::SetLocation(loc) = cmd {
-                let placement = SymbolPlacement::Redirect(Redirect {
-                    kind: RedirectKind::Script,
-                    expression: loc.address.clone(),
-                    loc: loc_for_global_expr(&loc.address, current_section_id),
-                });
+                let placement = SymbolPlacement::Redirect(Redirect::new(
+                    RedirectKind::Script,
+                    loc.address.clone(),
+                    loc_for_global_expr(&loc.address, current_section_id),
+                ));
                 symbol_defs.push(crate::parsing::InternalSymDefInfo::new(placement, b""));
             } else if let linker_script::Command::Sections(sections) = cmd {
                 let mut section_start_lc_idx = last_lc_idx;
@@ -360,22 +360,22 @@ impl<'data> LayoutRulesBuilder<'data> {
                                         last_symbol_loc = SymbolLoc::SectionEndRelative(section_id);
                                     }
                                     ContentsCommand::SymbolAssignment(assignment) => {
-                                        let placement = SymbolPlacement::Redirect(Redirect {
-                                            kind: RedirectKind::Script,
-                                            expression: assignment.expr.clone(),
-                                            loc: last_symbol_loc.clone(),
-                                        });
+                                        let placement = SymbolPlacement::Redirect(Redirect::new(
+                                            RedirectKind::Script,
+                                            assignment.expr.clone(),
+                                            last_symbol_loc.clone(),
+                                        ));
                                         symbol_defs.push(InternalSymDefInfo::new(
                                             placement,
                                             assignment.name,
                                         ));
                                     }
                                     ContentsCommand::Provide(provide) => {
-                                        let placement = SymbolPlacement::Redirect(Redirect {
-                                            kind: RedirectKind::Script,
-                                            expression: provide.value.clone(),
-                                            loc: last_symbol_loc.clone(),
-                                        });
+                                        let placement = SymbolPlacement::Redirect(Redirect::new(
+                                            RedirectKind::Script,
+                                            provide.value.clone(),
+                                            last_symbol_loc.clone(),
+                                        ));
                                         symbol_defs.push(
                                             InternalSymDefInfo::new(placement, provide.name)
                                                 .with_hidden(provide.hidden),
@@ -398,11 +398,11 @@ impl<'data> LayoutRulesBuilder<'data> {
                                     // (https://sourceware.org/binutils/docs/ld/Output-Section-Keywords.html#index-CONSTRUCTORS)
                                     ContentsCommand::Constructors => (),
                                     ContentsCommand::Assert(assert_cmd) => {
-                                        let placement = SymbolPlacement::Redirect(Redirect {
-                                            kind: RedirectKind::Script,
-                                            expression: Expression::Assert(assert_cmd.clone()),
-                                            loc: last_symbol_loc.clone(),
-                                        });
+                                        let placement = SymbolPlacement::Redirect(Redirect::new(
+                                            RedirectKind::Script,
+                                            Expression::Assert(assert_cmd.clone()),
+                                            last_symbol_loc.clone(),
+                                        ));
                                         symbol_defs.push(InternalSymDefInfo::new(placement, b""));
                                     }
                                 }
@@ -435,40 +435,40 @@ impl<'data> LayoutRulesBuilder<'data> {
                             last_lc_idx += 1;
                         }
                         SectionCommand::Assert(assert_cmd) => {
-                            let placement = SymbolPlacement::Redirect(Redirect {
-                                kind: RedirectKind::Script,
-                                expression: Expression::Assert(assert_cmd.clone()),
-                                loc: loc.clone(),
-                            });
+                            let placement = SymbolPlacement::Redirect(Redirect::new(
+                                RedirectKind::Script,
+                                Expression::Assert(assert_cmd.clone()),
+                                loc.clone(),
+                            ));
                             symbol_defs.push(InternalSymDefInfo::new(placement, b""));
                         }
                         SectionCommand::Provide(provide) => {
-                            let placement = SymbolPlacement::Redirect(Redirect {
-                                kind: RedirectKind::Script,
-                                expression: provide.value.clone(),
-                                loc: loc.clone(),
-                            });
+                            let placement = SymbolPlacement::Redirect(Redirect::new(
+                                RedirectKind::Script,
+                                provide.value.clone(),
+                                loc.clone(),
+                            ));
                             symbol_defs.push(
                                 InternalSymDefInfo::new(placement, provide.name)
                                     .with_hidden(provide.hidden),
                             );
                         }
                         SectionCommand::SymbolAssignment(assignment) => {
-                            let placement = SymbolPlacement::Redirect(Redirect {
-                                kind: RedirectKind::Script,
-                                expression: assignment.expr.clone(),
-                                loc: loc.clone(),
-                            });
+                            let placement = SymbolPlacement::Redirect(Redirect::new(
+                                RedirectKind::Script,
+                                assignment.expr.clone(),
+                                loc.clone(),
+                            ));
                             symbol_defs.push(InternalSymDefInfo::new(placement, assignment.name));
                         }
                     }
                 }
             } else if let linker_script::Command::Assert(assert_cmd) = cmd {
-                let placement = SymbolPlacement::Redirect(Redirect {
-                    kind: RedirectKind::Script,
-                    expression: Expression::Assert(assert_cmd.clone()),
-                    loc: loc_for_global_expr(&assert_cmd.expression, None),
-                });
+                let placement = SymbolPlacement::Redirect(Redirect::new(
+                    RedirectKind::Script,
+                    Expression::Assert(assert_cmd.clone()),
+                    loc_for_global_expr(&assert_cmd.expression, None),
+                ));
                 symbol_defs.push(InternalSymDefInfo::new(placement, b""));
             } else if let linker_script::Command::Memory(regions) = cmd {
                 memory_regions = regions.clone();

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -358,6 +358,13 @@ impl<'a> Expression<'a> {
                 | (ExprKind::PlainNumber, ExprKind::Absolute) => ExprKind::Absolute,
                 _ => ExprKind::SectionRelative,
             },
+            Expression::Min(l, r) | Expression::Max(l, r) | Expression::Ternary(_, l, r) => {
+                match (l.expr_kind(), r.expr_kind()) {
+                    (ExprKind::PlainNumber, ExprKind::PlainNumber) => ExprKind::PlainNumber,
+                    (ExprKind::Absolute, _) | (_, ExprKind::Absolute) => ExprKind::Absolute,
+                    _ => ExprKind::SectionRelative,
+                }
+            }
             Expression::Negate(e) | Expression::BitwiseNot(e) => e.expr_kind(),
             _ => ExprKind::SectionRelative,
         }

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -336,8 +336,39 @@ impl<'a> Expression<'a> {
     }
 
     pub(crate) fn is_absolute(&self) -> bool {
-        matches!(self, Expression::Absolute(_))
+        self.expr_kind() == ExprKind::Absolute
     }
+
+    fn expr_kind(&self) -> ExprKind {
+        match self {
+            Expression::Number(_) => ExprKind::PlainNumber,
+            Expression::Absolute(_) => ExprKind::Absolute,
+            Expression::Add(l, r)
+            | Expression::Subtract(l, r)
+            | Expression::Multiply(l, r)
+            | Expression::Divide(l, r)
+            | Expression::Modulo(l, r)
+            | Expression::BitwiseAnd(l, r)
+            | Expression::BitwiseOr(l, r)
+            | Expression::BitwiseXor(l, r)
+            | Expression::LeftShift(l, r)
+            | Expression::RightShift(l, r) => match (l.expr_kind(), r.expr_kind()) {
+                (ExprKind::PlainNumber, ExprKind::PlainNumber) => ExprKind::PlainNumber,
+                (ExprKind::Absolute, ExprKind::PlainNumber)
+                | (ExprKind::PlainNumber, ExprKind::Absolute) => ExprKind::Absolute,
+                _ => ExprKind::SectionRelative,
+            },
+            Expression::Negate(e) | Expression::BitwiseNot(e) => e.expr_kind(),
+            _ => ExprKind::SectionRelative,
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum ExprKind {
+    PlainNumber,
+    Absolute,
+    SectionRelative,
 }
 
 impl<'data> LinkerScript<'data> {

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -365,7 +365,9 @@ impl<'a> Expression<'a> {
                     _ => ExprKind::SectionRelative,
                 }
             }
-            Expression::Negate(e) | Expression::BitwiseNot(e) => e.expr_kind(),
+            Expression::Negate(e) | Expression::BitwiseNot(e) | Expression::LogicalNot(e) => {
+                e.expr_kind()
+            }
             _ => ExprKind::SectionRelative,
         }
     }

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -199,7 +199,7 @@ pub(crate) struct OutputFormat<'a> {
 /// - Logical: &&, ||
 /// - Unary: -, !, ~
 /// - Functions: SIZEOF, ALIGNOF, LENGTH, ORIGIN, ADDR, LOADADDR, ALIGN, MIN, MAX, SEGMENT_START,
-///   DEFINED
+///   DEFINED, ABSOLUTE
 /// - Numbers (hex/decimal), symbols, location counter (.)
 /// - Parentheses for grouping
 /// - Ternary operator (? :)
@@ -261,6 +261,7 @@ pub(crate) enum Expression<'a> {
     ),
     Defined(&'a [u8]),
     Assert(AssertCommand<'a>),
+    Absolute(Box<Expression<'a>>),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -323,7 +324,8 @@ impl<'a> Expression<'a> {
             | Expression::LogicalNot(e)
             | Expression::BitwiseNot(e)
             | Expression::Negate(e)
-            | Expression::Assert(AssertCommand { expression: e, .. }) => e.visit_expressions(cb),
+            | Expression::Assert(AssertCommand { expression: e, .. })
+            | Expression::Absolute(e) => e.visit_expressions(cb),
             Expression::SegmentStart(_, default_expr) => default_expr.visit_expressions(cb),
             Expression::Ternary(expression, expression1, expression2) => {
                 expression.visit_expressions(cb);
@@ -1037,6 +1039,14 @@ fn parse_identifier_or_function<'a>(input: &mut &'a BStr) -> winnow::Result<Expr
             b"ASSERT" => {
                 let assert = parse_assert.parse_next(input)?;
                 Ok(Expression::Assert(assert))
+            }
+            b"ABSOLUTE" => {
+                '('.parse_next(input)?;
+                skip_comments_and_whitespace(input)?;
+                let expr = parse_expression.parse_next(input)?;
+                skip_comments_and_whitespace(input)?;
+                ')'.parse_next(input)?;
+                Ok(Expression::Absolute(Box::new(expr)))
             }
             _ => Err(ContextError::default()),
         }

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -334,6 +334,10 @@ impl<'a> Expression<'a> {
             }
         }
     }
+
+    pub(crate) fn is_absolute(&self) -> bool {
+        matches!(self, Expression::Absolute(_))
+    }
 }
 
 impl<'data> LinkerScript<'data> {

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -137,6 +137,19 @@ pub(crate) struct Redirect<'data> {
     pub(crate) kind: RedirectKind,
     pub(crate) expression: Expression<'data>,
     pub(crate) loc: SymbolLoc,
+    pub(crate) is_absolute: bool,
+}
+
+impl<'data> Redirect<'data> {
+    pub(crate) fn new(kind: RedirectKind, expression: Expression<'data>, loc: SymbolLoc) -> Self {
+        let is_absolute = expression.is_absolute();
+        Self {
+            kind,
+            expression,
+            loc,
+            is_absolute,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -250,11 +263,11 @@ impl<'data, P: Platform> Prelude<'data, P> {
                 let expr = crate::linker_script::parse_expression(&mut value)
                     .with_context(|| format!("Failed to parse --defsym {name}={value}"))?;
 
-                let placement = SymbolPlacement::Redirect(Redirect {
-                    kind: RedirectKind::DefSym,
-                    expression: expr,
-                    loc: SymbolLoc::None,
-                });
+                let placement = SymbolPlacement::Redirect(Redirect::new(
+                    RedirectKind::DefSym,
+                    expr,
+                    SymbolLoc::None,
+                ));
                 symbols.add_symbol(InternalSymDefInfo::new(placement, name.as_bytes()));
                 Ok(())
             })?;

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -868,7 +868,11 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
                 let local_index = symbol_id.to_input(script.symbol_id_range);
                 let def_info = script.parsed.symbol_defs.get(local_index.0)?;
                 if let crate::parsing::SymbolPlacement::Redirect(redirect) = &def_info.placement {
-                    redirect.loc.relative_section_id()
+                    if redirect.expression.is_absolute() {
+                        None
+                    } else {
+                        redirect.loc.relative_section_id()
+                    }
                 } else {
                     None
                 }
@@ -2143,7 +2147,8 @@ impl<'data, P: Platform> Prelude<'data, P> {
                 }
                 SymbolPlacement::Redirect(redirect) => {
                     outputs.add_non_versioned(PendingSymbol::new(symbol_id, definition.name));
-                    if matches!(redirect.loc, SymbolLoc::None) {
+                    if matches!(redirect.loc, SymbolLoc::None) || redirect.expression.is_absolute()
+                    {
                         ValueFlags::NON_INTERPOSABLE | ValueFlags::ABSOLUTE
                     } else {
                         ValueFlags::NON_INTERPOSABLE
@@ -2167,7 +2172,17 @@ impl std::fmt::Display for SymbolId {
 impl<P: Platform> InternalSymDefInfo<'_, P> {
     pub(crate) fn section_id(&self) -> Option<OutputSectionId> {
         match self.placement {
-            SymbolPlacement::Redirect(Redirect { ref loc, .. }) => loc.section_id(),
+            SymbolPlacement::Redirect(Redirect {
+                ref loc,
+                ref expression,
+                ..
+            }) => {
+                if expression.is_absolute() {
+                    None
+                } else {
+                    loc.section_id()
+                }
+            }
             SymbolPlacement::Undefined
             | SymbolPlacement::ForceUndefined
             | SymbolPlacement::PlatformSpecific(_) => None,

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -28,7 +28,6 @@ use crate::output_section_map::OutputSectionMap;
 use crate::parsing;
 use crate::parsing::InternalSymDefInfo;
 use crate::parsing::Prelude;
-use crate::parsing::Redirect;
 use crate::parsing::SymbolLoc;
 use crate::parsing::SymbolPlacement;
 use crate::parsing::SyntheticSymbols;
@@ -868,7 +867,7 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
                 let local_index = symbol_id.to_input(script.symbol_id_range);
                 let def_info = script.parsed.symbol_defs.get(local_index.0)?;
                 if let crate::parsing::SymbolPlacement::Redirect(redirect) = &def_info.placement {
-                    if redirect.expression.is_absolute() {
+                    if redirect.is_absolute {
                         None
                     } else {
                         redirect.loc.relative_section_id()
@@ -2147,8 +2146,7 @@ impl<'data, P: Platform> Prelude<'data, P> {
                 }
                 SymbolPlacement::Redirect(redirect) => {
                     outputs.add_non_versioned(PendingSymbol::new(symbol_id, definition.name));
-                    if matches!(redirect.loc, SymbolLoc::None) || redirect.expression.is_absolute()
-                    {
+                    if matches!(redirect.loc, SymbolLoc::None) || redirect.is_absolute {
                         ValueFlags::NON_INTERPOSABLE | ValueFlags::ABSOLUTE
                     } else {
                         ValueFlags::NON_INTERPOSABLE
@@ -2172,15 +2170,11 @@ impl std::fmt::Display for SymbolId {
 impl<P: Platform> InternalSymDefInfo<'_, P> {
     pub(crate) fn section_id(&self) -> Option<OutputSectionId> {
         match self.placement {
-            SymbolPlacement::Redirect(Redirect {
-                ref loc,
-                ref expression,
-                ..
-            }) => {
-                if expression.is_absolute() {
+            SymbolPlacement::Redirect(ref redirect) => {
+                if redirect.is_absolute {
                     None
                 } else {
-                    loc.section_id()
+                    redirect.loc.section_id()
                 }
             }
             SymbolPlacement::Undefined

--- a/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.c
+++ b/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.c
@@ -1,0 +1,11 @@
+//#ReferenceLinkers:bfd
+//#Object:runtime.c
+//#LinkerScript:linker-script-absolute.ld
+//#SkipArch:riscv64
+
+#include "../common/runtime.h"
+
+void _start(void) {
+  runtime_init();
+  exit_syscall(42);
+}

--- a/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.c
+++ b/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.c
@@ -2,6 +2,7 @@
 //#Object:runtime.c
 //#LinkerScript:linker-script-absolute.ld
 //#SkipArch:riscv64
+//#ExpectSym:absolute_plus address=24
 
 #include "../common/runtime.h"
 

--- a/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.c
+++ b/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.c
@@ -3,6 +3,9 @@
 //#LinkerScript:linker-script-absolute.ld
 //#SkipArch:riscv64
 //#ExpectSym:absolute_plus address=24
+//#ExpectSym:abs_lnot address=0
+//#ExpectSym:abs_land section=".text"
+//#ExpectSym:abs_lor section=".text"
 
 #include "../common/runtime.h"
 

--- a/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.ld
+++ b/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.ld
@@ -1,0 +1,58 @@
+ENTRY(_start)
+
+abs_global = ABSOLUTE(0x1000);
+abs_global_calc = ABSOLUTE(0x1000 + 0x500);
+
+SECTIONS
+{
+    . = 0x400000;
+    .text : {
+        text_start = .;
+        a = . + 0x20;
+        b = . + 0x10;
+
+        abs_const = ABSOLUTE(0x500);
+        abs_dot = ABSOLUTE(.);
+        abs_sym_a = ABSOLUTE(a);
+        abs_sum_two = ABSOLUTE(ABSOLUTE(a) + ABSOLUTE(b));
+        abs_max_func = ABSOLUTE(MAX(a, b));
+        abs_nested = ABSOLUTE(ABSOLUTE(a));
+
+        ASSERT(a == ABSOLUTE(text_start) + 0x20, "a failed");
+
+        ASSERT(abs_global == 0x1000, "abs_global failed");
+        ASSERT(abs_global_calc == 0x1500, "abs_global_calc failed");
+        ASSERT(abs_const == 0x500, "abs_const failed");
+
+        ASSERT(abs_dot == ABSOLUTE(text_start), "abs_dot failed");
+        ASSERT(abs_dot != text_start, "abs_dot failed");
+        ASSERT((abs_dot * 2) == (ABSOLUTE(text_start) * 2), "abs_dot failed");
+        ASSERT((abs_dot * 2) != (text_start * 2), "abs_dot failed");
+
+        ASSERT(abs_sym_a == ABSOLUTE(text_start) + 0x20, "abs_sym_a failed");
+        ASSERT(abs_sym_a != text_start + 0x20, "abs_sym_a failed");
+
+        ASSERT(abs_sum_two == ABSOLUTE(text_start) * 2 + 0x30, "abs_sum_two failed");
+        ASSERT(abs_sum_two != text_start * 2 + 0x30, "abs_sum_two failed");
+
+        ASSERT(abs_max_func == ABSOLUTE(text_start) + 0x20, "abs_max_func failed");
+        ASSERT(abs_max_func != text_start + 0x20, "abs_max_func failed");
+
+        ASSERT(abs_nested == ABSOLUTE(text_start) + 0x20, "abs_nested failed");
+
+        *(.text)
+    }
+
+    . = 0x600000;
+    .data : {
+        data_start = .;
+
+        ASSERT(abs_const == 0x500, "abs_const failed");
+
+        *(.data .data.*)
+    }
+
+    .bss : {
+        *(.bss .bss.*)
+    }
+}

--- a/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.ld
+++ b/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.ld
@@ -17,6 +17,15 @@ SECTIONS
         abs_sum_two = ABSOLUTE(ABSOLUTE(a) + ABSOLUTE(b));
         abs_max_func = ABSOLUTE(MAX(a, b));
         abs_nested = ABSOLUTE(ABSOLUTE(a));
+        absolute_aligned = ABSOLUTE(ALIGN(16));
+        absolute_plus = ABSOLUTE(16) + 8;
+
+        padding = ABSOLUTE(16);
+        . += padding;
+        after_padding = .;
+
+        absolute_last = ABSOLUTE(. + ABSOLUTE(0));
+        absolute_first = ABSOLUTE(ABSOLUTE(0) + .);
 
         ASSERT(a == ABSOLUTE(text_start) + 0x20, "a failed");
 
@@ -40,6 +49,15 @@ SECTIONS
 
         ASSERT(abs_nested == ABSOLUTE(text_start) + 0x20, "abs_nested failed");
 
+        ASSERT(absolute_aligned == ABSOLUTE(text_start), "absolute_aligned failed");
+        ASSERT(absolute_aligned != text_start, "absolute_aligned failed");
+
+        ASSERT(absolute_plus == 24, "arithmetic must preserve absolute symbol classification");
+
+        ASSERT(after_padding == text_start + 0x10, "after_padding failed");
+
+        ASSERT(absolute_first == absolute_last, "order does not afftect value");
+
         *(.text)
     }
 
@@ -56,3 +74,5 @@ SECTIONS
         *(.bss .bss.*)
     }
 }
+
+ASSERT(absolute_aligned == text_start, "absolute_aligned failed");

--- a/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.ld
+++ b/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.ld
@@ -56,7 +56,7 @@ SECTIONS
 
         ASSERT(after_padding == text_start + 0x10, "after_padding failed");
 
-        ASSERT(absolute_first == absolute_last, "order does not afftect value");
+        ASSERT(absolute_first == absolute_last, "order does not affect value");
 
         *(.text)
     }

--- a/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.ld
+++ b/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.ld
@@ -27,7 +27,13 @@ SECTIONS
         absolute_last = ABSOLUTE(. + ABSOLUTE(0));
         absolute_first = ABSOLUTE(ABSOLUTE(0) + .);
 
+        ASSERT(ABSOLUTE(.) == ., "absolute location must equal relative location");
+        ASSERT(. == ABSOLUTE(.), "absolute location must equal relative location");
+
+        ASSERT(text_start == ABSOLUTE(text_start), "ABSOLUTE(text_start) == text_start");
+        ASSERT(ABSOLUTE(text_start) == text_start, "ABSOLUTE(text_start) == text_start");
         ASSERT(a == ABSOLUTE(text_start) + 0x20, "a failed");
+        ASSERT(ABSOLUTE(text_start) + 0x20 == a, "absolute+const == relative");
 
         ASSERT(abs_global == 0x1000, "abs_global failed");
         ASSERT(abs_global_calc == 0x1500, "abs_global_calc failed");
@@ -36,6 +42,7 @@ SECTIONS
         ASSERT(abs_dot == ABSOLUTE(text_start), "abs_dot failed");
         ASSERT(abs_dot != text_start, "abs_dot failed");
         ASSERT((abs_dot * 2) == (ABSOLUTE(text_start) * 2), "abs_dot failed");
+        ASSERT((ABSOLUTE(text_start) * 2) == (abs_dot * 2), "abs_dot failed");
         ASSERT((abs_dot * 2) != (text_start * 2), "abs_dot failed");
 
         ASSERT(abs_sym_a == ABSOLUTE(text_start) + 0x20, "abs_sym_a failed");
@@ -45,6 +52,7 @@ SECTIONS
         ASSERT(abs_sum_two != text_start * 2 + 0x30, "abs_sum_two failed");
 
         ASSERT(abs_max_func == ABSOLUTE(text_start) + 0x20, "abs_max_func failed");
+        ASSERT(ABSOLUTE(text_start) + 0x20 == abs_max_func, "abs_max_func failed");
         ASSERT(abs_max_func != text_start + 0x20, "abs_max_func failed");
 
         ASSERT(abs_nested == ABSOLUTE(text_start) + 0x20, "abs_nested failed");

--- a/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.ld
+++ b/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.ld
@@ -25,6 +25,14 @@ SECTIONS
         absolute_max = MAX(ABSOLUTE(16), ABSOLUTE(24));
         ASSERT(absolute_max == 24, "MAX must preserve absolute symbol classification");
 
+        abs_land = ABSOLUTE(1) && ADDR(.text);
+        abs_lor = ABSOLUTE(0) || ADDR(.text);
+        abs_lnot = !ABSOLUTE(ADDR(.text));
+
+        ASSERT(abs_land == text_start + 1, "abs_land inside failed");
+        ASSERT(abs_lor == text_start + 1, "abs_lor inside failed");
+        ASSERT(abs_lnot == 0, "abs_lnot inside failed");
+
         padding = ABSOLUTE(16);
         . += padding;
         after_padding = .;
@@ -90,3 +98,7 @@ SECTIONS
 
 ASSERT(absolute_aligned == text_start, "absolute_aligned failed");
 ASSERT(sum_absolute == text_start + 24, "sum of absolute operands must be section relative");
+
+ASSERT(abs_land == text_start + 1, "abs_land global failed");
+ASSERT(abs_lor == text_start + 1, "abs_lor global failed");
+ASSERT(abs_lnot == 0, "abs_lnot global failed");

--- a/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.ld
+++ b/wild/tests/sources/elf/linker-script-absolute/linker-script-absolute.ld
@@ -19,6 +19,11 @@ SECTIONS
         abs_nested = ABSOLUTE(ABSOLUTE(a));
         absolute_aligned = ABSOLUTE(ALIGN(16));
         absolute_plus = ABSOLUTE(16) + 8;
+        sum_absolute = ABSOLUTE(16) + ABSOLUTE(8);
+        absolute_ternary = 1 ? ABSOLUTE(24) : ABSOLUTE(32);
+        ASSERT(absolute_ternary == 24, "ternary must preserve absolute symbol classification");
+        absolute_max = MAX(ABSOLUTE(16), ABSOLUTE(24));
+        ASSERT(absolute_max == 24, "MAX must preserve absolute symbol classification");
 
         padding = ABSOLUTE(16);
         . += padding;
@@ -84,3 +89,4 @@ SECTIONS
 }
 
 ASSERT(absolute_aligned == text_start, "absolute_aligned failed");
+ASSERT(sum_absolute == text_start + 24, "sum of absolute operands must be section relative");

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
@@ -2,6 +2,12 @@ ENTRY(_start)
 
 SECTIONS {
     .text : {
+        text_start = .;
+
+        neg1 = ~0;
+        neg2 = . - 4;
+        neg3 = -4;
+
         *(.text*)
         symbol3 = 0x3000;
     }
@@ -73,3 +79,7 @@ symbol12 = ASSERT(ASSERT(0x5000 < 0x10000, "0x5000 < 0x10000 must be true") == 1
 . = ASSERT(symbol12 == 1, "must be 1");
 ASSERT(ALIGN(0x38, 16) == 0x40, "ALIGN value is incorrect");
 ASSERT(ALIGN(0x38, 18) == 0x48, "ALIGN value is incorrect");
+
+ASSERT(neg1 == text_start - 1, "sym_not_0 inside failed");
+ASSERT(neg2 == text_start - 4, "sym_neg_4 inside failed");
+ASSERT(neg3 == text_start - 4, "sym_sub_4 inside failed");


### PR DESCRIPTION
Implements the `ABSOLUTE` function within linker scripts. It returns the non relative value of an expression.