### PR TITLE
port(MachO): Emit bind fixups for non-GOT entries

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -1511,6 +1511,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
     fn create_layout_ext<'data>(
         finalise_sizes_ext: Self::FinaliseSizesExt<'data>,
         _resolutions: &layout::SymbolResolutions<Self>,
+        _group_layouts: &[layout::GroupLayout<'data, Self>],
     ) -> Result<Self::LayoutExt<'data>> {
         Ok(finalise_sizes_ext)
     }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -471,7 +471,8 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>, F: FileSystem>(
 
     let num_sections = output_sections.num_sections();
 
-    let format_specific = P::create_layout_ext(finalise_sizes_ext, &symbol_resolutions)?;
+    let format_specific =
+        P::create_layout_ext(finalise_sizes_ext, &symbol_resolutions, &group_layouts)?;
 
     let mut layout = Layout {
         symbol_db,

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -2,8 +2,8 @@ use crate::FileSystem;
 use crate::OutputKind;
 use crate::alignment;
 use crate::alignment::Alignment;
-use crate::alignment::MACHO_PAGE_ALIGNMENT;
 use crate::args::macho::MachOArgs;
+use crate::bail;
 use crate::ensure;
 use crate::error;
 use crate::error::Result;
@@ -12,6 +12,7 @@ use crate::file_writer::copy_section_data;
 use crate::grouping::SequencedInput;
 use crate::input_data::FileId;
 use crate::layout;
+use crate::layout::CommonGroupState;
 use crate::layout::HandlerData as _;
 use crate::layout::Layout;
 use crate::layout::OutputRecordLayout;
@@ -53,7 +54,10 @@ use crate::value_flags::ValueFlags;
 use crate::verbose_timing_phase;
 use anyhow::Context;
 use itertools::Itertools;
+use linker_utils::elf::RelocationKind;
+use linker_utils::elf::RelocationSize;
 use object::Endianness;
+use object::SectionIndex;
 use object::SymbolIndex;
 use object::macho;
 use object::macho::N_ABS;
@@ -172,7 +176,7 @@ pub(crate) const DYLINKER_PATH: &[u8] = b"/usr/lib/dyld";
 pub(crate) const MAX_SEGMENT_COUNT: usize = 6;
 pub(crate) const CHAINED_FIXUP_TABLE_BASE_SIZE: u64 = (size_of::<ChainedFixupsHeader>()
     + size_of::<u32>() * (MAX_SEGMENT_COUNT + /* leading segment count */ 1)
-    + size_of::<ChainedStartsInSegment>())
+    + size_of::<ChainedStartsInSegment>() * MAX_SEGMENT_COUNT)
     as u64;
 pub(crate) const CHAINED_FIXUP_IMPORT_SIZE: u64 = size_of::<u32>() as u64;
 pub(crate) const CHAINED_FIXUP_PAGE_START_SIZE: u64 = size_of::<u16>() as u64;
@@ -271,6 +275,7 @@ pub(crate) struct LayoutExt {
     pub(crate) imported_symbols: Vec<ImportedSymbolWithResolution>,
     /// Final addresses of initializer functions, in input relocation order.
     pub(crate) init_function_addresses: Vec<u64>,
+    pub(crate) fixups: Vec<Fixup>,
 }
 
 #[derive(Debug, Default)]
@@ -278,6 +283,7 @@ pub(crate) struct FinaliseSizesExt {
     imported_libraries: Vec<FileId>,
     imported_symbols: Vec<SymbolId>,
     init_functions: Vec<SymbolId>,
+    pending_fixups: Vec<PendingFixup>,
 }
 
 #[derive(Debug, Default)]
@@ -295,8 +301,22 @@ pub(crate) struct PreludeLayoutExt {
 #[derive(derive_more::Debug, Clone, Copy)]
 pub(crate) struct ImportedSymbolWithResolution {
     pub(crate) symbol_id: SymbolId,
-    pub(crate) got_address: NonZeroU64,
+    pub(crate) got_address: Option<NonZeroU64>,
     pub(crate) plt_address: Option<NonZeroU64>,
+}
+
+#[derive(Debug)]
+struct PendingFixup {
+    file_id: FileId,
+    section_index: SectionIndex,
+    offset_in_section: u64,
+    symbol_id: SymbolId,
+}
+
+#[derive(Debug)]
+pub(crate) struct Fixup {
+    pub(crate) ordinal: u64,
+    pub(crate) fixup_address: u64,
 }
 
 #[derive(derive_more::Debug)]
@@ -1071,7 +1091,7 @@ impl platform::Platform for MachO {
     type NonAddressableCounts = ();
     type EpilogueLayoutExt = EpilogueLayoutExt;
     type GroupLayoutExt = ();
-    type CommonGroupStateExt = ();
+    type CommonGroupStateExt = CommonGroupStateExt;
     type StubLibraryLayoutStateExt = DynamicLayoutStateExt;
     type StubLibraryLayoutExt = DynamicLayoutExt;
     type ArchIdentifier = ();
@@ -1268,7 +1288,7 @@ impl platform::Platform for MachO {
 
     fn load_object_section_relocations<'data, 'scope, A: platform::Arch<Platform = Self>>(
         state: &mut crate::layout::ObjectLayoutState<'data, Self>,
-        _common: &mut crate::layout::CommonGroupState<'data, Self>,
+        common: &mut crate::layout::CommonGroupState<'data, Self>,
         queue: &mut crate::layout::LocalWorkQueue<Self>,
         resources: &'scope crate::layout::GraphResources<'data, '_, Self>,
         _section: crate::layout::Section,
@@ -1277,7 +1297,7 @@ impl platform::Platform for MachO {
     ) -> Result {
         // TODO
         for rel in state.relocations(section_index)?.relocations {
-            process_relocation::<A>(state, rel, section_index, resources, queue, scope)?;
+            process_relocation::<A>(state, common, rel, section_index, resources, queue, scope)?;
         }
         Ok(())
     }
@@ -1372,8 +1392,10 @@ impl platform::Platform for MachO {
         let mut imported_libraries = Vec::new();
         let mut imported_symbols = Vec::new();
         let mut init_functions = Vec::new();
+        let mut pending_fixups = Vec::new();
 
         for group in groups {
+            pending_fixups.append(&mut group.common.format_specific.pending_fixups);
             for file in &group.files {
                 match file {
                     layout::FileLayoutState::Object(state) => {
@@ -1408,12 +1430,14 @@ impl platform::Platform for MachO {
             imported_libraries,
             imported_symbols,
             init_functions,
+            pending_fixups,
         })
     }
 
     fn create_layout_ext<'data>(
         finalise_sizes_ext: Self::FinaliseSizesExt<'data>,
         resolutions: &SymbolResolutions<Self>,
+        group_layouts: &[layout::GroupLayout<'data, Self>],
     ) -> Result<Self::LayoutExt<'data>> {
         let mut layout_ext = LayoutExt::default();
 
@@ -1425,22 +1449,18 @@ impl platform::Platform for MachO {
                     .get(symbol_id)
                     .with_context(|| "missing resolution for a stub library symbol".to_string())?;
 
-                let got_address = resolution
-                    .format_specific
-                    .got_address
-                    .ok_or_else(|| error!("missing GOT entry for a stub library symbol"))?;
-
                 Ok(ImportedSymbolWithResolution {
                     symbol_id,
-                    got_address,
+                    got_address: resolution.format_specific.got_address,
                     plt_address: resolution.format_specific.plt_address,
                 })
             })
             .collect::<Result<Vec<_>>>()?;
 
+        // Tiebreak by both `got_address` and `symbol_id` for imports that don't have a GOT entry.
         layout_ext.imported_symbols = imported_symbols
             .into_iter()
-            .sorted_by_key(|symbol| symbol.got_address)
+            .sorted_by_key(|symbol| (symbol.got_address, symbol.symbol_id))
             .collect();
         layout_ext.init_function_addresses = finalise_sizes_ext
             .init_functions
@@ -1455,6 +1475,43 @@ impl platform::Platform for MachO {
             })
             .collect::<Result<Vec<_>>>()?;
 
+        let mut fixups = Vec::with_capacity(finalise_sizes_ext.pending_fixups.len());
+
+        for (ordinal, import) in layout_ext.imported_symbols.iter().enumerate() {
+            if let Some(got_address) = import.got_address {
+                fixups.push(Fixup {
+                    ordinal: ordinal as u64,
+                    fixup_address: got_address.get(),
+                });
+            }
+        }
+
+        for pending in finalise_sizes_ext.pending_fixups {
+            let group = &group_layouts[pending.file_id.group()];
+            let layout::FileLayout::Object(object) = &group.files[pending.file_id.file()] else {
+                bail!("Fixup location belongs to a non-object input");
+            };
+
+            let section_address = object.section_resolutions[pending.section_index.0]
+                .address()
+                .context("Invalid section address for fixup")?;
+            let fixup_address = section_address
+                .checked_add(pending.offset_in_section)
+                .context("Invalid fixup address")?;
+            let ordinal = layout_ext
+                .imported_symbols
+                .iter()
+                .position(|import| import.symbol_id == pending.symbol_id)
+                .context("Invalid import ordinal for fixup")?;
+
+            fixups.push(Fixup {
+                ordinal: ordinal as u64,
+                fixup_address,
+            });
+        }
+
+        fixups.sort_unstable_by_key(|fixup| fixup.fixup_address);
+        layout_ext.fixups = fixups;
         Ok(layout_ext)
     }
 
@@ -1471,7 +1528,7 @@ impl platform::Platform for MachO {
 
     fn process_init_func_section<'data, 'scope, A: platform::Arch<Platform = Self>>(
         object: &mut crate::layout::ObjectLayoutState<'data, Self>,
-        _common: &mut crate::layout::CommonGroupState<'data, Self>,
+        common: &mut crate::layout::CommonGroupState<'data, Self>,
         section_index: object::SectionIndex,
         resources: &'scope crate::layout::GraphResources<'data, '_, Self>,
         queue: &mut crate::layout::LocalWorkQueue<Self>,
@@ -1502,7 +1559,7 @@ impl platform::Platform for MachO {
                     .symbol_id_range
                     .input_to_id(SymbolIndex(info.r_symbolnum as usize)),
             );
-            process_relocation::<A>(object, rel, section_index, resources, queue, scope)?;
+            process_relocation::<A>(object, common, rel, section_index, resources, queue, scope)?;
         }
 
         Ok(())
@@ -1580,10 +1637,10 @@ impl platform::Platform for MachO {
             })
             .sum::<u64>();
 
-        // Chained fixups record start information per page. At this point the final GOT size is
-        // known, so reserve the fixup table entries needed to describe the GOT pages.
-        fixup_table_size += CHAINED_FIXUP_PAGE_START_SIZE
-            * (state.imported_symbols.len() as u64).div_ceil(MACHO_PAGE_ALIGNMENT.value());
+        // TODO: Since we currently only support one page per segment, this is fine as a cap. But
+        // once we support multiple pages, we should figure out how to find exactly how many
+        // `page_start`s were emitted.
+        fixup_table_size += CHAINED_FIXUP_PAGE_START_SIZE * MAX_SEGMENT_COUNT as u64;
 
         mem_sizes.increment(
             part_id::CHAINED_FIXUP_TABLE,
@@ -2172,6 +2229,11 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
 };
 
 #[derive(Debug, Default)]
+pub(crate) struct CommonGroupStateExt {
+    pending_fixups: Vec<PendingFixup>,
+}
+
+#[derive(Debug, Default)]
 pub(crate) struct EpilogueLayoutExt {
     imported_symbols: Vec<SymbolId>,
 }
@@ -2295,6 +2357,7 @@ fn add_sections_in_segment<'data>(
 #[inline(always)]
 fn process_relocation<'data, 'scope, A: platform::Arch<Platform = MachO>>(
     object: &layout::ObjectLayoutState<'data, MachO>,
+    common: &mut CommonGroupState<'data, MachO>,
     rel: &Relocation,
     section_index: object::SectionIndex,
     resources: &'scope layout::GraphResources<'data, '_, MachO>,
@@ -2329,17 +2392,28 @@ fn process_relocation<'data, 'scope, A: platform::Arch<Platform = MachO>>(
             A::relocation_from_raw(rel_info)?
         };
         let mut flags_to_add = layout::resolution_flags(relocation.kind);
-        if is_dynamic_library(&symbol_db.file(symbol_db.file_id_for_symbol(symbol_id))) {
-            flags_to_add |= ValueFlags::GOT;
+        if is_dynamic_library(&symbol_db.file(symbol_db.file_id_for_symbol(symbol_id)))
+            && rel_info.r_type == object::macho::ARM64_RELOC_BRANCH26
+        {
             // TODO: classify symbols more reliably, likely by checking whether their section is
             // __text.
-            if rel_info.r_type == object::macho::ARM64_RELOC_BRANCH26 {
-                flags_to_add |= ValueFlags::DYNAMIC_FUNCTION | ValueFlags::PLT;
-            }
+            flags_to_add |= ValueFlags::GOT | ValueFlags::DYNAMIC_FUNCTION | ValueFlags::PLT;
         }
 
         let atomic_flags = &resources.per_symbol_flags.get_atomic(symbol_id);
         let previous_flags = atomic_flags.fetch_or(flags_to_add);
+
+        if is_dynamic_library(&symbol_db.file(symbol_db.file_id_for_symbol(symbol_id)))
+            && relocation.kind == RelocationKind::Absolute
+            && relocation.size == RelocationSize::ByteSize(8)
+        {
+            common.format_specific.pending_fixups.push(PendingFixup {
+                file_id: object.file_id,
+                section_index,
+                offset_in_section: u64::from(rel_info.r_address),
+                symbol_id,
+            });
+        }
 
         layout::check_for_undefined::<A>(
             object,

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -37,7 +37,6 @@ use crate::macho::DylibCommand;
 use crate::macho::DylinkerCommand;
 use crate::macho::EntryPointCommand;
 use crate::macho::FileHeader;
-use crate::macho::GOT_ENTRY_SIZE;
 use crate::macho::MACHO_COMMAND_ALIGNMENT;
 use crate::macho::MACHO_START_MEM_ADDRESS;
 use crate::macho::MAX_SEGMENT_COUNT;
@@ -167,8 +166,8 @@ pub(crate) fn write<'data, A: Arch<Platform = MachO>>(
         })?;
 
     let mut section_buffers = split_output_into_sections(layout, &mut sized_output.out).0;
-    write_got_entries(layout, section_buffers.get_mut(output_section_id::GOT))?;
     write_plt_entries::<A>(layout, section_buffers.get_mut(output_section_id::PLT_GOT))?;
+    write_chained_fixups(layout, &mut sized_output.out)?;
 
     write_code_signature_metadata(layout, sized_output)?;
     write_uuid(layout, sized_output)?;
@@ -387,38 +386,6 @@ fn exported_symbol_is_weak(layout: &MachOLayout<'_>, symbol_id: SymbolId) -> Res
     Ok(object.object.symbol(symbol_index)?.is_weak())
 }
 
-fn write_got_entries(layout: &MachOLayout<'_>, got: &mut [u8]) -> Result {
-    let got_layout = layout.section_layouts.get(output_section_id::GOT);
-
-    let sorted_symbols = &layout.format_specific.imported_symbols;
-    for (i, imported_symbol) in sorted_symbols.iter().enumerate() {
-        let offset = imported_symbol
-            .got_address
-            .get()
-            .checked_sub(got_layout.mem_offset)
-            .ok_or_else(|| error!("GOT entry address is before __got"))?
-            as usize;
-        let end = offset + GOT_ENTRY_SIZE as usize;
-
-        /* DYLD_CHAINED_PTR_64 format:
-        uint64_t dyld_chained_ptr_64_bind:
-          ordinal: 24
-          addend: 8 // 0 thru 255
-          reserved: 19 // all zeros
-          next: 12 // 4-byte stride
-          bind: 1 // == 1
-        */
-        let bind = 1u64 << 63;
-        // TODO: when crossing a page boundary, next is equal to zero
-        let next = if i == sorted_symbols.len() - 1 { 0 } else { 2 };
-        let next = next << 51;
-        let ordinal = i as u64;
-        got[offset..end].copy_from_slice(&(bind | next | ordinal).to_le_bytes());
-    }
-
-    Ok(())
-}
-
 fn write_plt_entries<A: Arch<Platform = MachO>>(
     layout: &MachOLayout<'_>,
     plt: &mut [u8],
@@ -437,14 +404,75 @@ fn write_plt_entries<A: Arch<Platform = MachO>>(
             as usize;
         let end = offset + PLT_ENTRY_SIZE as usize;
 
-        A::write_plt_entry(
-            &mut plt[offset..end],
-            imported_symbol.got_address.get(),
-            stub_address.get(),
-        )?;
+        let got_address = imported_symbol
+            .got_address
+            .ok_or("PLT entries must have corresponding GOT entries")?
+            .get();
+
+        A::write_plt_entry(&mut plt[offset..end], got_address, stub_address.get())?;
     }
 
     Ok(())
+}
+
+fn write_chained_fixups(layout: &MachOLayout<'_>, out: &mut [u8]) -> Result {
+    let mut fixups = layout.format_specific.fixups.iter().peekable();
+
+    for segment in &layout.segment_layouts.segments {
+        let segment_addresses =
+            segment.sizes.mem_offset..segment.sizes.mem_offset + segment.sizes.mem_size;
+
+        while let Some(fixup) =
+            fixups.next_if(|fixup| segment_addresses.contains(&fixup.fixup_address))
+        {
+            let offset_in_segment = fixup.fixup_address - segment.sizes.mem_offset;
+            let file_offset = segment.sizes.file_offset + usize::try_from(offset_in_segment)?;
+            let page_index = offset_in_segment / MACHO_PAGE_ALIGNMENT.value();
+
+            let next_fixup = fixups
+                .peek()
+                .filter(|next| segment_addresses.contains(&next.fixup_address));
+            let next_offset_in_segment =
+                next_fixup.map(|fixup| fixup.fixup_address - segment.sizes.mem_offset);
+            let next = match next_offset_in_segment {
+                Some(next_offset) if next_offset / MACHO_PAGE_ALIGNMENT.value() == page_index => {
+                    let distance = next_offset - offset_in_segment;
+                    // TODO: Support layouts that don't support divisibility by the four byte
+                    // chained fixup stride (e.g. manual assembly or packed
+                    // structs).
+                    ensure!(
+                        distance % 4 == 0,
+                        "Fixup distances need to be divisible by 4"
+                    );
+                    distance / 4
+                }
+                _ => 0,
+            };
+
+            let encoding = write_bind_encoding(fixup.ordinal, next);
+            out[file_offset..file_offset + encoding.len()].copy_from_slice(&encoding);
+        }
+    }
+
+    ensure!(
+        fixups.next().is_none(),
+        "Fixups are out of bounds for any segment"
+    );
+    Ok(())
+}
+
+fn write_bind_encoding(ordinal: u64, next: u64) -> [u8; 8] {
+    /* DYLD_CHAINED_PTR_64 format:
+    uint64_t dyld_chained_ptr_64_bind:
+      ordinal: 24
+      addend: 8 // 0 thru 255
+      reserved: 19 // all zeros
+      next: 12 // 4-byte stride
+      bind: 1 // == 1
+    */
+    let bind = 1u64 << 63;
+    let next = next << 51;
+    (bind | next | ordinal).to_le_bytes()
 }
 
 fn populate_file_header(
@@ -1016,69 +1044,80 @@ fn write_chained_fixup_table(layout: &MachOLayout, chained_fixup_table: &mut [u8
     let starts_in_segment_len =
         size_of::<ChainedStartsInSegment>() + CHAINED_FIXUP_PAGE_START_SIZE as usize;
     let imports_len = size_of::<u32>() * symbols.len();
-
     let starts_offset = size_of::<ChainedFixupsHeader>();
-    let imports_offset = starts_offset + starts_in_image_len + starts_in_segment_len;
-    let symbols_offset = imports_offset + imports_len;
 
     let (header, rest) = from_bytes_mut::<ChainedFixupsHeader>(chained_fixup_table)
         .map_err(|_| error!("Invalid chained fixups header allocation"))?;
-    let (starts_in_image, rest) = slice_from_bytes_mut::<U32<Endianness>>(rest, segment_count + 1)
-        .map_err(|_| error!("Invalid chained fixups starts allocation"))?;
+    let (starts_in_image, mut rest) =
+        slice_from_bytes_mut::<U32<Endianness>>(rest, segment_count + 1)
+            .map_err(|_| error!("Invalid chained fixups starts allocation"))?;
 
-    // 1) fill up ChainedFixupsHeader
+    // 1) fill up ChainedFixupsHeader. `imports_offset` and `symbols_offset` are written later once
+    //    we know how many DyldChainedStartsInSegment entries have been emitted
     header.fixups_version.set(LE, 0);
     header.starts_offset.set(LE, starts_offset as u32);
-    header.imports_offset.set(LE, imports_offset as u32);
-    header.symbols_offset.set(LE, symbols_offset as u32);
     header.imports_count.set(LE, symbols.len() as u32);
     header.imports_format.set(LE, DYLD_CHAINED_IMPORT);
     header.symbols_format.set(LE, 0);
 
     // 2) fill up dyld_chained_starts_in_image, which is `seg_count` (u32) followed by
-    //    `seg_info_offset` ([u32; seg_count]); only __DATA_CONST,__got segment is covered
+    //    `seg_info_offset` ([u32; seg_count])
     starts_in_image[0].set(LE, segment_count as u32);
     starts_in_image[1..].fill(U32::new(LE, 0));
 
-    // Early exit if we don't have any GOT entry to be encoded.
-    if layout.section_layouts.get(output_section_id::GOT).mem_size == 0 {
-        rest.zero();
-        return Ok(());
+    // 3) fill up DyldChainedStartsInSegment entries
+    let mut starts_in_segment_offset = starts_in_image_len;
+
+    for (i, segment) in active_segments.iter().enumerate() {
+        let segment_addresses =
+            segment.sizes.mem_offset..segment.sizes.mem_offset + segment.sizes.mem_size;
+
+        // TODO: For now, find the first fixup in a page for each segment. Once we support multiple
+        // pages, we should reimplement this so that we have a linear scan through fixups instead.
+        let Some(fixup) = layout
+            .format_specific
+            .fixups
+            .iter()
+            .find(|fixup| segment_addresses.contains(&fixup.fixup_address))
+        else {
+            continue;
+        };
+
+        // Accounts for both seg_count and __PAGEZERO.
+        starts_in_image[i + 2].set(LE, u32::try_from(starts_in_segment_offset)?);
+        let starts_in_segment = take_mut::<ChainedStartsInSegment>(&mut rest)?;
+        let page_starts = take_mut::<U16<Endianness>>(&mut rest)?;
+
+        starts_in_segment.size.set(LE, starts_in_segment_len as u32);
+        starts_in_segment
+            .page_size
+            .set(LE, MACHO_PAGE_ALIGNMENT.value() as u16);
+        starts_in_segment
+            .pointer_format
+            .set(LE, DYLD_CHAINED_PTR_64_OFFSET);
+        starts_in_segment
+            .segment_offset
+            .set(LE, segment.sizes.mem_offset - MACHO_START_MEM_ADDRESS);
+        starts_in_segment.max_valid_pointer.set(LE, 0);
+        // TODO:
+        starts_in_segment.page_count.set(LE, 1);
+        page_starts.set(
+            LE,
+            u16::try_from(
+                (fixup.fixup_address - segment.sizes.mem_offset) % MACHO_PAGE_ALIGNMENT.value(),
+            )?,
+        );
+
+        starts_in_segment_offset += starts_in_segment_len;
     }
 
-    let (data_const_segment_index, data_const_segment) = active_segments
-        .iter()
-        .enumerate()
-        .find(|(_, segment)| {
-            layout.program_segments.segment_def(segment.id).name == SegmentName::DATA_CONST
-        })
-        .ok_or_else(|| error!("non-empty __got requires __DATA_CONST segment"))?;
+    let imports_offset = starts_offset + starts_in_segment_offset;
+    let symbols_offset = imports_offset + imports_len;
+    header.imports_offset.set(LE, imports_offset as u32);
+    header.symbols_offset.set(LE, symbols_offset as u32);
 
-    // Accounts for both seg_count and __PAGEZERO.
-    starts_in_image[data_const_segment_index + 2].set(LE, starts_in_image_len as u32);
-
-    let (starts_in_segment, rest) = from_bytes_mut::<ChainedStartsInSegment>(rest)
-        .map_err(|_| error!("Invalid chained fixups starts in segment allocation"))?;
-    let (page_starts, rest) = slice_from_bytes_mut::<U16<Endianness>>(rest, 1)
-        .map_err(|_| error!("Invalid chained fixups page starts allocation"))?;
     let (imports, string_pool) = slice_from_bytes_mut::<U32<Endianness>>(rest, symbols.len())
         .map_err(|_| error!("Invalid chained fixups imports allocation"))?;
-
-    // 3) fill up DyldChainedStartsInSegment for the __got section
-    starts_in_segment.size.set(LE, starts_in_segment_len as u32);
-    starts_in_segment
-        .page_size
-        .set(LE, MACHO_PAGE_ALIGNMENT.value() as u16);
-    starts_in_segment
-        .pointer_format
-        .set(LE, DYLD_CHAINED_PTR_64_OFFSET);
-    starts_in_segment
-        .segment_offset
-        .set(LE, data_const_segment.sizes.file_offset as u64);
-    starts_in_segment.max_valid_pointer.set(LE, 0);
-    // TODO:
-    starts_in_segment.page_count.set(LE, 1);
-    page_starts[0].set(LE, 0);
 
     // 4) fill up all imported symbols chunked by the pages
     // TODO: support more pages
@@ -1118,6 +1157,7 @@ fn write_chained_fixup_table(layout: &MachOLayout, chained_fixup_table: &mut [u8
 
         let lib_ordinal = dynamic.ordinal.get();
 
+        // TODO: support weak import handling
         imports[i].set(
             Endianness::Little,
             u32::from(lib_ordinal) | ((symbol_offsets[i] as u32) << 9),

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -674,6 +674,7 @@ pub(crate) trait Platform:
     fn create_layout_ext<'data>(
         finalise_sizes_ext: Self::FinaliseSizesExt<'data>,
         _resolutions: &SymbolResolutions<Self>,
+        _group_layouts: &[layout::GroupLayout<'data, Self>],
     ) -> Result<Self::LayoutExt<'data>>;
 
     fn load_exception_frame_data<'data, 'scope, A: Arch<Platform = Self>>(

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -6922,6 +6922,7 @@ impl platform::Platform for Wasm {
     fn create_layout_ext<'data>(
         finalise_sizes_ext: Self::FinaliseSizesExt<'data>,
         _resolutions: &layout::SymbolResolutions<Self>,
+        _group_layouts: &[layout::GroupLayout<'data, Self>],
     ) -> Result<Self::LayoutExt<'data>> {
         Ok(finalise_sizes_ext)
     }

--- a/wild/tests/sources/macho/bind-fixup/bind-fixup.c
+++ b/wild/tests/sources/macho/bind-fixup/bind-fixup.c
@@ -1,0 +1,12 @@
+//#LinkerDriver:clang
+//#SoSingleLinker:lld
+//#Shared:foo.c
+//#DiffIgnore:section.__unwind_info
+//#NoSection:__got
+//#ExpectSym:_ptr section="__data",segment="__DATA"
+
+extern int value;
+
+int* volatile ptr = &value;
+
+int main(void) { return *ptr; }

--- a/wild/tests/sources/macho/bind-fixup/foo.c
+++ b/wild/tests/sources/macho/bind-fixup/foo.c
@@ -1,0 +1,1 @@
+int value = 42;


### PR DESCRIPTION
Previously, we only emitted chained fixups for GOT entries and assumed that every import had a corresponding GOT entry. We need to emit chained fixups for non-GOT entries as well, including both bind and rebase fixups, although the latter will be covered in a future diff.

For 64-bit absolute relocations that require a strong bind fixup, we store `pending_fixups` in `CommonGroupStateExt` during relocation processing. This state is propagated through to `FinaliseSizesExt` and then consumed by `LayoutExt`, which holds the final state of all sorted fixups (including GOT entry fixups) with their import ordinal and fixup address. This information is ultimately used in the writing phase to encode all binded fixups and their chained fixup table metadata.

Once multiple pages are supported, we'll need to revisit some of the implementation here, which I've documented with TODOs. cc: @marxin 

Part of #2512 