### PR TITLE
port(wasm): Support --import-memory

### DIFF
--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -30,6 +30,12 @@ pub(crate) const DEFAULT_ENTRY: &str = "_start";
 /// Default export name for the module's linear memory.
 pub(crate) const DEFAULT_MEMORY_EXPORT_NAME: &str = "memory";
 
+/// Default module name used when importing the linear memory (`--import-memory`).
+pub(crate) const DEFAULT_MEMORY_IMPORT_MODULE: &str = "env";
+
+/// Default field name used when importing the linear memory (`--import-memory`).
+pub(crate) const DEFAULT_MEMORY_IMPORT_NAME: &str = "memory";
+
 #[derive(Debug)]
 pub struct WasmArgs {
     pub(crate) common: super::CommonArgs,
@@ -50,6 +56,7 @@ pub struct WasmArgs {
     // Emit a shared linear memory (`memory.shared`). Requires the `atomics` and `bulk-memory`
     // target features.
     pub(crate) shared_memory: bool,
+    pub(crate) import_memory: bool,
     pub(crate) gc_sections: bool,
     pub(crate) allow_undefined: bool,
     pub(crate) allow_multiple_definition: bool,
@@ -84,6 +91,7 @@ impl Default for WasmArgs {
             initial_memory: None,
             max_memory: None,
             shared_memory: false,
+            import_memory: false,
             export_memory: None,
             gc_sections: true,
             allow_undefined: false,
@@ -419,6 +427,15 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
         .help("Use shared linear memory")
         .execute(|args, _modifier_stack| {
             args.shared_memory = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("import-memory")
+        .help("Import the module's memory from the default module of env with the name memory")
+        .execute(|args, _modifier_stack| {
+            args.import_memory = true;
             Ok(())
         });
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1692,6 +1692,7 @@ fn build_name_section<'data>(
                 set_name_first_wins(&mut global_names, next_global_import, import.name);
                 next_global_import += 1;
             }
+            crate::wasm_writer::OutputImportEntity::Memory(_) => {}
         }
     }
 
@@ -1835,6 +1836,7 @@ fn count_output_imports(layout: &WasmLayout<'_>) -> (usize, usize) {
         match import.entity {
             crate::wasm_writer::OutputImportEntity::Function { .. } => functions += 1,
             crate::wasm_writer::OutputImportEntity::Global(_) => globals += 1,
+            crate::wasm_writer::OutputImportEntity::Memory(_) => {}
         }
     }
     (functions, globals)
@@ -5604,6 +5606,18 @@ fn linker_output_memory_type(inputs: &[WasmObjectLayoutInput<'_>], shared: bool)
     }
 }
 
+/// Moves the output memory into the import section so that the module imports its memory from
+/// the host rather than defining it (`--import-memory`).
+fn import_output_memory(layout: &mut WasmLayout<'_>) {
+    for memory in layout.memories.drain(..) {
+        layout.imports.push(OutputImport {
+            module: crate::args::wasm::DEFAULT_MEMORY_IMPORT_MODULE,
+            name: crate::args::wasm::DEFAULT_MEMORY_IMPORT_NAME,
+            entity: crate::wasm_writer::OutputImportEntity::Memory(memory),
+        });
+    }
+}
+
 fn ensure_memory_export<'data>(exports: &mut Vec<OutputExport<'data>>, name: &'data str) {
     exports.retain(|export| !matches!(export.kind, wasmparser::ExternalKind::Memory));
     exports.push(OutputExport {
@@ -5910,6 +5924,9 @@ where
     let initial_memory = symbol_db.args.initial_memory;
     let max_memory = symbol_db.args.max_memory;
     let shared_memory = symbol_db.args.shared_memory;
+    let import_memory = symbol_db.args.import_memory;
+    let export_memory = &symbol_db.args.export_memory;
+
     if stack_size > 0 {
         ensure_stack_size_aligned(stack_size)?;
     }
@@ -6042,7 +6059,7 @@ where
                 .memories
                 .push(linker_output_memory_type(&layout_inputs, shared_memory));
         }
-        if !layout.memories.is_empty() {
+        if !layout.memories.is_empty() && (!import_memory || export_memory.is_some()) {
             ensure_memory_export(&mut layout.exports, symbol_db.args.memory_export_name());
         }
         layout.data_end = memory_cursor;
@@ -6060,6 +6077,11 @@ where
         } else {
             Some(heap_end_from_initial_pages(initial_pages)?)
         };
+        if import_memory {
+            // The output memory is imported rather than defined using --import-memory,
+            // so remove the memory section and add an import instead.
+            import_output_memory(&mut layout);
+        }
         let data_end = layout.data_end;
         compute_data_addresses(
             &mut layout.object_index_maps,

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -478,6 +478,9 @@ pub(crate) fn build_import_section(imports: &[OutputImport<'_>]) -> Result<Impor
             OutputImportEntity::Global(ty) => {
                 wasm_encoder::EntityType::Global(convert_global_type(ty)?)
             }
+            OutputImportEntity::Memory(ty) => {
+                wasm_encoder::EntityType::Memory(convert_memory_type(ty))
+            }
         };
         section.import(import.module, import.name, entity);
     }
@@ -568,6 +571,7 @@ pub(crate) struct OutputImport<'a> {
 pub(crate) enum OutputImportEntity {
     Function { type_index: u32 },
     Global(wasmparser::GlobalType),
+    Memory(wasmparser::MemoryType),
 }
 
 #[derive(Debug, Clone)]

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -90,6 +90,12 @@
 //! ExpectSharedMemory:{bool} (Wasm) When true, asserts that the output module defines a shared
 //! linear memory with a maximum.
 //!
+//! ExpectMemoryImport:{module}/{name} [properties] (Wasm) Asserts that the output module
+//! imports a linear memory with the given module and field name. Optional properties:
+//!   initial=M: Asserts the memory has the specified initial size.
+//!   max=N: Asserts the memory has the specified maximum size.
+//!   shared=true|false: Asserts the memory is shared.
+//!
 //! ExpectSection:{section_name} [properties] Checks that the specified section exists in the
 //! output binary. Optional properties:
 //!   max_entries=N: Asserts the section has at most N entries (uses the section's sh_entsize,
@@ -557,6 +563,7 @@ struct WasmModuleInfo {
     defined_global_i32: Vec<Option<i32>>,
     export_global_indices: HashMap<String, u32>,
     memories: Vec<wasmparser::MemoryType>,
+    memory_imports: Vec<(String, String, wasmparser::MemoryType)>,
 }
 
 fn i32_const_from_expr(expr: &wasmparser::ConstExpr<'_>) -> Option<i32> {
@@ -583,6 +590,7 @@ impl WasmModuleInfo {
         let mut defined_global_i32 = Vec::new();
         let mut export_global_indices = HashMap::new();
         let mut memories = Vec::new();
+        let mut memory_imports = Vec::new();
 
         for payload in Parser::new(0).parse_all(&bytes) {
             match payload? {
@@ -618,6 +626,13 @@ impl WasmModuleInfo {
                         }
                         if matches!(import.ty, wasmparser::TypeRef::Global(_)) {
                             imported_global_count += 1;
+                        }
+                        if let wasmparser::TypeRef::Memory(memory) = import.ty {
+                            memory_imports.push((
+                                import.module.to_owned(),
+                                import.name.to_owned(),
+                                memory,
+                            ));
                         }
                     }
                 }
@@ -689,6 +704,7 @@ impl WasmModuleInfo {
             defined_global_i32,
             export_global_indices,
             memories,
+            memory_imports,
         })
     }
 
@@ -831,6 +847,66 @@ impl WasmModuleInfo {
                     .map(|(i, t)| format!("{i}:{t}"))
                     .collect::<Vec<_>>()
                     .join(", ")
+            );
+        }
+        Ok(())
+    }
+
+    fn ensure_memory_import(
+        &self,
+        expected: Option<&ExpectedMemoryImport>,
+        linker_name: &str,
+    ) -> Result {
+        let Some(exp) = expected else {
+            return Ok(());
+        };
+        let matching = self
+            .memory_imports
+            .iter()
+            .filter(|(module, name, _)| module == &exp.module && name == &exp.name)
+            .collect::<Vec<_>>();
+        ensure!(
+            matching.len() == 1,
+            "Expected exactly one memory import `{}/{}` in {linker_name} output ({}), \
+             found {} (all: {:?})",
+            exp.module,
+            exp.name,
+            self.path.display(),
+            matching.len(),
+            self.memory_imports
+        );
+        let (_, _, actual) = matching[0];
+        if let Some(shared) = exp.assertions.shared {
+            ensure!(
+                actual.shared == shared,
+                "Expected memory import `{}/{}` shared={shared} in {linker_name} output ({}), \
+                 found shared={}",
+                exp.module,
+                exp.name,
+                self.path.display(),
+                actual.shared
+            );
+        }
+        if let Some(initial) = exp.assertions.initial {
+            ensure!(
+                actual.initial == initial,
+                "Expected memory import `{}/{}` initial={initial} page(s) in {linker_name} \
+                 output ({}), found initial={}",
+                exp.module,
+                exp.name,
+                self.path.display(),
+                actual.initial
+            );
+        }
+        if let Some(max) = exp.assertions.max {
+            ensure!(
+                actual.maximum == Some(max),
+                "Expected memory import `{}/{}` max={max} page(s) in {linker_name} output ({}), \
+                 found max={:?}",
+                exp.module,
+                exp.name,
+                self.path.display(),
+                actual.maximum
             );
         }
         Ok(())
@@ -1924,6 +2000,8 @@ struct Assertions {
     expected_func_import_count: Option<usize>,
     /// Wasm: require a shared linear memory with a maximum.
     expect_shared_memory: bool,
+    /// Wasm: require the linear memory to be imported as `module/name`.
+    expected_memory_import: Option<ExpectedMemoryImport>,
     relr_count: Option<u64>,
     expected_gdb_index_cu_count: Option<usize>,
     expected_gdb_index_symbols: Vec<String>,
@@ -1943,9 +2021,24 @@ struct ExpectedSectionBytes {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+struct ExpectedMemoryImport {
+    module: String,
+    name: String,
+    assertions: MemoryImportAssertions,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct ExpectedSection {
     section_name: String,
     assertions: SectionAssertions,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct MemoryImportAssertions {
+    initial: Option<u64>,
+    max: Option<u64>,
+    shared: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
@@ -2489,6 +2582,23 @@ fn process_directive(
         }
         "ExpectSharedMemory" => {
             config.assertions.expect_shared_memory = arg.parse()?;
+        }
+        "ExpectMemoryImport" => {
+            // module/name [initial=<pages>,max=<pages>,shared=<bool>]
+            let arg = arg.trim();
+            let (path, assertions) = if let Some((path, props)) = arg.split_once(' ') {
+                (path, serde_keyvalue::from_key_values(props.trim())?)
+            } else {
+                (arg, MemoryImportAssertions::default())
+            };
+            let (module, name) = path
+                .split_once('/')
+                .with_context(|| format!("ExpectMemoryImport requires module/name, got `{arg}`"))?;
+            config.assertions.expected_memory_import = Some(ExpectedMemoryImport {
+                module: module.to_owned(),
+                name: name.to_owned(),
+                assertions,
+            });
         }
         "ExpectSection" => {
             let arg = arg.trim();
@@ -5001,6 +5111,7 @@ impl Assertions {
             expected_func_imports: self.expected_func_imports.clone(),
             expected_func_import_count: self.expected_func_import_count,
             expect_shared_memory: self.expect_shared_memory,
+            expected_memory_import: self.expected_memory_import.clone(),
             ..Default::default()
         };
         ensure!(
@@ -5033,6 +5144,7 @@ impl Assertions {
         info.ensure_func_types_unique(linker_name)?;
         info.ensure_exports(&self.expected_symtab_entries, &self.no_sym, linker_name)?;
         info.ensure_shared_memory(self.expect_shared_memory, linker_name)?;
+        info.ensure_memory_import(self.expected_memory_import.as_ref(), linker_name)?;
         self.verify_strings(&info.bytes)?;
         Ok(())
     }

--- a/wild/tests/sources/wasm/import-memory/import-memory.c
+++ b/wild/tests/sources/wasm/import-memory/import-memory.c
@@ -1,0 +1,33 @@
+//#Config:default
+//#LinkArgs: --import-memory
+//#NoSection: Memory
+//#ExpectSection: Import
+//#ExpectMemoryImport: env/memory
+//#NoSym: memory
+//#RunEnabled: false
+
+//#Config:shared
+//#CompArgs: -matomics
+//#LinkArgs: --import-memory --shared-memory --initial-memory=131072 --max-memory=196608
+//#NoSection: Memory
+//#ExpectSection: Import
+//#ExpectMemoryImport: env/memory initial=2,max=3,shared=true
+//#NoSym: memory
+//#RunEnabled: false
+
+//#Config:import-max
+//#LinkArgs: --import-memory --initial-memory=131072 --max-memory=196608 -z stack-size=65536 --stack-first
+//#NoSection: Memory
+//#ExpectMemoryImport: env/memory initial=2,max=3,shared=false
+//#NoSym: memory
+//#RunEnabled: false
+
+//#Config:exported
+//#LinkArgs: --import-memory --export-memory
+//#RunEnabled: false
+//#NoSection: Memory
+//#ExpectMemoryImport: env/memory
+//#ExpectSection: Export
+//#ExpectSym: memory
+
+void _start(void) {}


### PR DESCRIPTION
Adds `--import-memory`: As mentioned in the original issue, the output module imports its
linear memory from `env.memory` instead of defining one.

Closes https://github.com/wild-linker/wild/issues/2337
Part of https://github.com/wild-linker/wild/issues/1431