### PR TITLE
feat(args): implement --image-base flag

### DIFF
--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -101,6 +101,9 @@ pub struct ElfArgs {
     pub(crate) tdata: Option<u64>,
     pub(crate) tbss: Option<u64>,
 
+    /// Base address for the output binary from --image-base.
+    pub(crate) image_base: Option<u64>,
+
     /// If set, GC stats will be written to the specified filename.
     pub(crate) write_gc_stats: Option<PathBuf>,
 
@@ -372,6 +375,7 @@ impl Default for ElfArgs {
             defsym: Vec::new(),
             section_start: HashMap::new(),
             ttext: None,
+            image_base: None,
             tdata: None,
             tbss: None,
             got_plt_syms: false,
@@ -1533,6 +1537,18 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
 
     parser
         .declare_with_param()
+        .long("image-base")
+        .help("Set the base address of the output binary")
+        .execute(|args, _modifier_stack, value| {
+            args.image_base = Some(
+                parse_number(value)
+                    .with_context(|| format!("Invalid address `{value}` in --image-base"))?,
+            );
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
         .long("hash-style")
         .help("Set hash style")
         .execute(|args, _modifier_stack, value| {
@@ -1944,6 +1960,10 @@ impl platform::Args for ElfArgs {
 
     fn rosegment(&self) -> bool {
         self.rosegment
+    }
+
+    fn image_base(&self) -> Option<u64> {
+        self.image_base
     }
 
     fn common(&self) -> &crate::args::CommonArgs {

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -336,8 +336,17 @@ impl<F: FileSystem> Linker<F> {
 
         let mut output = file_writer::Output::new::<P>(args, output_kind, self.file_system.clone());
 
-        let mut output_sections =
-            OutputSections::with_base_address(A::start_memory_address(output_kind), output_kind);
+        let mut output_sections = OutputSections::with_base_address(
+            args.image_base()
+                .unwrap_or_else(|| A::start_memory_address(output_kind)),
+            output_kind,
+        );
+        if let Some(base) = args.image_base() {
+            let page_size = args.loadable_segment_alignment().value();
+            if base % page_size != 0 {
+                bail!("--image-base: address isn't multiple of page size: {base:#x}");
+            }
+        }
         output_sections.set_rosegment(args.rosegment());
 
         let mut layout_rules_builder = LayoutRulesBuilder::default();

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -1567,6 +1567,10 @@ pub(crate) trait Args: std::fmt::Debug + Send + Sync + 'static {
         true
     }
 
+    fn image_base(&self) -> Option<u64> {
+        None
+    }
+
     fn should_emit_got_plt_syms(&self) -> bool {
         false
     }

--- a/wild/tests/external_tests/lld_skip_tests.toml
+++ b/wild/tests/external_tests/lld_skip_tests.toml
@@ -3,6 +3,7 @@ reason = "Wild uses immediate binding or different load address; output differs 
 tests = [
   "x86-64-tlsdesc-ld.s",
   "x86-64-tlsdesc-gd-mixed.s",
+  "x86-64-plt-high-addr.s",
   "x86-64-reloc-gotoff64.s",
   "x86-64-reloc-gotpc64.s",
   "x86-64-reloc-pltoff64.s",
@@ -90,6 +91,7 @@ tests = [
   "x86-64-reloc-size.s",
   "x86-64-reloc-size-shared.s",
   "x86-64-split-stack-prologue-adjust-shared.s",
+  "aarch64-undefined-weak.s",
   "x86-64-split-stack-prologue-adjust-silent.s",
   "x86-64-tls-opt-noplt.s",
   "x86-64-tls-pie.s",
@@ -153,14 +155,10 @@ tests = [
 [skipped_groups.missing_flag_support]
 reason = "Wild doesn't recognize a flag this test uses"
 tests = [
-  "x86-64-reloc-32.s",
   "x86-64-branch-to-branch.s",
   "x86-64-gotpc-relax.s",
-  "x86-64-plt-high-addr.s",
   "x86-64-relax-jump-tables.s",
   "aarch64-branch-to-branch.s",
-  "aarch64-thunk-align.s",
-  "aarch64-undefined-weak.s",
 ]
 
 [skipped_groups.missing_validation]
@@ -170,6 +168,7 @@ tests = [
   "x86-64-dyn-rel-error.s",
   "x86-64-dyn-rel-error5.s",
   "x86-64-reloc-error.s",
+  "x86-64-reloc-32.s",
   "x86-64-reloc-pc32.s",
   "x86-64-reloc-range.s",
   "x86-64-reloc-8-16.s",
@@ -220,7 +219,11 @@ tests = [
 
 [skipped_groups.thunk_for_absolute_symbol]
 reason = "Wild does not allocate thunks for out-of-range branches to absolute symbols"
-tests = ["aarch64-call26-thunk.s", "aarch64-jump26-thunk.s"]
+tests = [
+  "aarch64-call26-thunk.s",
+  "aarch64-jump26-thunk.s",
+  "aarch64-thunk-align.s",
+]
 
 [skipped_groups.gc_sections_skips_validation]
 reason = "Wild skips validation for GC'd sections by design"

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -21,7 +21,6 @@ tests = [
   "icf.sh",                                # `--icf`  
   "icf-alignment-bug.sh",
   "icf-preemption.sh",
-  "image-base.sh",
   "init-in-dso.sh",
   "init.sh",
   "library.sh",

--- a/wild/tests/sources/elf/image-base/image-base.c
+++ b/wild/tests/sources/elf/image-base/image-base.c
@@ -1,0 +1,19 @@
+// Verify that --image-base sets the load address of the output binary.
+// Also verifies that an error is emitted when the address is not page-aligned.
+//#AbstractConfig:default
+//#Mode:static
+//#RunEnabled:false
+//#Object:runtime.c
+
+//#Config:aligned:default
+//#ReferenceLinkers:bfd,lld
+//#LinkArgs:--image-base=0x10000000 --undefined=__executable_start
+//#ExpectSym:__executable_start address=0x10000000
+
+//#Config:unaligned:default
+//#ReferenceLinkers:
+//#LinkArgs:--image-base=0x10000001
+//#ExpectError:--image-base: address isn't multiple of page size: 0x10000001
+
+#include "../common/runtime.h"
+void _start(void) { exit_syscall(42); }


### PR DESCRIPTION
Adds --image-base=<address> to set the base load address of the output binary. Wild previously always used the platform default (0x400000 for x86-64).

Updates the lld skip list to move tests that were in missing_flag_support due to --image-base into their correct failure categories now that the flag is implemented.'


Part of #2380 