### PR TITLE
refactor: move section-header table to end of file, outside PT_LOAD

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -2507,7 +2507,6 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
 
         builder.add_section(crate::output_section_id::FILE_HEADER);
         builder.add_section(output_section_id::PROGRAM_HEADERS);
-        builder.add_section(output_section_id::SECTION_HEADERS);
         builder.add_section(output_section_id::NOTE_GNU_PROPERTY);
         builder.add_section(output_section_id::NOTE_GNU_BUILD_ID);
         builder.add_section(output_section_id::INTERP);
@@ -2562,6 +2561,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
         builder.add_section(output_section_id::SYMTAB_SHNDX_LOCAL);
         builder.add_section(output_section_id::STRTAB);
         builder.add_section(output_section_id::PARTIAL_LINKING_SINGLETONS);
+        builder.add_section(output_section_id::SECTION_HEADERS);
 
         builder.build()
     }
@@ -2773,7 +2773,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
                 while let Some((_, seg_id)) = it.next_if(|&(cat, _)| cat == 3) {
                     builder.push_event(OrderEvent::SegmentEnd(seg_id));
                 }
-                builder.push_event(OrderEvent::Section(output_section_id::SECTION_HEADERS));
+
                 for (_, seg_id) in it {
                     builder.push_event(OrderEvent::SegmentStart(seg_id));
                 }
@@ -2837,6 +2837,8 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
         builder.push_event(OrderEvent::SegmentStart(riscv_segment));
         builder.add_section(output_section_id::RISCV_ATTRIBUTES);
         builder.push_event(OrderEvent::SegmentEnd(riscv_segment));
+
+        builder.add_section(output_section_id::SECTION_HEADERS);
 
         Ok(builder.build())
     }
@@ -5518,7 +5520,6 @@ impl<C: ElfClass> Elf<C> {
         };
         defs[output_section_id::SECTION_HEADERS.as_usize()] = BuiltInSectionDetails {
             kind: Self::primary_section(SECTION_HEADERS_SECTION_NAME),
-            section_flags: shf::ALLOC,
             ..Self::DEFAULT_DEFS
         };
         defs[output_section_id::SHSTRTAB.as_usize()] = BuiltInSectionDetails {

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -241,6 +241,7 @@ pub(crate) trait ElfClass: Copy + Default + Send + Sync + std::fmt::Debug + 'sta
     const NOTE_HEADER_SIZE: u64 = size_of::<NoteHeader<Self>>() as u64;
     const GNU_HASH_BLOOM_SIZE: u64 = Self::ADDRESS_SIZE;
     const PROGRAM_HEADER_ALIGNMENT: Alignment = Self::ADDRESS_ALIGNMENT;
+    const SECTION_HEADER_ALIGNMENT: Alignment = Self::ADDRESS_ALIGNMENT;
     const GOT_ENTRY_ALIGNMENT: Alignment = Self::ADDRESS_ALIGNMENT;
     const RELA_ENTRY_ALIGNMENT: Alignment = Self::ADDRESS_ALIGNMENT;
     const RELR_ENTRY_ALIGNMENT: Alignment = Self::ADDRESS_ALIGNMENT;
@@ -5520,6 +5521,7 @@ impl<C: ElfClass> Elf<C> {
         };
         defs[output_section_id::SECTION_HEADERS.as_usize()] = BuiltInSectionDetails {
             kind: Self::primary_section(SECTION_HEADERS_SECTION_NAME),
+            min_alignment: C::SECTION_HEADER_ALIGNMENT,
             ..Self::DEFAULT_DEFS
         };
         defs[output_section_id::SHSTRTAB.as_usize()] = BuiltInSectionDetails {

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -455,7 +455,10 @@ fn populate_file_header<C: ElfClass, A: Arch<Platform = elf::Elf<C>>>(
         u64::from(C::FILE_HEADER_SIZE)
     })?;
     header.set_section_header_offset(
-        u64::from(C::FILE_HEADER_SIZE) + crate::elf::program_headers_size::<C>(header_info),
+        layout
+            .section_layouts
+            .get(output_section_id::SECTION_HEADERS)
+            .file_offset as u64,
     )?;
     header.set_flags(layout.format_specific.eflags);
     header.set_header_size(C::FILE_HEADER_SIZE);

--- a/wild/tests/sources/elf/section-header-alignment/section-header-alignment.c
+++ b/wild/tests/sources/elf/section-header-alignment/section-header-alignment.c
@@ -1,0 +1,19 @@
+//#Arch:x86_64
+//#ReferenceLinkers:bfd,lld
+//#Object:runtime.c
+
+#include <elf.h>
+
+#include "../common/runtime.h"
+
+extern const Elf64_Ehdr __ehdr_start;
+
+void _start(void) {
+  runtime_init();
+
+  if (__ehdr_start.e_shoff % _Alignof(Elf64_Shdr) != 0) {
+    exit_syscall(1);
+  }
+
+  exit_syscall(42);
+}


### PR DESCRIPTION
This PR is pre-requisite to #2472 
Wild models the ELF section-header table as an internal output section named `SECTION_HEADERS`. Previously, it was marked `SHF_ALLOC` and placed inside the first `PT_LOAD`, so changing the number of sections could change the loadable layout and shift virtual addresses.

This PR moves `SECTION_HEADERS` to the end of the file, removes `SHF_ALLOC`, and takes `e_shoff` from its actual laid-out file offset. This matches the layout used by other linkers.

This is a prerequisite for `--only-keep-debug`, since `--strip-debug` and `--only-keep-debug` need to preserve the same address layout.