### PR TITLE
perf: enable mmap on Btrfs with sufficiently new kernel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ memchr = { version = "2.7.0", default-features = false }
 memmap2 = { version = "0.9.0", default-features = false }
 mimalloc = { version = "0.1", default-features = false }
 nix = { version = "0.31.1", default-features = false, features = [
+  "feature",
   "resource",
   "fs",
 ] }

--- a/libwild/src/fs.rs
+++ b/libwild/src/fs.rs
@@ -740,3 +740,14 @@ pub(crate) fn path_from_bytes(bytes: &[u8]) -> PathBuf {
         }
     }
 }
+
+#[cfg(target_os = "linux")]
+fn kernel_version() -> Option<(u64, u64)> {
+    let uname = nix::sys::utsname::uname().ok()?;
+    let release = uname.release().to_string_lossy();
+    let mut parts = release.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+
+    Some((major, minor))
+}

--- a/libwild/src/fs.rs
+++ b/libwild/src/fs.rs
@@ -674,10 +674,15 @@ impl OutputFileDefaults {
                 };
 
                 match fs_type {
-                    // Multi-threaded write performance with BTRFS is terrible. It's substantially
-                    // faster to just buffer it all in memory then write it afterwards.
-                    statfs::BTRFS_SUPER_MAGIC => {
+                    // Multi-threaded write performance with BTRFS is terrible without huge pages
+                    // and when using huge pages with Linux < 7.2.
+                    // It's substantially faster to just buffer it all in memory
+                    // then write it afterwards.
+                    statfs::BTRFS_SUPER_MAGIC
+                        if kernel_version().is_none_or(|version| version < (7, 2)) =>
+                    {
                         defaults.write_mode = FileWriteMode::BufferThenWrite;
+                        defaults.madvise_huge_pages = false;
                     }
                     // vfat isn't quite as bad as BTRFS in this regard, but it's still at least
                     // 4-10% faster if we avoid mmap.


### PR DESCRIPTION
Together with huge pages enabled by default fixes https://github.com/wild-linker/wild/issues/1499 for real.