### PR TITLE
fix: Define hidden `__dso_handle` linker symbol

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -1354,6 +1354,10 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
             .hide();
 
         symbols
+            .section_start(crate::output_section_id::FILE_HEADER, "__dso_handle")
+            .hide();
+
+        symbols
             .section_start(output_section_id::GOT, "_GLOBAL_OFFSET_TABLE_")
             .hide();
 

--- a/wild/tests/sources/elf/dso-handle/dso-handle.c
+++ b/wild/tests/sources/elf/dso-handle/dso-handle.c
@@ -2,7 +2,6 @@
 //#Object:runtime.c
 //#Object:ptr_black_box.c
 //#ReferenceLinkers:lld
-//#DiffMatchAny:true
 //#ExpectSym:__dso_handle
 //#NoDynSym:__dso_handle
 

--- a/wild/tests/sources/elf/dso-handle/dso-handle.c
+++ b/wild/tests/sources/elf/dso-handle/dso-handle.c
@@ -1,0 +1,39 @@
+//#AbstractConfig:default
+//#Object:runtime.c
+//#Object:ptr_black_box.c
+//#ReferenceLinkers:lld
+//#DiffMatchAny:true
+//#ExpectSym:__dso_handle
+//#NoDynSym:__dso_handle
+
+//#Config:exec:default
+//#LinkArgs:-z now
+
+//#Config:shared:default
+//#LinkArgs:-shared -z now
+//#CompArgs:-fPIC -DSHARED
+//#RunEnabled:false
+
+#include "../common/ptr_black_box.h"
+#include "../common/runtime.h"
+
+extern char __dso_handle;
+extern char __ehdr_start;
+
+#ifdef SHARED
+void* get_dso_handle(void) { return &__dso_handle; }
+#else
+void _start(void) {
+  runtime_init();
+
+  if (ptr_to_int(&__dso_handle) == 0) {
+    exit_syscall(10);
+  }
+
+  if (&__dso_handle != &__ehdr_start) {
+    exit_syscall(11);
+  }
+
+  exit_syscall(42);
+}
+#endif


### PR DESCRIPTION
Noticed while building llvm-min-tblgen (as part of the TensorFlow build).