### PR TITLE
fix(elf): ignore unknown GNU property types instead of erroring

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -4383,7 +4383,7 @@ impl LayoutExt {
         args: &ElfArgs,
     ) -> Result<Self> {
         let states = objects_iter(groups).map(|o| &o.format_specific);
-        let gnu_property_notes = merge_gnu_property_notes::<C, A>(states.clone(), args.z_isa)?;
+        let gnu_property_notes = merge_gnu_property_notes::<C, A>(states.clone(), args.z_isa);
         let riscv_attributes = merge_riscv_attributes::<C, A>(states)?;
         let eflags = merge_eflags::<C, A>(objects_iter(groups).map(|o| o.object))?;
         let has_eh_frame_input = objects_iter(groups).any(|o| o.format_specific.has_eh_frame_input);
@@ -4409,7 +4409,7 @@ impl LayoutExt {
 fn merge_gnu_property_notes<'states, 'data: 'states, C: ElfClass, A: Arch>(
     states: impl Iterator<Item = &'states ObjectLayoutStateExt<'data, C>>,
     isa_needed: Option<NonZeroU32>,
-) -> Result<Vec<GnuProperty>> {
+) -> Vec<GnuProperty> {
     timing_phase!("Merge GNU property notes");
 
     let properties_per_file = states.map(|state| &state.gnu_property_notes).collect_vec();
@@ -4423,8 +4423,9 @@ fn merge_gnu_property_notes<'states, 'data: 'states, C: ElfClass, A: Arch>(
         // First OR within file to accumulate all features this file has.
         let mut file_map: HashMap<_, (u32, PropertyClass)> = HashMap::new();
         for prop in *file_props {
-            let property_class = A::get_property_class(prop.ptype.0)
-                .ok_or_else(|| crate::error!("unclassified property type {}", prop.ptype))?;
+            let Some(property_class) = A::get_property_class(prop.ptype.0) else {
+                continue;
+            };
             file_map
                 .entry(prop.ptype)
                 .and_modify(|entry: &mut (u32, PropertyClass)| {
@@ -4456,7 +4457,8 @@ fn merge_gnu_property_notes<'states, 'data: 'states, C: ElfClass, A: Arch>(
     }
 
     // Iterate the properties sorted by property_type so that we have a stable output!
-    let output_properties = property_map
+
+    property_map
         .into_iter()
         .sorted_by_key(|x| x.0)
         .filter_map(|(property_type, (property_value, property_class))| {
@@ -4478,9 +4480,7 @@ fn merge_gnu_property_notes<'states, 'data: 'states, C: ElfClass, A: Arch>(
                 None
             }
         })
-        .collect_vec();
-
-    Ok(output_properties)
+        .collect_vec()
 }
 
 fn merge_eflags<'files, 'data: 'files, C: ElfClass, A: Arch<Platform = Elf<C>>>(

--- a/wild/tests/sources/elf/gnu-property-unknown/gnu-property-unknown.s
+++ b/wild/tests/sources/elf/gnu-property-unknown/gnu-property-unknown.s
@@ -1,0 +1,30 @@
+# Verify that unknown GNU property types are ignored rather than causing errors.
+# The object contains both an unknown property (0xc0000000) and a known one
+# (0xc0000002 = IBT+SHSTK). Wild should ignore the unknown one and process
+# the known one correctly.
+//#Arch:x86_64
+//#Mode:static
+//#ReferenceLinkers:lld
+//#RunEnabled:false
+
+.section ".note.gnu.property", "a"
+.align 4
+.long 4
+.long 32
+.long 5
+.asciz "GNU"
+
+.long 0xc0000000
+.long 4
+.long 0
+.long 0
+
+.long 0xc0000002
+.long 4
+.long 3
+.long 0
+
+.text
+.globl _start
+_start:
+  ret


### PR DESCRIPTION
Previously Wild would error with "unclassified property type" when encountering unknown GNU property types like 0xc0000000. lld and bfd silently ignore unknown property types, which is the correct behavior for forward compatibility.

This fixes linking of objects that contain both unknown and known property types (e.g. IBT/SHSTK), which is a real-world pattern seen in toolchain-generated objects.

Also simplifies the merge_gnu_property_notes function return type from Result<Vec<GnuProperty>> to Vec<GnuProperty> since it can no longer fail.

Follow-up: implement -z force-ibt and -z cet-report= flags for full CET support.

Part of #2380 